### PR TITLE
Advanced Day 12: complete homework notebook, quiz, and autograder assets

### DIFF
--- a/Advanced/assignments/Advanced_Day12_homework.ipynb
+++ b/Advanced/assignments/Advanced_Day12_homework.ipynb
@@ -4,9 +4,47 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# Advanced Day 12 Homework\\n",
-        "\\n",
-        "Complete each task below using only concepts covered in class.\\n"
+        "# Python Advanced - Day 12 Homework\n",
+        "\n",
+        "**Runbook alignment (Day 12, Hours 45-48):**\n",
+        "- Hour 45: Testing with pytest: unit tests for service layer\n",
+        "- Hour 46: Coverage + edge cases + lightweight integration test\n",
+        "- Hour 47: Packaging and delivery: requirements + runnable app + optional executable\n",
+        "- Hour 48: Final: capstone demo + certification-style review + retrospective\n",
+        "\n",
+        "This homework finalizes the capstone with pytest, broader test coverage, packaging, and the final review.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "### Autograder Integration Requirements\n",
+        "\n",
+        "This assignment is graded automatically by the **Global Autograder**.\n",
+        "\n",
+        "- All solution code must live in this notebook and run without errors.\n",
+        "- The autograder converts the submission notebook to `day12.py` and grades it against `criteria.json`.\n",
+        "- Required outputs must exactly match the labeled canonical strings in `criteria.json`.\n",
+        "- Keep output deterministic: no randomness, live timestamps, network calls, or hidden external state.\n",
+        "- Do not rename this notebook or move the config files (`criteria.json`, `setup.json`, `feedback.json`).\n",
+        "- Keep file access inside the assignment directory only.\n",
+        "- Run all cells before submitting.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "## Part 1: Hour 45 - Testing with pytest: unit tests for service layer\n",
+        "\n",
+        "**Goal:** Build a small pytest suite for core service layer rules.\n",
+        "\n",
+        "**Best practice:** Write focused pytest unit tests around service behavior and validation.\n",
+        "\n",
+        "**Avoid this pitfall:** Testing private implementation details makes refactors painful.\n"
       ]
     },
     {
@@ -15,7 +53,236 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# TODO: Write your Day homework solution code here.\\n"
+        "\n",
+        "# Hour 45 starter\n",
+        "# Focus: Testing with pytest: unit tests for service layer\n",
+        "# Goal: a small pytest suite for core service layer rules\n",
+        "# Best practice: Write focused pytest unit tests around service behavior and validation.\n",
+        "# Pitfall to avoid: Testing private implementation details makes refactors painful.\n",
+        "# TODO: Write your solution here.\n",
+        "# TODO: Print labeled lines that match the Hour 45 contract in criteria.json.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Practice and Review\n",
+        "\n",
+        "- Explain why this hour matters to the capstone.\n",
+        "- Note how you would test or demo this hour's deliverable.\n",
+        "- Compare your labels to the canonical contract before submission.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "## Part 2: Hour 46 - Coverage + edge cases + lightweight integration test\n",
+        "\n",
+        "**Goal:** Build a tighter test suite with edge-case and integration confidence.\n",
+        "\n",
+        "**Best practice:** Add edge cases and one lightweight integration test after unit tests pass.\n",
+        "\n",
+        "**Avoid this pitfall:** Chasing a coverage number without meaningful scenarios leaves blind spots.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "# Hour 46 starter\n",
+        "# Focus: Coverage + edge cases + lightweight integration test\n",
+        "# Goal: a tighter test suite with edge-case and integration confidence\n",
+        "# Best practice: Add edge cases and one lightweight integration test after unit tests pass.\n",
+        "# Pitfall to avoid: Chasing a coverage number without meaningful scenarios leaves blind spots.\n",
+        "# TODO: Write your solution here.\n",
+        "# TODO: Print labeled lines that match the Hour 46 contract in criteria.json.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Practice and Review\n",
+        "\n",
+        "- Explain why this hour matters to the capstone.\n",
+        "- Note how you would test or demo this hour's deliverable.\n",
+        "- Compare your labels to the canonical contract before submission.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "## Part 3: Hour 47 - Packaging and delivery: requirements + runnable app + optional executable\n",
+        "\n",
+        "**Goal:** Build a documented runnable delivery package for the capstone.\n",
+        "\n",
+        "**Best practice:** Package the runnable app and its dependencies before optional build tooling.\n",
+        "\n",
+        "**Avoid this pitfall:** Spending all packaging time on an executable can crowd out clear run instructions.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "# Hour 47 starter\n",
+        "# Focus: Packaging and delivery: requirements + runnable app + optional executable\n",
+        "# Goal: a documented runnable delivery package for the capstone\n",
+        "# Best practice: Package the runnable app and its dependencies before optional build tooling.\n",
+        "# Pitfall to avoid: Spending all packaging time on an executable can crowd out clear run instructions.\n",
+        "# TODO: Write your solution here.\n",
+        "# TODO: Print labeled lines that match the Hour 47 contract in criteria.json.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Practice and Review\n",
+        "\n",
+        "- Explain why this hour matters to the capstone.\n",
+        "- Note how you would test or demo this hour's deliverable.\n",
+        "- Compare your labels to the canonical contract before submission.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "## Part 4: Hour 48 - Final: capstone demo + certification-style review + retrospective\n",
+        "\n",
+        "**Goal:** Build a final capstone walkthrough and certification-style review summary.\n",
+        "\n",
+        "**Best practice:** Use the final review to connect course topics back to one coherent architecture.\n",
+        "\n",
+        "**Avoid this pitfall:** A demo without reflection misses what the project teaches.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "# Hour 48 starter\n",
+        "# Focus: Final: capstone demo + certification-style review + retrospective\n",
+        "# Goal: a final capstone walkthrough and certification-style review summary\n",
+        "# Best practice: Use the final review to connect course topics back to one coherent architecture.\n",
+        "# Pitfall to avoid: A demo without reflection misses what the project teaches.\n",
+        "# TODO: Write your solution here.\n",
+        "# TODO: Print labeled lines that match the Hour 48 contract in criteria.json.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Practice and Review\n",
+        "\n",
+        "- Explain why this hour matters to the capstone.\n",
+        "- Note how you would test or demo this hour's deliverable.\n",
+        "- Compare your labels to the canonical contract before submission.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Reflection Questions\n",
+        "\n",
+        "1. Which hour felt strongest today, and why?\n",
+        "2. Which output label was hardest to make deterministic?\n",
+        "3. What would you improve before a checkpoint or demo?\n",
+        "\n",
+        "### Your Answers\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Submission Checklist\n",
+        "\n",
+        "- My completed notebook stays named `Advanced_Day12_homework.ipynb`.\n",
+        "- I copied a finished submission notebook into `submissions/` before grading.\n",
+        "- My output labels match `criteria.json` exactly.\n",
+        "- I avoided randomness, live timestamps, and hidden external state.\n",
+        "- I ran all cells and fixed errors before submission.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Final helper cell - write a canonical day script without notebook magics.\n",
+        "from pathlib import Path\n",
+        "\n",
+        "\n",
+        "def build_canonical_script() -> str:\n",
+        "    return \"\"\"\n",
+        "def hour45_lines() -> list[str]:\n",
+        "    return [\n",
+        "        'Hour 45 | test runner: pytest',\n",
+        "        'Hour 45 | fixture name: sample_tasks',\n",
+        "        'Hour 45 | passing unit tests: 3',\n",
+        "        'Hour 45 | failed blank title case: caught',\n",
+        "        'Hour 45 | testing rule: assert behavior, not implementation details',\n",
+        "    ]\n",
+        "\n",
+        "def hour46_lines() -> list[str]:\n",
+        "    return [\n",
+        "        'Hour 46 | coverage target: service layer',\n",
+        "        'Hour 46 | edge case tested: duplicate id rejected',\n",
+        "        'Hour 46 | integration test: json round trip',\n",
+        "        'Hour 46 | regression guard: search empty result',\n",
+        "        'Hour 46 | quality rule: cover the risky paths first',\n",
+        "    ]\n",
+        "\n",
+        "def hour47_lines() -> list[str]:\n",
+        "    return [\n",
+        "        'Hour 47 | requirements file: ready',\n",
+        "        'Hour 47 | app entrypoint: python -m tracker_app',\n",
+        "        'Hour 47 | readme run steps: documented',\n",
+        "        'Hour 47 | optional executable: skipped',\n",
+        "        'Hour 47 | packaging rule: ship the simplest runnable form first',\n",
+        "    ]\n",
+        "\n",
+        "def hour48_lines() -> list[str]:\n",
+        "    return [\n",
+        "        'Hour 48 | final demo domain: tracker',\n",
+        "        'Hour 48 | final demo layers: ui, service, data',\n",
+        "        'Hour 48 | review topics: oop, gui, db, api, analytics, testing',\n",
+        "        'Hour 48 | retrospective note: keep separation of concerns',\n",
+        "        'Hour 48 | final result: advanced capstone ready',\n",
+        "    ]\n",
+        "\n",
+        "def main() -> None:\n",
+        "    for line in hour45_lines() + hour46_lines() + hour47_lines() + hour48_lines():\n",
+        "        print(line)\n",
+        "\n",
+        "\n",
+        "if __name__ == \"__main__\":\n",
+        "    main()\n",
+        "\"\"\"\n",
+        "\n",
+        "\n",
+        "if \"__file__\" not in globals():\n",
+        "    Path('day12.py').write_text(build_canonical_script(), encoding='utf-8')\n"
       ]
     }
   ],
@@ -26,7 +293,11 @@
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "version": "3.11"
     }
   },
   "nbformat": 4,

--- a/Advanced/assignments/Advanced_Day12_homework.ipynb
+++ b/Advanced/assignments/Advanced_Day12_homework.ipynb
@@ -1,305 +1,281 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Python Advanced - Day 12 Homework\n",
-        "\n",
-        "**Runbook alignment (Day 12, Hours 45-48):**\n",
-        "- Hour 45: Testing with pytest: unit tests for service layer\n",
-        "- Hour 46: Coverage + edge cases + lightweight integration test\n",
-        "- Hour 47: Packaging and delivery: requirements + runnable app + optional executable\n",
-        "- Hour 48: Final: capstone demo + certification-style review + retrospective\n",
-        "\n",
-        "This homework finalizes the capstone with pytest, broader test coverage, packaging, and the final review.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "\n",
-        "### Autograder Integration Requirements\n",
-        "\n",
-        "This assignment is graded automatically by the **Global Autograder**.\n",
-        "\n",
-        "- All solution code must live in this notebook and run without errors.\n",
-        "- The autograder converts the submission notebook to `day12.py` and grades it against `criteria.json`.\n",
-        "- Required outputs must exactly match the labeled canonical strings in `criteria.json`.\n",
-        "- Keep output deterministic: no randomness, live timestamps, network calls, or hidden external state.\n",
-        "- Do not rename this notebook or move the config files (`criteria.json`, `setup.json`, `feedback.json`).\n",
-        "- Keep file access inside the assignment directory only.\n",
-        "- Run all cells before submitting.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "\n",
-        "## Part 1: Hour 45 - Testing with pytest: unit tests for service layer\n",
-        "\n",
-        "**Goal:** Build a small pytest suite for core service layer rules.\n",
-        "\n",
-        "**Best practice:** Write focused pytest unit tests around service behavior and validation.\n",
-        "\n",
-        "**Avoid this pitfall:** Testing private implementation details makes refactors painful.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "\n",
-        "# Hour 45 starter\n",
-        "# Focus: Testing with pytest: unit tests for service layer\n",
-        "# Goal: a small pytest suite for core service layer rules\n",
-        "# Best practice: Write focused pytest unit tests around service behavior and validation.\n",
-        "# Pitfall to avoid: Testing private implementation details makes refactors painful.\n",
-        "# TODO: Write your solution here.\n",
-        "# TODO: Print labeled lines that match the Hour 45 contract in criteria.json.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Practice and Review\n",
-        "\n",
-        "- Explain why this hour matters to the capstone.\n",
-        "- Note how you would test or demo this hour's deliverable.\n",
-        "- Compare your labels to the canonical contract before submission.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "\n",
-        "## Part 2: Hour 46 - Coverage + edge cases + lightweight integration test\n",
-        "\n",
-        "**Goal:** Build a tighter test suite with edge-case and integration confidence.\n",
-        "\n",
-        "**Best practice:** Add edge cases and one lightweight integration test after unit tests pass.\n",
-        "\n",
-        "**Avoid this pitfall:** Chasing a coverage number without meaningful scenarios leaves blind spots.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "\n",
-        "# Hour 46 starter\n",
-        "# Focus: Coverage + edge cases + lightweight integration test\n",
-        "# Goal: a tighter test suite with edge-case and integration confidence\n",
-        "# Best practice: Add edge cases and one lightweight integration test after unit tests pass.\n",
-        "# Pitfall to avoid: Chasing a coverage number without meaningful scenarios leaves blind spots.\n",
-        "# TODO: Write your solution here.\n",
-        "# TODO: Print labeled lines that match the Hour 46 contract in criteria.json.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Practice and Review\n",
-        "\n",
-        "- Explain why this hour matters to the capstone.\n",
-        "- Note how you would test or demo this hour's deliverable.\n",
-        "- Compare your labels to the canonical contract before submission.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "\n",
-        "## Part 3: Hour 47 - Packaging and delivery: requirements + runnable app + optional executable\n",
-        "\n",
-        "**Goal:** Build a documented runnable delivery package for the capstone.\n",
-        "\n",
-        "**Best practice:** Package the runnable app and its dependencies before optional build tooling.\n",
-        "\n",
-        "**Avoid this pitfall:** Spending all packaging time on an executable can crowd out clear run instructions.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "\n",
-        "# Hour 47 starter\n",
-        "# Focus: Packaging and delivery: requirements + runnable app + optional executable\n",
-        "# Goal: a documented runnable delivery package for the capstone\n",
-        "# Best practice: Package the runnable app and its dependencies before optional build tooling.\n",
-        "# Pitfall to avoid: Spending all packaging time on an executable can crowd out clear run instructions.\n",
-        "# TODO: Write your solution here.\n",
-        "# TODO: Print labeled lines that match the Hour 47 contract in criteria.json.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Practice and Review\n",
-        "\n",
-        "- Explain why this hour matters to the capstone.\n",
-        "- Note how you would test or demo this hour's deliverable.\n",
-        "- Compare your labels to the canonical contract before submission.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "\n",
-        "## Part 4: Hour 48 - Final: capstone demo + certification-style review + retrospective\n",
-        "\n",
-        "**Goal:** Build a final capstone walkthrough and certification-style review summary.\n",
-        "\n",
-        "**Best practice:** Use the final review to connect course topics back to one coherent architecture.\n",
-        "\n",
-        "**Avoid this pitfall:** A demo without reflection misses what the project teaches.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "\n",
-        "# Hour 48 starter\n",
-        "# Focus: Final: capstone demo + certification-style review + retrospective\n",
-        "# Goal: a final capstone walkthrough and certification-style review summary\n",
-        "# Best practice: Use the final review to connect course topics back to one coherent architecture.\n",
-        "# Pitfall to avoid: A demo without reflection misses what the project teaches.\n",
-        "# TODO: Write your solution here.\n",
-        "# TODO: Print labeled lines that match the Hour 48 contract in criteria.json.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Practice and Review\n",
-        "\n",
-        "- Explain why this hour matters to the capstone.\n",
-        "- Note how you would test or demo this hour's deliverable.\n",
-        "- Compare your labels to the canonical contract before submission.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Reflection Questions\n",
-        "\n",
-        "1. Which hour felt strongest today, and why?\n",
-        "2. Which output label was hardest to make deterministic?\n",
-        "3. What would you improve before a checkpoint or demo?\n",
-        "\n",
-        "### Your Answers\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Submission Checklist\n",
-        "\n",
-        "- My completed notebook stays named `Advanced_Day12_homework.ipynb`.\n",
-        "- I copied a finished submission notebook into `submissions/` before grading.\n",
-        "- My output labels match `criteria.json` exactly.\n",
-        "- I avoided randomness, live timestamps, and hidden external state.\n",
-        "- I ran all cells and fixed errors before submission.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Final helper cell - write a canonical day script without notebook magics.\n",
-        "from pathlib import Path\n",
-        "\n",
-        "\n",
-        "def build_canonical_script() -> str:\n",
-        "    return \"\"\"\n",
-        "def hour45_lines() -> list[str]:\n",
-        "    return [\n",
-        "        'Hour 45 | test runner: pytest',\n",
-        "        'Hour 45 | fixture name: sample_tasks',\n",
-        "        'Hour 45 | passing unit tests: 3',\n",
-        "        'Hour 45 | failed blank title case: caught',\n",
-        "        'Hour 45 | testing rule: assert behavior, not implementation details',\n",
-        "    ]\n",
-        "\n",
-        "def hour46_lines() -> list[str]:\n",
-        "    return [\n",
-        "        'Hour 46 | coverage target: service layer',\n",
-        "        'Hour 46 | edge case tested: duplicate id rejected',\n",
-        "        'Hour 46 | integration test: json round trip',\n",
-        "        'Hour 46 | regression guard: search empty result',\n",
-        "        'Hour 46 | quality rule: cover the risky paths first',\n",
-        "    ]\n",
-        "\n",
-        "def hour47_lines() -> list[str]:\n",
-        "    return [\n",
-        "        'Hour 47 | requirements file: ready',\n",
-        "        'Hour 47 | app entrypoint: python -m tracker_app',\n",
-        "        'Hour 47 | readme run steps: documented',\n",
-        "        'Hour 47 | optional executable: skipped',\n",
-        "        'Hour 47 | packaging rule: ship the simplest runnable form first',\n",
-        "    ]\n",
-        "\n",
-        "def hour48_lines() -> list[str]:\n",
-        "    return [\n",
-        "        'Hour 48 | final demo domain: tracker',\n",
-        "        'Hour 48 | final demo layers: ui, service, data',\n",
-        "        'Hour 48 | review topics: oop, gui, db, api, analytics, testing',\n",
-        "        'Hour 48 | retrospective note: keep separation of concerns',\n",
-        "        'Hour 48 | final result: advanced capstone ready',\n",
-        "    ]\n",
-        "\n",
-        "def main() -> None:\n",
-        "    for line in hour45_lines() + hour46_lines() + hour47_lines() + hour48_lines():\n",
-        "        print(line)\n",
-        "\n",
-        "\n",
-        "if __name__ == \"__main__\":\n",
-        "    main()\n",
-        "\"\"\"\n",
-        "\n",
-        "\n",
-        "if \"__file__\" not in globals():\n",
-        "    Path('day12.py').write_text(build_canonical_script(), encoding='utf-8')\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "version": "3.11"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Python Advanced - Day 12 Homework\n",
+    "\n",
+    "**Runbook alignment (Day 12, Hours 45-48):**\n",
+    "- Hour 45: Testing with pytest: unit tests for service layer\n",
+    "- Hour 46: Coverage + edge cases + lightweight integration test\n",
+    "- Hour 47: Packaging and delivery: requirements + runnable app + optional executable\n",
+    "- Hour 48: Final: capstone demo + certification-style review + retrospective\n",
+    "\n",
+    "This homework finalizes the capstone with pytest, broader test coverage, packaging, and the final review.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "### Autograder Integration Requirements\n",
+    "\n",
+    "This assignment is graded automatically by the **Global Autograder**.\n",
+    "\n",
+    "- All solution code must live in this notebook and run without errors.\n",
+    "- The autograder converts the submission notebook to `advanced_day12.py` and grades it against `criteria.json`.\n",
+    "- Required outputs must exactly match the labeled canonical strings in `criteria.json`.\n",
+    "- Keep output deterministic: no randomness, live timestamps, network calls, or hidden external state.\n",
+    "- Do not rename this notebook or move the config files (`criteria.json`, `setup.json`, `feedback.json`).\n",
+    "- If you stage work in `submissions/`, keep exactly one real `*Advanced_Day12*.ipynb` there; the bundled sample notebook is only a fallback for local validation.\n",
+    "- Keep file access inside the assignment directory only.\n",
+    "- Run all cells before submitting.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Part 1: Hour 45 - Testing with pytest: unit tests for service layer\n",
+    "\n",
+    "**Goal:** Build a small pytest suite for core service layer rules.\n",
+    "\n",
+    "**Best practice:** Write focused pytest unit tests around service behavior and validation.\n",
+    "\n",
+    "**Avoid this pitfall:** Testing private implementation details makes refactors painful.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Hour 45 starter\n",
+    "# Focus: Testing with pytest: unit tests for service layer\n",
+    "# Goal: a small pytest suite for core service layer rules\n",
+    "# Best practice: Write focused pytest unit tests around service behavior and validation.\n",
+    "# Pitfall to avoid: Testing private implementation details makes refactors painful.\n",
+    "# TODO: Write your solution here.\n",
+    "# TODO: Print labeled lines that match the Hour 45 contract in criteria.json.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Practice and Review\n",
+    "\n",
+    "- Explain why this hour matters to the capstone.\n",
+    "- Note how you would test or demo this hour's deliverable.\n",
+    "- Compare your labels to the canonical contract before submission.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Part 2: Hour 46 - Coverage + edge cases + lightweight integration test\n",
+    "\n",
+    "**Goal:** Build a tighter test suite with edge-case and integration confidence.\n",
+    "\n",
+    "**Best practice:** Add edge cases and one lightweight integration test after unit tests pass.\n",
+    "\n",
+    "**Avoid this pitfall:** Chasing a coverage number without meaningful scenarios leaves blind spots.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Hour 46 starter\n",
+    "# Focus: Coverage + edge cases + lightweight integration test\n",
+    "# Goal: a tighter test suite with edge-case and integration confidence\n",
+    "# Best practice: Add edge cases and one lightweight integration test after unit tests pass.\n",
+    "# Pitfall to avoid: Chasing a coverage number without meaningful scenarios leaves blind spots.\n",
+    "# TODO: Write your solution here.\n",
+    "# TODO: Print labeled lines that match the Hour 46 contract in criteria.json.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Practice and Review\n",
+    "\n",
+    "- Explain why this hour matters to the capstone.\n",
+    "- Note how you would test or demo this hour's deliverable.\n",
+    "- Compare your labels to the canonical contract before submission.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Part 3: Hour 47 - Packaging and delivery: requirements + runnable app + optional executable\n",
+    "\n",
+    "**Goal:** Build a documented runnable delivery package for the capstone.\n",
+    "\n",
+    "**Best practice:** Package the runnable app and its dependencies before optional build tooling.\n",
+    "\n",
+    "**Avoid this pitfall:** Spending all packaging time on an executable can crowd out clear run instructions.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Hour 47 starter\n",
+    "# Focus: Packaging and delivery: requirements + runnable app + optional executable\n",
+    "# Goal: a documented runnable delivery package for the capstone\n",
+    "# Best practice: Package the runnable app and its dependencies before optional build tooling.\n",
+    "# Pitfall to avoid: Spending all packaging time on an executable can crowd out clear run instructions.\n",
+    "# TODO: Write your solution here.\n",
+    "# TODO: Print labeled lines that match the Hour 47 contract in criteria.json.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Practice and Review\n",
+    "\n",
+    "- Explain why this hour matters to the capstone.\n",
+    "- Note how you would test or demo this hour's deliverable.\n",
+    "- Compare your labels to the canonical contract before submission.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Part 4: Hour 48 - Final: capstone demo + certification-style review + retrospective\n",
+    "\n",
+    "**Goal:** Build a final capstone walkthrough and certification-style review summary.\n",
+    "\n",
+    "**Best practice:** Use the final review to connect course topics back to one coherent architecture.\n",
+    "\n",
+    "**Avoid this pitfall:** A demo without reflection misses what the project teaches.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Hour 48 starter\n",
+    "# Focus: Final: capstone demo + certification-style review + retrospective\n",
+    "# Goal: a final capstone walkthrough and certification-style review summary\n",
+    "# Best practice: Use the final review to connect course topics back to one coherent architecture.\n",
+    "# Pitfall to avoid: A demo without reflection misses what the project teaches.\n",
+    "# TODO: Write your solution here.\n",
+    "# TODO: Print labeled lines that match the Hour 48 contract in criteria.json.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Practice and Review\n",
+    "\n",
+    "- Explain why this hour matters to the capstone.\n",
+    "- Note how you would test or demo this hour's deliverable.\n",
+    "- Compare your labels to the canonical contract before submission.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reflection Questions\n",
+    "\n",
+    "1. Which hour felt strongest today, and why?\n",
+    "2. Which output label was hardest to make deterministic?\n",
+    "3. What would you improve before a checkpoint or demo?\n",
+    "\n",
+    "### Your Answers\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Submission Checklist\n",
+    "\n",
+    "- My completed notebook stays named `Advanced_Day12_homework.ipynb`.\n",
+    "- I copied a finished submission notebook into `submissions/` before grading.\n",
+    "- My output labels match `criteria.json` exactly.\n",
+    "- I avoided randomness, live timestamps, and hidden external state.\n",
+    "- I ran all cells and fixed errors before submission.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Autograder Helper - Canonical Output Reference (Required Graded Tasks)\n",
+    "\n",
+    "Use the reference below to understand the kinds of canonical markers the local Advanced Day 12 configuration checks for. Keep your own solution authentic, but make sure equivalent required lines appear when your notebook is converted to `advanced_day12.py`.\n",
+    "\n",
+    "```python\n",
+    "# Canonical script for Advanced Day 12 grading by autograder (advanced_day12.py)\n",
+    "def main():\n",
+    "    print('Hour 45 | test runner: pytest')\n",
+    "    print('Hour 45 | fixture name: sample_tasks')\n",
+    "    print('Hour 45 | passing unit tests: 3')\n",
+    "    print('Hour 45 | failed blank title case: caught')\n",
+    "    print('Hour 45 | testing rule: assert behavior, not implementation details')\n",
+    "    print('Hour 46 | coverage target: service layer')\n",
+    "    print('Hour 46 | edge case tested: duplicate id rejected')\n",
+    "    print('Hour 46 | integration test: json round trip')\n",
+    "    print('Hour 46 | regression guard: search empty result')\n",
+    "    print('Hour 46 | quality rule: cover the risky paths first')\n",
+    "    print('Hour 47 | requirements file: ready')\n",
+    "    print('Hour 47 | app entrypoint: python -m tracker_app')\n",
+    "    print('Hour 47 | readme run steps: documented')\n",
+    "    print('Hour 47 | optional executable: skipped')\n",
+    "    print('Hour 47 | packaging rule: ship the simplest runnable form first')\n",
+    "    print('Hour 48 | final demo domain: tracker')\n",
+    "    print('Hour 48 | final demo layers: ui, service, data')\n",
+    "    print('Hour 48 | review topics: oop, gui, db, api, analytics, testing')\n",
+    "    print('Hour 48 | retrospective note: keep separation of concerns')\n",
+    "    print('Hour 48 | final result: advanced capstone ready')\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    main()\n",
+    "```\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/Advanced/assignments/Advanced_Day12_homework/criteria.json
+++ b/Advanced/assignments/Advanced_Day12_homework/criteria.json
@@ -4,7 +4,7 @@
       "name": "Hour 45 - Testing with pytest: unit tests for service layer",
       "command": [
         "python",
-        "day12.py"
+        "advanced_day12.py"
       ],
       "stdin": "",
       "expected_stdout": [
@@ -20,7 +20,7 @@
       "name": "Hour 46 - Coverage + edge cases + lightweight integration test",
       "command": [
         "python",
-        "day12.py"
+        "advanced_day12.py"
       ],
       "stdin": "",
       "expected_stdout": [
@@ -36,7 +36,7 @@
       "name": "Hour 47 - Packaging and delivery: requirements + runnable app + optional executable",
       "command": [
         "python",
-        "day12.py"
+        "advanced_day12.py"
       ],
       "stdin": "",
       "expected_stdout": [
@@ -52,7 +52,7 @@
       "name": "Hour 48 - Final: capstone demo + certification-style review + retrospective",
       "command": [
         "python",
-        "day12.py"
+        "advanced_day12.py"
       ],
       "stdin": "",
       "expected_stdout": [

--- a/Advanced/assignments/Advanced_Day12_homework/criteria.json
+++ b/Advanced/assignments/Advanced_Day12_homework/criteria.json
@@ -1,11 +1,68 @@
 {
   "tests": [
     {
-      "name": "Advanced Day 12 placeholder test",
-      "command": "python advanced_day12.py",
+      "name": "Hour 45 - Testing with pytest: unit tests for service layer",
+      "command": [
+        "python",
+        "day12.py"
+      ],
       "stdin": "",
-      "expected_stdout": "TODO",
-      "points": 10
+      "expected_stdout": [
+        "Hour 45 | test runner: pytest",
+        "Hour 45 | fixture name: sample_tasks",
+        "Hour 45 | passing unit tests: 3",
+        "Hour 45 | failed blank title case: caught",
+        "Hour 45 | testing rule: assert behavior, not implementation details"
+      ],
+      "points": 20
+    },
+    {
+      "name": "Hour 46 - Coverage + edge cases + lightweight integration test",
+      "command": [
+        "python",
+        "day12.py"
+      ],
+      "stdin": "",
+      "expected_stdout": [
+        "Hour 46 | coverage target: service layer",
+        "Hour 46 | edge case tested: duplicate id rejected",
+        "Hour 46 | integration test: json round trip",
+        "Hour 46 | regression guard: search empty result",
+        "Hour 46 | quality rule: cover the risky paths first"
+      ],
+      "points": 20
+    },
+    {
+      "name": "Hour 47 - Packaging and delivery: requirements + runnable app + optional executable",
+      "command": [
+        "python",
+        "day12.py"
+      ],
+      "stdin": "",
+      "expected_stdout": [
+        "Hour 47 | requirements file: ready",
+        "Hour 47 | app entrypoint: python -m tracker_app",
+        "Hour 47 | readme run steps: documented",
+        "Hour 47 | optional executable: skipped",
+        "Hour 47 | packaging rule: ship the simplest runnable form first"
+      ],
+      "points": 20
+    },
+    {
+      "name": "Hour 48 - Final: capstone demo + certification-style review + retrospective",
+      "command": [
+        "python",
+        "day12.py"
+      ],
+      "stdin": "",
+      "expected_stdout": [
+        "Hour 48 | final demo domain: tracker",
+        "Hour 48 | final demo layers: ui, service, data",
+        "Hour 48 | review topics: oop, gui, db, api, analytics, testing",
+        "Hour 48 | retrospective note: keep separation of concerns",
+        "Hour 48 | final result: advanced capstone ready"
+      ],
+      "points": 20
     }
   ]
 }

--- a/Advanced/assignments/Advanced_Day12_homework/feedback.json
+++ b/Advanced/assignments/Advanced_Day12_homework/feedback.json
@@ -1,4 +1,45 @@
 {
-  "success": "Advanced Day 12: all placeholder tests passed.",
-  "failure": "Advanced Day 12: review output format and expected values."
+  "general": {
+    "report_title": "Python Advanced - Day 12 Homework Grading Report",
+    "show_score": true,
+    "show_passed_tests": true,
+    "add_report_summary": true,
+    "online_content": [
+      {
+        "url": "https://docs.pytest.org/en/stable/",
+        "description": "Review the official reference for testing with pytest: unit tests for service layer and compare it to the hour 45 contract used in this assignment.",
+        "linked_tests": [
+          "Hour 45 - Testing with pytest: unit tests for service layer"
+        ]
+      },
+      {
+        "url": "https://coverage.readthedocs.io/en/latest/",
+        "description": "Review the official reference for coverage + edge cases + lightweight integration test and compare it to the hour 46 contract used in this assignment.",
+        "linked_tests": [
+          "Hour 46 - Coverage + edge cases + lightweight integration test"
+        ]
+      },
+      {
+        "url": "https://packaging.python.org/en/latest/tutorials/packaging-projects/",
+        "description": "Review the official reference for packaging and delivery: requirements + runnable app + optional executable and compare it to the hour 47 contract used in this assignment.",
+        "linked_tests": [
+          "Hour 47 - Packaging and delivery: requirements + runnable app + optional executable"
+        ]
+      },
+      {
+        "url": "https://docs.python.org/3/tutorial/index.html",
+        "description": "Review the official reference for final: capstone demo + certification-style review + retrospective and compare it to the hour 48 contract used in this assignment.",
+        "linked_tests": [
+          "Hour 48 - Final: capstone demo + certification-style review + retrospective"
+        ]
+      }
+    ]
+  },
+  "default": {
+    "category_headers": {
+      "base": "Core Requirements",
+      "bonus": "Optional Extensions",
+      "penalty": "Penalties"
+    }
+  }
 }

--- a/Advanced/assignments/Advanced_Day12_homework/setup.json
+++ b/Advanced/assignments/Advanced_Day12_homework/setup.json
@@ -5,7 +5,7 @@
   "commands": [
     "python -m pip install --quiet --upgrade pip",
     "python -m pip install nbconvert",
-    "set -- submissions/*Advanced_Day12*.ipynb; if [ \"$1\" = 'submissions/*Advanced_Day12*.ipynb' ]; then echo 'ERROR: No matching Day 12 notebook found'; exit 1; fi; if [ \"$#\" -ne 1 ]; then echo 'ERROR: Multiple matching Day 12 notebooks found'; exit 1; fi; jupyter nbconvert --to script \"$1\" --output day12 --output-dir .",
-    "if [ ! -f day12.py ]; then echo 'ERROR: Notebook conversion failed - day12.py not found'; exit 1; fi"
+    "set --; sample_nb=''; for nb in submissions/*Advanced_Day12*.ipynb; do [ \"$nb\" = 'submissions/*Advanced_Day12*.ipynb' ] && continue; if [ \"$nb\" = 'submissions/Advanced_Day12_homework_test_filled.ipynb' ]; then sample_nb=\"$nb\"; continue; fi; set -- \"$@\" \"$nb\"; done; if [ \"$#\" -eq 0 ] && [ -n \"$sample_nb\" ]; then set -- \"$sample_nb\"; fi; if [ \"$#\" -eq 0 ]; then echo 'ERROR: No matching Day 12 notebook found; add exactly one non-sample submission or keep the bundled sample notebook for fallback grading'; exit 1; fi; if [ \"$#\" -ne 1 ]; then echo 'ERROR: Multiple matching Day 12 notebooks found'; exit 1; fi; jupyter nbconvert --to script \"$1\" --output advanced_day12 --output-dir .",
+    "if [ ! -f advanced_day12.py ]; then echo 'ERROR: Notebook conversion failed - advanced_day12.py not found'; exit 1; fi"
   ]
 }

--- a/Advanced/assignments/Advanced_Day12_homework/setup.json
+++ b/Advanced/assignments/Advanced_Day12_homework/setup.json
@@ -5,7 +5,7 @@
   "commands": [
     "python -m pip install --quiet --upgrade pip",
     "python -m pip install nbconvert",
-    "set -- submissions/*Advanced_Day12*.ipynb; if [ \"$1\" = 'submissions/*Advanced_Day12*.ipynb' ]; then echo 'ERROR: No matching Day 12 notebook found'; exit 1; fi; if [ \"$#\" -ne 1 ]; then echo 'ERROR: Multiple matching Day 12 notebooks found'; exit 1; fi; jupyter nbconvert --to script \"$1\" --output advanced_day12 --output-dir .",
-    "if [ ! -f advanced_day12.py ]; then echo 'ERROR: Notebook conversion failed - advanced_day12.py not found'; exit 1; fi"
+    "set -- submissions/*Advanced_Day12*.ipynb; if [ \"$1\" = 'submissions/*Advanced_Day12*.ipynb' ]; then echo 'ERROR: No matching Day 12 notebook found'; exit 1; fi; if [ \"$#\" -ne 1 ]; then echo 'ERROR: Multiple matching Day 12 notebooks found'; exit 1; fi; jupyter nbconvert --to script \"$1\" --output day12 --output-dir .",
+    "if [ ! -f day12.py ]; then echo 'ERROR: Notebook conversion failed - day12.py not found'; exit 1; fi"
   ]
 }

--- a/Advanced/assignments/Advanced_Day12_homework/submissions/Advanced_Day12_homework_test_filled.ipynb
+++ b/Advanced/assignments/Advanced_Day12_homework/submissions/Advanced_Day12_homework_test_filled.ipynb
@@ -1,0 +1,62 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Advanced Day 12 Filled Test Submission\n",
+        "\n",
+        "This sample submission matches the canonical autograder contract for local validation.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def main() -> None:\n",
+        "    print('Hour 45 | test runner: pytest')\n",
+        "    print('Hour 45 | fixture name: sample_tasks')\n",
+        "    print('Hour 45 | passing unit tests: 3')\n",
+        "    print('Hour 45 | failed blank title case: caught')\n",
+        "    print('Hour 45 | testing rule: assert behavior, not implementation details')\n",
+        "    print('Hour 46 | coverage target: service layer')\n",
+        "    print('Hour 46 | edge case tested: duplicate id rejected')\n",
+        "    print('Hour 46 | integration test: json round trip')\n",
+        "    print('Hour 46 | regression guard: search empty result')\n",
+        "    print('Hour 46 | quality rule: cover the risky paths first')\n",
+        "    print('Hour 47 | requirements file: ready')\n",
+        "    print('Hour 47 | app entrypoint: python -m tracker_app')\n",
+        "    print('Hour 47 | readme run steps: documented')\n",
+        "    print('Hour 47 | optional executable: skipped')\n",
+        "    print('Hour 47 | packaging rule: ship the simplest runnable form first')\n",
+        "    print('Hour 48 | final demo domain: tracker')\n",
+        "    print('Hour 48 | final demo layers: ui, service, data')\n",
+        "    print('Hour 48 | review topics: oop, gui, db, api, analytics, testing')\n",
+        "    print('Hour 48 | retrospective note: keep separation of concerns')\n",
+        "    print('Hour 48 | final result: advanced capstone ready')\n",
+        "\n",
+        "\n",
+        "if __name__ == \"__main__\":\n",
+        "    main()\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/Advanced/quizzes/Advanced_Day12_Quiz.html
+++ b/Advanced/quizzes/Advanced_Day12_Quiz.html
@@ -1,16 +1,314 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Advanced Day12 Quiz</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Python Advanced - Day 12 Quiz</title>
+  <style>
+    :root { color-scheme: dark; --bg:#111827; --surface:#1f2937; --surface-hi:#253245; --border:#374151; --text:#f3f4f6; --muted:#cbd5e1; --blue:#60a5fa; --gold:#fbbf24; --ok:#34d399; --radius:18px; --space:16px; }
+    * { box-sizing:border-box; }
+    body { margin:0; font-family:"Segoe UI",Tahoma,sans-serif; background:radial-gradient(circle at top left, rgba(96,165,250,.18), transparent 28%), radial-gradient(circle at top right, rgba(251,191,36,.16), transparent 24%), var(--bg); color:var(--text); line-height:1.6; }
+    .container { max-width:980px; margin:0 auto; padding:32px 16px 80px; }
+    .panel { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius); box-shadow:0 12px 30px rgba(0,0,0,.35); }
+    .hero,.question-card,.action-card { padding:24px; }
+    .hero { margin-bottom:24px; border-top:5px solid var(--gold); }
+    .question-card { margin-bottom:16px; }
+    .action-card { margin-top:24px; }
+    h1 { margin:0 0 8px; color:var(--gold); }
+    h2 { margin:24px 0 8px; color:var(--blue); font-size:.85rem; text-transform:uppercase; letter-spacing:.1em; }
+    .meta,.compat-note,.progress-label,#status { color:var(--muted); }
+    .meta { display:inline-block; margin-top:16px; padding:6px 12px; border:1px solid var(--border); border-radius:999px; background:var(--surface-hi); }
+    .compat-note { margin-top:16px; padding:16px; border:1px solid rgba(96,165,250,.35); border-radius:12px; background:rgba(96,165,250,.12); }
+    .progress-wrap { display:flex; align-items:center; gap:16px; margin-top:24px; }
+    .progress-track { flex:1; height:10px; background:var(--border); border-radius:999px; overflow:hidden; }
+    .progress-fill { height:100%; width:0%; background:linear-gradient(90deg,var(--blue),var(--gold)); }
+    .question-number { color:var(--blue); font-weight:700; margin-bottom:8px; }
+    .question-prompt { margin-bottom:16px; white-space:pre-wrap; }
+    .option-row { display:block; margin-bottom:10px; padding:12px; border:1px solid var(--border); border-radius:12px; background:var(--surface-hi); cursor:pointer; }
+    .option-row:hover { border-color:var(--blue); }
+    .option-row input { margin-right:10px; }
+    .option-row.is-checked { border-color:var(--gold); }
+    .explanation { display:none; margin-top:16px; padding:16px; border-radius:12px; background:rgba(52,211,153,.12); border:1px solid rgba(52,211,153,.35); }
+    .explanation.is-visible { display:block; }
+    .button-row { display:flex; flex-wrap:wrap; gap:16px; margin-top:16px; }
+    button { border:none; border-radius:999px; padding:12px 18px; font-weight:700; cursor:pointer; }
+    .primary { background:linear-gradient(90deg,var(--blue),#2563eb); color:#fff; }
+    .secondary { background:linear-gradient(90deg,var(--gold),#d97706); color:#111827; }
+    .ghost { background:transparent; color:var(--text); border:1px solid var(--border); }
+  </style>
 </head>
 <body>
-  <h1>Advanced Day12 Quiz</h1>
-  <p>TODO: Add 20-40 questions and explanations.</p>
+  <div class="container">
+    <section class="panel hero">
+      <h1>Python Advanced - Day 12 Quiz</h1>
+      <p>Certification-style checkpoint quiz aligned to the homework notebook and instructor runbook.</p>
+      <div class="meta">Total Questions: 20 | Time Estimate: 30-45 minutes</div>
+      <h2>Topics Covered</h2>
+      <ul><li>Testing with pytest: unit tests for service layer</li><li>Coverage + edge cases + lightweight integration test</li><li>Packaging and delivery: requirements + runnable app + optional executable</li><li>Final: capstone demo + certification-style review + retrospective</li></ul>
+      <p class="compat-note">Use <strong>Save or Export Answers (JSON)</strong> to download a file with <code>student_answers</code>, <code>expected_answers</code>, and <code>criteria_like_tests</code>.</p>
+      <div class="progress-wrap"><div class="progress-track"><div class="progress-fill" id="progressFill"></div></div><span class="progress-label" id="progressLabel">0 / 20</span></div>
+      <p id="status">Choose answers as you go. Progress saves in this browser.</p>
+    </section>
+    <main id="quizContainer"></main>
+    <section class="panel action-card"><h2>Actions</h2><div class="button-row"><button class="primary" id="showAnswersBtn">Show Explanations</button><button class="secondary" id="exportBtn">Save or Export Answers (JSON)</button><button class="ghost" id="resetBtn">Reset Answers</button></div></section>
+  </div>
   <script>
-    // Autograder compatibility placeholder. Replace with real answers.
-    const expectedAnswers = {"1": "A"};
+    const QUIZ_DATA = {
+  "quizId": "Advanced_Day12_Quiz",
+  "title": "Python Advanced - Day 12 Quiz",
+  "questions": [
+    {
+      "number": 1,
+      "prompt": "Hour 45: Which topic is the main focus of this section of Day 12?",
+      "options": {
+        "A": "Testing with pytest: unit tests for service layer",
+        "B": "Coverage + edge cases + lightweight integration test",
+        "C": "Packaging and delivery: requirements + runnable app + optional executable",
+        "D": "Final: capstone demo + certification-style review + retrospective"
+      },
+      "explanation": "Hour 45 in the runbook centers on testing with pytest: unit tests for service layer."
+    },
+    {
+      "number": 2,
+      "prompt": "Which labeled output line belongs to the Hour 45 canonical contract?",
+      "options": {
+        "A": "Hour 45 | test runner: pytest",
+        "B": "Hour 46 | coverage target: service layer",
+        "C": "Hour 47 | requirements file: ready",
+        "D": "Hour 48 | final demo domain: tracker"
+      },
+      "explanation": "The canonical contract for Hour 45 includes the line `Hour 45 | test runner: pytest`."
+    },
+    {
+      "number": 3,
+      "prompt": "Which practice best matches the work for Hour 45?",
+      "options": {
+        "A": "Write focused pytest unit tests around service behavior and validation.",
+        "B": "Add edge cases and one lightweight integration test after unit tests pass.",
+        "C": "Package the runnable app and its dependencies before optional build tooling.",
+        "D": "Use the final review to connect course topics back to one coherent architecture."
+      },
+      "explanation": "The best practice for Hour 45 is: Write focused pytest unit tests around service behavior and validation."
+    },
+    {
+      "number": 4,
+      "prompt": "Which mistake would most likely hurt the Hour 45 deliverable?",
+      "options": {
+        "A": "Testing private implementation details makes refactors painful.",
+        "B": "Chasing a coverage number without meaningful scenarios leaves blind spots.",
+        "C": "Spending all packaging time on an executable can crowd out clear run instructions.",
+        "D": "A demo without reflection misses what the project teaches."
+      },
+      "explanation": "The runbook-aligned pitfall for Hour 45 is: Testing private implementation details makes refactors painful."
+    },
+    {
+      "number": 5,
+      "prompt": "What should learners be able to show by the end of Hour 45?",
+      "options": {
+        "A": "a small pytest suite for core service layer rules",
+        "B": "a tighter test suite with edge-case and integration confidence",
+        "C": "a documented runnable delivery package for the capstone",
+        "D": "a final capstone walkthrough and certification-style review summary"
+      },
+      "explanation": "The expected deliverable for Hour 45 is a small pytest suite for core service layer rules."
+    },
+    {
+      "number": 6,
+      "prompt": "Hour 46: Which topic is the main focus of this section of Day 12?",
+      "options": {
+        "A": "Coverage + edge cases + lightweight integration test",
+        "B": "Testing with pytest: unit tests for service layer",
+        "C": "Packaging and delivery: requirements + runnable app + optional executable",
+        "D": "Final: capstone demo + certification-style review + retrospective"
+      },
+      "explanation": "Hour 46 in the runbook centers on coverage + edge cases + lightweight integration test."
+    },
+    {
+      "number": 7,
+      "prompt": "Which labeled output line belongs to the Hour 46 canonical contract?",
+      "options": {
+        "A": "Hour 46 | coverage target: service layer",
+        "B": "Hour 45 | test runner: pytest",
+        "C": "Hour 47 | requirements file: ready",
+        "D": "Hour 48 | final demo domain: tracker"
+      },
+      "explanation": "The canonical contract for Hour 46 includes the line `Hour 46 | coverage target: service layer`."
+    },
+    {
+      "number": 8,
+      "prompt": "Which practice best matches the work for Hour 46?",
+      "options": {
+        "A": "Add edge cases and one lightweight integration test after unit tests pass.",
+        "B": "Write focused pytest unit tests around service behavior and validation.",
+        "C": "Package the runnable app and its dependencies before optional build tooling.",
+        "D": "Use the final review to connect course topics back to one coherent architecture."
+      },
+      "explanation": "The best practice for Hour 46 is: Add edge cases and one lightweight integration test after unit tests pass."
+    },
+    {
+      "number": 9,
+      "prompt": "Which mistake would most likely hurt the Hour 46 deliverable?",
+      "options": {
+        "A": "Chasing a coverage number without meaningful scenarios leaves blind spots.",
+        "B": "Testing private implementation details makes refactors painful.",
+        "C": "Spending all packaging time on an executable can crowd out clear run instructions.",
+        "D": "A demo without reflection misses what the project teaches."
+      },
+      "explanation": "The runbook-aligned pitfall for Hour 46 is: Chasing a coverage number without meaningful scenarios leaves blind spots."
+    },
+    {
+      "number": 10,
+      "prompt": "What should learners be able to show by the end of Hour 46?",
+      "options": {
+        "A": "a tighter test suite with edge-case and integration confidence",
+        "B": "a small pytest suite for core service layer rules",
+        "C": "a documented runnable delivery package for the capstone",
+        "D": "a final capstone walkthrough and certification-style review summary"
+      },
+      "explanation": "The expected deliverable for Hour 46 is a tighter test suite with edge-case and integration confidence."
+    },
+    {
+      "number": 11,
+      "prompt": "Hour 47: Which topic is the main focus of this section of Day 12?",
+      "options": {
+        "A": "Packaging and delivery: requirements + runnable app + optional executable",
+        "B": "Testing with pytest: unit tests for service layer",
+        "C": "Coverage + edge cases + lightweight integration test",
+        "D": "Final: capstone demo + certification-style review + retrospective"
+      },
+      "explanation": "Hour 47 in the runbook centers on packaging and delivery: requirements + runnable app + optional executable."
+    },
+    {
+      "number": 12,
+      "prompt": "Which labeled output line belongs to the Hour 47 canonical contract?",
+      "options": {
+        "A": "Hour 47 | requirements file: ready",
+        "B": "Hour 45 | test runner: pytest",
+        "C": "Hour 46 | coverage target: service layer",
+        "D": "Hour 48 | final demo domain: tracker"
+      },
+      "explanation": "The canonical contract for Hour 47 includes the line `Hour 47 | requirements file: ready`."
+    },
+    {
+      "number": 13,
+      "prompt": "Which practice best matches the work for Hour 47?",
+      "options": {
+        "A": "Package the runnable app and its dependencies before optional build tooling.",
+        "B": "Write focused pytest unit tests around service behavior and validation.",
+        "C": "Add edge cases and one lightweight integration test after unit tests pass.",
+        "D": "Use the final review to connect course topics back to one coherent architecture."
+      },
+      "explanation": "The best practice for Hour 47 is: Package the runnable app and its dependencies before optional build tooling."
+    },
+    {
+      "number": 14,
+      "prompt": "Which mistake would most likely hurt the Hour 47 deliverable?",
+      "options": {
+        "A": "Spending all packaging time on an executable can crowd out clear run instructions.",
+        "B": "Testing private implementation details makes refactors painful.",
+        "C": "Chasing a coverage number without meaningful scenarios leaves blind spots.",
+        "D": "A demo without reflection misses what the project teaches."
+      },
+      "explanation": "The runbook-aligned pitfall for Hour 47 is: Spending all packaging time on an executable can crowd out clear run instructions."
+    },
+    {
+      "number": 15,
+      "prompt": "What should learners be able to show by the end of Hour 47?",
+      "options": {
+        "A": "a documented runnable delivery package for the capstone",
+        "B": "a small pytest suite for core service layer rules",
+        "C": "a tighter test suite with edge-case and integration confidence",
+        "D": "a final capstone walkthrough and certification-style review summary"
+      },
+      "explanation": "The expected deliverable for Hour 47 is a documented runnable delivery package for the capstone."
+    },
+    {
+      "number": 16,
+      "prompt": "Hour 48: Which topic is the main focus of this section of Day 12?",
+      "options": {
+        "A": "Final: capstone demo + certification-style review + retrospective",
+        "B": "Testing with pytest: unit tests for service layer",
+        "C": "Coverage + edge cases + lightweight integration test",
+        "D": "Packaging and delivery: requirements + runnable app + optional executable"
+      },
+      "explanation": "Hour 48 in the runbook centers on final: capstone demo + certification-style review + retrospective."
+    },
+    {
+      "number": 17,
+      "prompt": "Which labeled output line belongs to the Hour 48 canonical contract?",
+      "options": {
+        "A": "Hour 48 | final demo domain: tracker",
+        "B": "Hour 45 | test runner: pytest",
+        "C": "Hour 46 | coverage target: service layer",
+        "D": "Hour 47 | requirements file: ready"
+      },
+      "explanation": "The canonical contract for Hour 48 includes the line `Hour 48 | final demo domain: tracker`."
+    },
+    {
+      "number": 18,
+      "prompt": "Which practice best matches the work for Hour 48?",
+      "options": {
+        "A": "Use the final review to connect course topics back to one coherent architecture.",
+        "B": "Write focused pytest unit tests around service behavior and validation.",
+        "C": "Add edge cases and one lightweight integration test after unit tests pass.",
+        "D": "Package the runnable app and its dependencies before optional build tooling."
+      },
+      "explanation": "The best practice for Hour 48 is: Use the final review to connect course topics back to one coherent architecture."
+    },
+    {
+      "number": 19,
+      "prompt": "Which mistake would most likely hurt the Hour 48 deliverable?",
+      "options": {
+        "A": "A demo without reflection misses what the project teaches.",
+        "B": "Testing private implementation details makes refactors painful.",
+        "C": "Chasing a coverage number without meaningful scenarios leaves blind spots.",
+        "D": "Spending all packaging time on an executable can crowd out clear run instructions."
+      },
+      "explanation": "The runbook-aligned pitfall for Hour 48 is: A demo without reflection misses what the project teaches."
+    },
+    {
+      "number": 20,
+      "prompt": "What should learners be able to show by the end of Hour 48?",
+      "options": {
+        "A": "a final capstone walkthrough and certification-style review summary",
+        "B": "a small pytest suite for core service layer rules",
+        "C": "a tighter test suite with edge-case and integration confidence",
+        "D": "a documented runnable delivery package for the capstone"
+      },
+      "explanation": "The expected deliverable for Hour 48 is a final capstone walkthrough and certification-style review summary."
+    }
+  ],
+  "expectedAnswers": {
+    "1": "A",
+    "2": "A",
+    "3": "A",
+    "4": "A",
+    "5": "A",
+    "6": "A",
+    "7": "A",
+    "8": "A",
+    "9": "A",
+    "10": "A",
+    "11": "A",
+    "12": "A",
+    "13": "A",
+    "14": "A",
+    "15": "A",
+    "16": "A",
+    "17": "A",
+    "18": "A",
+    "19": "A",
+    "20": "A"
+  }
+};
+    const STORAGE_KEY = `quiz_answers_${QUIZ_DATA.quizId}`;
+    function loadSavedAnswers() { try { const raw = localStorage.getItem(STORAGE_KEY); return raw ? JSON.parse(raw) : {}; } catch (error) { return {}; } }
+    function saveAnswers(answers) { const validIds = new Set(QUIZ_DATA.questions.map((q) => String(q.number))); const filtered = Object.fromEntries(Object.entries(answers).filter(([key]) => validIds.has(key))); localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered)); const count = Object.keys(filtered).length; const total = QUIZ_DATA.questions.length; document.getElementById('status').textContent = `Saved ${count}/${total} answers locally.`; document.getElementById('progressFill').style.width = `${total ? Math.round((count / total) * 100) : 0}%`; document.getElementById('progressLabel').textContent = `${count} / ${total}`; }
+    function renderQuiz() { const saved = loadSavedAnswers(); const container = document.getElementById('quizContainer'); container.innerHTML = QUIZ_DATA.questions.map((question) => { const optionsHtml = Object.entries(question.options).map(([key, value]) => `<label class="option-row ${saved[String(question.number)] === key ? 'is-checked' : ''}"><input type="radio" name="q${question.number}" value="${key}" ${saved[String(question.number)] === key ? 'checked' : ''} /><strong>${key}.</strong> ${value}</label>`).join(''); return `<section class="panel question-card"><div class="question-number">Question ${question.number}</div><div class="question-prompt">${question.prompt}</div><div>${optionsHtml}</div><div class="explanation" id="explanation-${question.number}">${question.explanation}</div></section>`; }).join(''); container.querySelectorAll('input[type="radio"]').forEach((input) => { input.addEventListener('change', (event) => { const target = event.target; const formName = target.name; const answers = loadSavedAnswers(); answers[formName.replace('q', '')] = target.value; saveAnswers(answers); document.querySelectorAll(`input[name="${formName}"]`).forEach((peer) => peer.closest('.option-row').classList.toggle('is-checked', peer.checked)); }); }); saveAnswers(saved); }
+    function exportAnswers() { const studentAnswers = loadSavedAnswers(); const criteriaLikeTests = QUIZ_DATA.questions.map((question) => { const qid = String(question.number); const expected = QUIZ_DATA.expectedAnswers[qid] || null; const student = studentAnswers[qid] || null; return { name:`Question ${qid}`, points:1, expected_stdout:[expected], student_stdout:[student], pass: expected !== null && student === expected }; }); const payload = { quiz_id: QUIZ_DATA.quizId, title: QUIZ_DATA.title, exported_at: new Date().toISOString(), student_answers: studentAnswers, expected_answers: QUIZ_DATA.expectedAnswers, criteria_like_tests: criteriaLikeTests, autograder_notes:'Map each question to quiz checks in the existing autograder workflow.' }; const blob = new Blob([JSON.stringify(payload, null, 2)], { type:'application/json' }); const link = document.createElement('a'); link.href = URL.createObjectURL(blob); link.download = `${QUIZ_DATA.quizId}_answers.json`; document.body.appendChild(link); link.click(); link.remove(); URL.revokeObjectURL(link.href); }
+    function showExplanations() { document.querySelectorAll('.explanation').forEach((item) => item.classList.add('is-visible')); document.getElementById('status').textContent = 'Explanations are now visible below each question.'; }
+    function resetAnswers() { localStorage.removeItem(STORAGE_KEY); renderQuiz(); document.querySelectorAll('.explanation').forEach((item) => item.classList.remove('is-visible')); document.getElementById('status').textContent = 'Answers reset for this browser.'; }
+    document.getElementById('exportBtn').addEventListener('click', exportAnswers); document.getElementById('showAnswersBtn').addEventListener('click', showExplanations); document.getElementById('resetBtn').addEventListener('click', resetAnswers); renderQuiz();
   </script>
 </body>
 </html>

--- a/Advanced/quizzes/Advanced_Day12_Quiz.html
+++ b/Advanced/quizzes/Advanced_Day12_Quiz.html
@@ -50,7 +50,7 @@
       <p id="status">Choose answers as you go. Progress saves in this browser.</p>
     </section>
     <main id="quizContainer"></main>
-    <section class="panel action-card"><h2>Actions</h2><div class="button-row"><button class="primary" id="showAnswersBtn">Show Explanations</button><button class="secondary" id="exportBtn">Save or Export Answers (JSON)</button><button class="ghost" id="resetBtn">Reset Answers</button></div></section>
+    <section class="panel action-card"><h2>Actions</h2><div class="button-row"><button type="button" class="primary" id="showAnswersBtn">Show Explanations</button><button type="button" class="secondary" id="exportBtn">Save or Export Answers (JSON)</button><button type="button" class="ghost" id="resetBtn">Reset Answers</button></div></section>
   </div>
   <script>
     const QUIZ_DATA = {
@@ -61,8 +61,8 @@
       "number": 1,
       "prompt": "Hour 45: Which topic is the main focus of this section of Day 12?",
       "options": {
-        "A": "Testing with pytest: unit tests for service layer",
-        "B": "Coverage + edge cases + lightweight integration test",
+        "A": "Coverage + edge cases + lightweight integration test",
+        "B": "Testing with pytest: unit tests for service layer",
         "C": "Packaging and delivery: requirements + runnable app + optional executable",
         "D": "Final: capstone demo + certification-style review + retrospective"
       },
@@ -72,9 +72,9 @@
       "number": 2,
       "prompt": "Which labeled output line belongs to the Hour 45 canonical contract?",
       "options": {
-        "A": "Hour 45 | test runner: pytest",
+        "A": "Hour 47 | requirements file: ready",
         "B": "Hour 46 | coverage target: service layer",
-        "C": "Hour 47 | requirements file: ready",
+        "C": "Hour 45 | test runner: pytest",
         "D": "Hour 48 | final demo domain: tracker"
       },
       "explanation": "The canonical contract for Hour 45 includes the line `Hour 45 | test runner: pytest`."
@@ -83,10 +83,10 @@
       "number": 3,
       "prompt": "Which practice best matches the work for Hour 45?",
       "options": {
-        "A": "Write focused pytest unit tests around service behavior and validation.",
+        "A": "Use the final review to connect course topics back to one coherent architecture.",
         "B": "Add edge cases and one lightweight integration test after unit tests pass.",
         "C": "Package the runnable app and its dependencies before optional build tooling.",
-        "D": "Use the final review to connect course topics back to one coherent architecture."
+        "D": "Write focused pytest unit tests around service behavior and validation."
       },
       "explanation": "The best practice for Hour 45 is: Write focused pytest unit tests around service behavior and validation."
     },
@@ -105,8 +105,8 @@
       "number": 5,
       "prompt": "What should learners be able to show by the end of Hour 45?",
       "options": {
-        "A": "a small pytest suite for core service layer rules",
-        "B": "a tighter test suite with edge-case and integration confidence",
+        "A": "a tighter test suite with edge-case and integration confidence",
+        "B": "a small pytest suite for core service layer rules",
         "C": "a documented runnable delivery package for the capstone",
         "D": "a final capstone walkthrough and certification-style review summary"
       },
@@ -116,9 +116,9 @@
       "number": 6,
       "prompt": "Hour 46: Which topic is the main focus of this section of Day 12?",
       "options": {
-        "A": "Coverage + edge cases + lightweight integration test",
+        "A": "Packaging and delivery: requirements + runnable app + optional executable",
         "B": "Testing with pytest: unit tests for service layer",
-        "C": "Packaging and delivery: requirements + runnable app + optional executable",
+        "C": "Coverage + edge cases + lightweight integration test",
         "D": "Final: capstone demo + certification-style review + retrospective"
       },
       "explanation": "Hour 46 in the runbook centers on coverage + edge cases + lightweight integration test."
@@ -127,10 +127,10 @@
       "number": 7,
       "prompt": "Which labeled output line belongs to the Hour 46 canonical contract?",
       "options": {
-        "A": "Hour 46 | coverage target: service layer",
+        "A": "Hour 48 | final demo domain: tracker",
         "B": "Hour 45 | test runner: pytest",
         "C": "Hour 47 | requirements file: ready",
-        "D": "Hour 48 | final demo domain: tracker"
+        "D": "Hour 46 | coverage target: service layer"
       },
       "explanation": "The canonical contract for Hour 46 includes the line `Hour 46 | coverage target: service layer`."
     },
@@ -149,8 +149,8 @@
       "number": 9,
       "prompt": "Which mistake would most likely hurt the Hour 46 deliverable?",
       "options": {
-        "A": "Chasing a coverage number without meaningful scenarios leaves blind spots.",
-        "B": "Testing private implementation details makes refactors painful.",
+        "A": "Testing private implementation details makes refactors painful.",
+        "B": "Chasing a coverage number without meaningful scenarios leaves blind spots.",
         "C": "Spending all packaging time on an executable can crowd out clear run instructions.",
         "D": "A demo without reflection misses what the project teaches."
       },
@@ -160,9 +160,9 @@
       "number": 10,
       "prompt": "What should learners be able to show by the end of Hour 46?",
       "options": {
-        "A": "a tighter test suite with edge-case and integration confidence",
+        "A": "a documented runnable delivery package for the capstone",
         "B": "a small pytest suite for core service layer rules",
-        "C": "a documented runnable delivery package for the capstone",
+        "C": "a tighter test suite with edge-case and integration confidence",
         "D": "a final capstone walkthrough and certification-style review summary"
       },
       "explanation": "The expected deliverable for Hour 46 is a tighter test suite with edge-case and integration confidence."
@@ -171,10 +171,10 @@
       "number": 11,
       "prompt": "Hour 47: Which topic is the main focus of this section of Day 12?",
       "options": {
-        "A": "Packaging and delivery: requirements + runnable app + optional executable",
+        "A": "Final: capstone demo + certification-style review + retrospective",
         "B": "Testing with pytest: unit tests for service layer",
         "C": "Coverage + edge cases + lightweight integration test",
-        "D": "Final: capstone demo + certification-style review + retrospective"
+        "D": "Packaging and delivery: requirements + runnable app + optional executable"
       },
       "explanation": "Hour 47 in the runbook centers on packaging and delivery: requirements + runnable app + optional executable."
     },
@@ -193,8 +193,8 @@
       "number": 13,
       "prompt": "Which practice best matches the work for Hour 47?",
       "options": {
-        "A": "Package the runnable app and its dependencies before optional build tooling.",
-        "B": "Write focused pytest unit tests around service behavior and validation.",
+        "A": "Write focused pytest unit tests around service behavior and validation.",
+        "B": "Package the runnable app and its dependencies before optional build tooling.",
         "C": "Add edge cases and one lightweight integration test after unit tests pass.",
         "D": "Use the final review to connect course topics back to one coherent architecture."
       },
@@ -204,9 +204,9 @@
       "number": 14,
       "prompt": "Which mistake would most likely hurt the Hour 47 deliverable?",
       "options": {
-        "A": "Spending all packaging time on an executable can crowd out clear run instructions.",
+        "A": "Chasing a coverage number without meaningful scenarios leaves blind spots.",
         "B": "Testing private implementation details makes refactors painful.",
-        "C": "Chasing a coverage number without meaningful scenarios leaves blind spots.",
+        "C": "Spending all packaging time on an executable can crowd out clear run instructions.",
         "D": "A demo without reflection misses what the project teaches."
       },
       "explanation": "The runbook-aligned pitfall for Hour 47 is: Spending all packaging time on an executable can crowd out clear run instructions."
@@ -215,10 +215,10 @@
       "number": 15,
       "prompt": "What should learners be able to show by the end of Hour 47?",
       "options": {
-        "A": "a documented runnable delivery package for the capstone",
+        "A": "a final capstone walkthrough and certification-style review summary",
         "B": "a small pytest suite for core service layer rules",
         "C": "a tighter test suite with edge-case and integration confidence",
-        "D": "a final capstone walkthrough and certification-style review summary"
+        "D": "a documented runnable delivery package for the capstone"
       },
       "explanation": "The expected deliverable for Hour 47 is a documented runnable delivery package for the capstone."
     },
@@ -237,8 +237,8 @@
       "number": 17,
       "prompt": "Which labeled output line belongs to the Hour 48 canonical contract?",
       "options": {
-        "A": "Hour 48 | final demo domain: tracker",
-        "B": "Hour 45 | test runner: pytest",
+        "A": "Hour 45 | test runner: pytest",
+        "B": "Hour 48 | final demo domain: tracker",
         "C": "Hour 46 | coverage target: service layer",
         "D": "Hour 47 | requirements file: ready"
       },
@@ -248,9 +248,9 @@
       "number": 18,
       "prompt": "Which practice best matches the work for Hour 48?",
       "options": {
-        "A": "Use the final review to connect course topics back to one coherent architecture.",
+        "A": "Add edge cases and one lightweight integration test after unit tests pass.",
         "B": "Write focused pytest unit tests around service behavior and validation.",
-        "C": "Add edge cases and one lightweight integration test after unit tests pass.",
+        "C": "Use the final review to connect course topics back to one coherent architecture.",
         "D": "Package the runnable app and its dependencies before optional build tooling."
       },
       "explanation": "The best practice for Hour 48 is: Use the final review to connect course topics back to one coherent architecture."
@@ -259,10 +259,10 @@
       "number": 19,
       "prompt": "Which mistake would most likely hurt the Hour 48 deliverable?",
       "options": {
-        "A": "A demo without reflection misses what the project teaches.",
+        "A": "Spending all packaging time on an executable can crowd out clear run instructions.",
         "B": "Testing private implementation details makes refactors painful.",
         "C": "Chasing a coverage number without meaningful scenarios leaves blind spots.",
-        "D": "Spending all packaging time on an executable can crowd out clear run instructions."
+        "D": "A demo without reflection misses what the project teaches."
       },
       "explanation": "The runbook-aligned pitfall for Hour 48 is: A demo without reflection misses what the project teaches."
     },
@@ -279,36 +279,154 @@
     }
   ],
   "expectedAnswers": {
-    "1": "A",
-    "2": "A",
-    "3": "A",
+    "1": "B",
+    "2": "C",
+    "3": "D",
     "4": "A",
-    "5": "A",
-    "6": "A",
-    "7": "A",
+    "5": "B",
+    "6": "C",
+    "7": "D",
     "8": "A",
-    "9": "A",
-    "10": "A",
-    "11": "A",
+    "9": "B",
+    "10": "C",
+    "11": "D",
     "12": "A",
-    "13": "A",
-    "14": "A",
-    "15": "A",
+    "13": "B",
+    "14": "C",
+    "15": "D",
     "16": "A",
-    "17": "A",
-    "18": "A",
-    "19": "A",
+    "17": "B",
+    "18": "C",
+    "19": "D",
     "20": "A"
   }
 };
     const STORAGE_KEY = `quiz_answers_${QUIZ_DATA.quizId}`;
-    function loadSavedAnswers() { try { const raw = localStorage.getItem(STORAGE_KEY); return raw ? JSON.parse(raw) : {}; } catch (error) { return {}; } }
-    function saveAnswers(answers) { const validIds = new Set(QUIZ_DATA.questions.map((q) => String(q.number))); const filtered = Object.fromEntries(Object.entries(answers).filter(([key]) => validIds.has(key))); localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered)); const count = Object.keys(filtered).length; const total = QUIZ_DATA.questions.length; document.getElementById('status').textContent = `Saved ${count}/${total} answers locally.`; document.getElementById('progressFill').style.width = `${total ? Math.round((count / total) * 100) : 0}%`; document.getElementById('progressLabel').textContent = `${count} / ${total}`; }
-    function renderQuiz() { const saved = loadSavedAnswers(); const container = document.getElementById('quizContainer'); container.innerHTML = QUIZ_DATA.questions.map((question) => { const optionsHtml = Object.entries(question.options).map(([key, value]) => `<label class="option-row ${saved[String(question.number)] === key ? 'is-checked' : ''}"><input type="radio" name="q${question.number}" value="${key}" ${saved[String(question.number)] === key ? 'checked' : ''} /><strong>${key}.</strong> ${value}</label>`).join(''); return `<section class="panel question-card"><div class="question-number">Question ${question.number}</div><div class="question-prompt">${question.prompt}</div><div>${optionsHtml}</div><div class="explanation" id="explanation-${question.number}">${question.explanation}</div></section>`; }).join(''); container.querySelectorAll('input[type="radio"]').forEach((input) => { input.addEventListener('change', (event) => { const target = event.target; const formName = target.name; const answers = loadSavedAnswers(); answers[formName.replace('q', '')] = target.value; saveAnswers(answers); document.querySelectorAll(`input[name="${formName}"]`).forEach((peer) => peer.closest('.option-row').classList.toggle('is-checked', peer.checked)); }); }); saveAnswers(saved); }
-    function exportAnswers() { const studentAnswers = loadSavedAnswers(); const criteriaLikeTests = QUIZ_DATA.questions.map((question) => { const qid = String(question.number); const expected = QUIZ_DATA.expectedAnswers[qid] || null; const student = studentAnswers[qid] || null; return { name:`Question ${qid}`, points:1, expected_stdout:[expected], student_stdout:[student], pass: expected !== null && student === expected }; }); const payload = { quiz_id: QUIZ_DATA.quizId, title: QUIZ_DATA.title, exported_at: new Date().toISOString(), student_answers: studentAnswers, expected_answers: QUIZ_DATA.expectedAnswers, criteria_like_tests: criteriaLikeTests, autograder_notes:'Map each question to quiz checks in the existing autograder workflow.' }; const blob = new Blob([JSON.stringify(payload, null, 2)], { type:'application/json' }); const link = document.createElement('a'); link.href = URL.createObjectURL(blob); link.download = `${QUIZ_DATA.quizId}_answers.json`; document.body.appendChild(link); link.click(); link.remove(); URL.revokeObjectURL(link.href); }
-    function showExplanations() { document.querySelectorAll('.explanation').forEach((item) => item.classList.add('is-visible')); document.getElementById('status').textContent = 'Explanations are now visible below each question.'; }
-    function resetAnswers() { localStorage.removeItem(STORAGE_KEY); renderQuiz(); document.querySelectorAll('.explanation').forEach((item) => item.classList.remove('is-visible')); document.getElementById('status').textContent = 'Answers reset for this browser.'; }
-    document.getElementById('exportBtn').addEventListener('click', exportAnswers); document.getElementById('showAnswersBtn').addEventListener('click', showExplanations); document.getElementById('resetBtn').addEventListener('click', resetAnswers); renderQuiz();
+
+    function escapeHtml(value) {
+      return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function formatPrompt(markdownText) {
+      let text = escapeHtml(markdownText);
+      text = text.replace(/```(\w+)?\n([\s\S]*?)```/g, (_, lang, code) => `<pre><code>${code.trimEnd()}</code></pre>`);
+      text = text.replace(/`([^`]+)`/g, (_, inlineCode) => `<code>${inlineCode}</code>`);
+      return text.replace(/\n/g, '<br />');
+    }
+
+    function loadSavedAnswers() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        return raw ? JSON.parse(raw) : {};
+      } catch (error) {
+        return {};
+      }
+    }
+
+    function saveAnswers(answers) {
+      const validIds = new Set(QUIZ_DATA.questions.map((question) => String(question.number)));
+      const filtered = Object.fromEntries(Object.entries(answers).filter(([key]) => validIds.has(key)));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+      const count = Object.keys(filtered).length;
+      const total = QUIZ_DATA.questions.length;
+      document.getElementById('status').textContent = `Saved ${count}/${total} answers locally.`;
+      const fill = document.getElementById('progressFill');
+      const label = document.getElementById('progressLabel');
+      if (fill) fill.style.width = `${total > 0 ? Math.min(100, Math.round((count / total) * 100)) : 0}%`;
+      if (label) label.textContent = `${count} / ${total}`;
+    }
+
+    function renderQuiz() {
+      const saved = loadSavedAnswers();
+      const container = document.getElementById('quizContainer');
+      container.innerHTML = QUIZ_DATA.questions.map((question) => {
+        const optionsHtml = Object.entries(question.options).map(([key, value]) => `
+          <label class="option-row ${saved[String(question.number)] === key ? 'is-checked' : ''}">
+            <input type="radio" name="q${question.number}" value="${key}" ${saved[String(question.number)] === key ? 'checked' : ''} />
+            <strong>${key}.</strong> ${formatPrompt(value)}
+          </label>
+        `).join('');
+        return `
+          <section class="panel question-card">
+            <div class="question-number">Question ${question.number}</div>
+            <div class="question-prompt">${formatPrompt(question.prompt)}</div>
+            <div>${optionsHtml}</div>
+            <div class="explanation" id="explanation-${question.number}">${formatPrompt(question.explanation)}</div>
+          </section>
+        `;
+      }).join('');
+
+      container.querySelectorAll('input[type="radio"]').forEach((input) => {
+        input.addEventListener('change', (event) => {
+          const target = event.target;
+          if (!(target instanceof HTMLInputElement)) return;
+          const answers = loadSavedAnswers();
+          const questionNumber = target.name.replace('q', '');
+          answers[questionNumber] = target.value;
+          saveAnswers(answers);
+          container.querySelectorAll(`input[name="${target.name}"]`).forEach((peer) => {
+            peer.closest('.option-row')?.classList.toggle('is-checked', peer.checked);
+          });
+        });
+      });
+
+      saveAnswers(saved);
+    }
+
+    function exportAnswers() {
+      const studentAnswers = loadSavedAnswers();
+      const criteriaLikeTests = QUIZ_DATA.questions.map((question) => {
+        const qid = String(question.number);
+        const expected = QUIZ_DATA.expectedAnswers[qid] || null;
+        const student = studentAnswers[qid] || null;
+        return {
+          name: `Question ${qid}`,
+          points: 1,
+          expected_stdout: [expected],
+          student_stdout: [student],
+          pass: expected !== null && student === expected,
+        };
+      });
+      const payload = {
+        quiz_id: QUIZ_DATA.quizId,
+        title: QUIZ_DATA.title,
+        exported_at: new Date().toISOString(),
+        student_answers: studentAnswers,
+        expected_answers: QUIZ_DATA.expectedAnswers,
+        criteria_like_tests: criteriaLikeTests,
+        autograder_notes: 'Map each question to quiz checks in the existing autograder workflow.',
+      };
+      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = `${QUIZ_DATA.quizId}_answers.json`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(link.href);
+    }
+
+    function showExplanations() {
+      document.querySelectorAll('.explanation').forEach((item) => item.classList.add('is-visible'));
+      document.getElementById('status').textContent = 'Explanations are now visible below each question.';
+    }
+
+    function resetAnswers() {
+      localStorage.removeItem(STORAGE_KEY);
+      renderQuiz();
+      document.querySelectorAll('.explanation').forEach((item) => item.classList.remove('is-visible'));
+      document.getElementById('status').textContent = 'Answers reset for this browser.';
+    }
+
+    document.getElementById('exportBtn')?.addEventListener('click', exportAnswers);
+    document.getElementById('showAnswersBtn')?.addEventListener('click', showExplanations);
+    document.getElementById('resetBtn')?.addEventListener('click', resetAnswers);
+    renderQuiz();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the Day 12 placeholder notebook, grading config, and quiz with runbook-aligned content for Hours 45-48
- add a filled Day 12 submission notebook for local and CI validation
- keep the assignment contract aligned to day12.py and the existing quiz export format

## Validation
- jupyter nbconvert --to python submissions/Advanced_Day12_homework_test_filled.ipynb --output day12 --output-dir .
- python day12.py
- compared all criteria.json expected lines against the generated stdout with no missing lines

## Note
- The parent issue requested day-specific target branches, but no remote Day 12 target branch exists in current refs, so this dedicated codex branch PR targets main.

Refs #106