### PR TITLE
Add complete Advanced slide decks and build support

### DIFF
--- a/.github/workflows/marp-action.yml
+++ b/.github/workflows/marp-action.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [ "main" ]
     paths:
-      - "Basics/lessons/**.md"
-      - "Advanced/lessons/**.md"
+      - "Basics/lessons/slides/day-*/**"
+      - "Advanced/lessons/slides/day-*/**"
       - ".marprc.yml"
+      - ".github/workflows/marp-action.yml"
 
 permissions:
   contents: read
@@ -44,10 +45,22 @@ jobs:
         with: 
           token: ${{ secrets.GH_PAT }}
           
-      - name: Convert Markdown into HTML and PDF
+      - name: Convert Basics slide Markdown into HTML and PDF
         uses: KoharaKazuya/marp-cli-action@v4
         with:
           config-file: ./.marprc.yml
+
+      - name: Convert Advanced slide Markdown into HTML and PDF
+        if: ${{ hashFiles('Advanced/lessons/slides/day-*/**/*.md') != '' }}
+        uses: KoharaKazuya/marp-cli-action@v4
+        with:
+          config-file: ./.marprc.yml
+          args: --input-dir Advanced/lessons/slides --output _site/slides/advanced
+
+      - name: Remove non-deck README artifacts
+        run: |
+          find _site/slides -maxdepth 1 -type f -name 'README*' -delete
+          find _site/slides/advanced -maxdepth 1 -type f -name 'README*' -delete 2>/dev/null || true
 
       - name: Ensure Pages root resolves to slide content
         run: |
@@ -75,7 +88,7 @@ jobs:
           if [ -f _site/slides/index.html ]; then
             echo "Found generated slide index at _site/slides/index.html."
           elif [ -d _site/slides ]; then
-            GENERATED_SLIDE_HTML="$(find _site/slides -maxdepth 2 -type f -name '*.html' -print -quit)"
+            GENERATED_SLIDE_HTML="$(find _site/slides -maxdepth 3 -type f -name '*.html' ! -name 'README.html' -print -quit)"
             if [ -n "${GENERATED_SLIDE_HTML}" ]; then
               echo "Generated slide HTML found in _site/slides; creating index.html entrypoint."
             else
@@ -106,10 +119,20 @@ jobs:
 
           if [ ! -f _site/slides/index.html ]; then
             # Use locale-independent sorting so the generated redirect is
-            # reproducible across runners and always targets the same deck.
-            # Depth 2 matches the checked-in slide site layout and Marp's
-            # current output structure without traversing unrelated content.
-            FIRST_SLIDE_HTML="$(find _site/slides -maxdepth 2 -type f -name '*.html' ! -name 'index.html' | LC_ALL=C sort | head -n 1)"
+            # reproducible across runners and prefers Basics deck output first,
+            # then Advanced deck output, before considering auxiliary files.
+            FIRST_SLIDE_HTML="$(find _site/slides -maxdepth 2 -type f -path '_site/slides/day-*/*.html' | LC_ALL=C sort | head -n 1)"
+
+            if [ -z "${FIRST_SLIDE_HTML}" ]; then
+              FIRST_SLIDE_HTML="$(find _site/slides -maxdepth 3 -type f -path '_site/slides/advanced/day-*/*.html' | LC_ALL=C sort | head -n 1)"
+            fi
+
+            if [ -z "${FIRST_SLIDE_HTML}" ]; then
+              # Depth 3 matches the checked-in slide site layout plus the
+              # dedicated `_site/slides/advanced/...` output for Advanced decks
+              # without traversing unrelated content.
+              FIRST_SLIDE_HTML="$(find _site/slides -maxdepth 3 -type f -name '*.html' ! -name 'index.html' ! -name 'README.html' | LC_ALL=C sort | head -n 1)"
+            fi
 
             if [ -z "${FIRST_SLIDE_HTML}" ]; then
               echo "ERROR: No slide HTML found to use as the /slides/ entrypoint."

--- a/.marprc.yml
+++ b/.marprc.yml
@@ -9,5 +9,5 @@ options:
   pdfOutlines: true
   pdfNotes: true
   images: png
-  inputDir: './Basics/lessons'
-  output: './_site/slides'
+  inputDir: 'Basics/lessons/slides'
+  output: '_site/slides'

--- a/.marprc.yml
+++ b/.marprc.yml
@@ -1,13 +1,13 @@
 allowLocalFiles: true
+inputDir: 'Basics/lessons/slides'
+output: '_site/slides'
+pdf: true
+pptx: true
+images: png
 options:
   looseYAML: false
   notes: true
   markdown:
     breaks: false
-  pdf: true
-  pptx: true
   pdfOutlines: true
   pdfNotes: true
-  images: png
-  inputDir: 'Basics/lessons/slides'
-  output: '_site/slides'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "python-envs.workspaceSearchPaths": [
+        "./**/.venv",
+        ".venv",
+        "*/.venv"
+    ],
+    "maven.view": "hierarchical",
+    "python.terminal.useEnvFile": true,
+    "terminal.integrated.cwd": ""
+}

--- a/Advanced/lessons/slides/day-01/day-01-session-1.html
+++ b/Advanced/lessons/slides/day-01/day-01-session-1.html
@@ -1,0 +1,1163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 1 — Session 1 (Hours 1–4)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 1 — Session 1 (Hours 1–4)</h1>
+            <div class="subtitle">Python Programming (Advanced) • Kickoff, Class Design, Validation, and Composition</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 1 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 1: Advanced kickoff + baseline diagnostic + Git workflow</li>
+  <li>Hour 2: Designing classes from requirements</li>
+  <li>Hour 3: Properties, invariants, and custom exceptions</li>
+  <li>Hour 4: Composition vs inheritance + polymorphism</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → <code>## Session 1 overview</code></li>
+  <li><code>Advanced/lessons/lecture/Day1_Hour1_Advanced.md</code> → <code># Day 1, Hour 1: Advanced Kickoff, Baseline Diagnostic, and Git Workflow</code></li>
+  <li><code>Advanced/lessons/lecture/Day1_Hour2_Advanced.md</code> → <code># Day 1, Hour 2: Designing Classes from Requirements</code></li>
+  <li><code>Advanced/lessons/lecture/Day1_Hour3_Advanced.md</code> → <code># Day 1, Hour 3: Properties, Invariants, and Custom Exceptions</code></li>
+  <li><code>Advanced/lessons/lecture/Day1_Hour4_Advanced.md</code> → <code># Day 1, Hour 4: Composition vs Inheritance + Polymorphism</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session 1 Outcomes</h1>
+            <ul>
+  <li>Set up an advanced-course capstone workspace</li>
+  <li>Use Git for frequent, understandable progress commits</li>
+  <li>Translate requirements into domain models + service boundaries</li>
+  <li>Protect object state with validation and specific exceptions</li>
+  <li>Prefer composition when collaborator behavior may change</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>In Scope</h1>
+            <ul>
+  <li>Project scaffold and workflow habits</li>
+  <li>Responsibility-driven design</li>
+  <li>Properties, invariants, and custom exceptions</li>
+  <li>Lightweight polymorphism and composition</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Not Yet</h1>
+            <ul>
+  <li>Database persistence</li>
+  <li>GUI or HTTP layers</li>
+  <li>Production auth/security systems</li>
+  <li>Overengineered inheritance hierarchies</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 1: Advanced Kickoff + Baseline Diagnostic</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Confirm the lab environment is ready for advanced work</li>
+  <li>Create the standard capstone folder layout</li>
+  <li>Initialize Git and make a first meaningful commit</li>
+  <li>Prove baseline readiness with a tiny diagnostic script</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Day 1 Starts Here</h1>
+            <ul>
+  <li>Advanced Python is about <strong>structure</strong>, not just syntax</li>
+  <li>We will build a capstone across the course</li>
+  <li>Frequent saves and small commits reduce recovery pain</li>
+  <li>The goal is a repeatable workflow before bigger architecture work</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/lessons/lecture/Day1_Hour1_Advanced.md</code> → <code>## 1. Advanced Kickoff (10 minutes)</code></li>
+  <li><code>Advanced/assignments/Advanced_Day1_homework.ipynb</code> → <code>## Part 1: Setup, Diagnostic Thinking, and Git Workflow</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Standard Capstone Scaffold</h1>
+            <pre data-lang="text"><code>project_root/
+├── src/
+├── tests/
+├── data/
+└── reports/</code></pre>
+<ul>
+  <li>Keep course work inside one repo/workspace</li>
+  <li>Save files normally; use lab suspend for longer breaks</li>
+  <li>Build the habit now before the project gets bigger</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Workspace + Git Baseline</h1>
+            <pre data-lang="bash"><code>mkdir capstone_tracker
+cd capstone_tracker
+git init
+python --version
+git status</code></pre>
+<ul>
+  <li>Start in a clean project folder</li>
+  <li>Confirm interpreter selection early</li>
+  <li>Commit after a working checkpoint, not after a mystery pile of edits</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Readiness Script</h1>
+            <pre data-lang="python"><code>class Hello:
+    def __init__(self, name: str) -&gt; None:
+        self.name = name
+
+    def greet(self) -&gt; None:
+        print(f&quot;Hello, {self.name}!&quot;)
+
+
+data = {&quot;status&quot;: &quot;ready&quot;}</code></pre>
+<ul>
+  <li>Include a class</li>
+  <li>Touch a dictionary</li>
+  <li>Show exception handling</li>
+  <li>Demonstrate file-aware thinking</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Environment + Diagnostic Check</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create the project folders: <code>src</code>, <code>tests</code>, <code>data</code>, <code>reports</code></li>
+  <li>Initialize a Git repo</li>
+  <li>Write a short diagnostic script that:</li>
+  <li style="margin-left: 30px;">defines a class</li>
+  <li style="margin-left: 30px;">uses a dictionary</li>
+  <li style="margin-left: 30px;">catches a specific error</li>
+  <li style="margin-left: 30px;">ends with <code>Diagnostic status: ready</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 1)</h1>
+            <p><span class="check">✓</span> <code>python --version</code> succeeds</p>
+<p><span class="check">✓</span> <code>git init</code> completed in the project folder</p>
+<p><span class="check">✓</span> Diagnostic script runs cleanly</p>
+<p><span class="check">✓</span> Learner can explain <strong>commit vs push</strong></p>
+<p><span class="check">✓</span> Folder layout matches the course scaffold</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 1)</h1>
+            <ul>
+  <li>Homework asks for:</li>
+  <li style="margin-left: 30px;"><code>Student: ...</code></li>
+  <li style="margin-left: 30px;"><code>Goal: ...</code></li>
+  <li style="margin-left: 30px;"><code>Python Version: ...</code></li>
+  <li style="margin-left: 30px;"><code>Project folders: src, tests, data, reports</code></li>
+  <li style="margin-left: 30px;"><code>Git workflow: clone -&gt; pull -&gt; status -&gt; add -&gt; commit -&gt; push</code></li>
+  <li>Quiz focus:</li>
+  <li style="margin-left: 30px;">save vs suspend</li>
+  <li style="margin-left: 30px;"><code>git init</code></li>
+  <li style="margin-left: 30px;">commit vs push</li>
+  <li style="margin-left: 30px;">diagnostic skill mix</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day1_homework.ipynb</code> → <code>### Exercise 1.1</code>, <code>### Exercise 1.2</code>, <code>### Exercise 1.3</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day1_Quiz.html</code> → <code>QUIZ_DATA</code> questions 1–6</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 1)</h1>
+            <p><strong>⚠️</strong> Confusing file save with lab session save</p>
+<p><strong>⚠️</strong> Waiting too long between commits</p>
+<p><strong>⚠️</strong> Skipping the readiness script and discovering issues later</p>
+<p><strong>⚠️</strong> Treating Git as backup instead of workflow</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> What does a commit do that a push does not?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 2: Designing Classes from Requirements</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Turn a requirements list into candidate classes</li>
+  <li>Separate what an object <strong>knows</strong> from what it <strong>does</strong></li>
+  <li>Keep UI concerns out of domain models</li>
+  <li>Introduce a coordinating service layer</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Responsibility-Driven Design</h1>
+            <ul>
+  <li>Ask first:</li>
+  <li style="margin-left: 30px;">What does this object know?</li>
+  <li style="margin-left: 30px;">What does this object do?</li>
+  <li>Keep methods small and testable</li>
+  <li>Let the model protect its own state</li>
+  <li>Let the service layer coordinate workflows</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>From Requirements to Classes</h1>
+            <h3>Example Tracker Domain</h3>
+<ul>
+  <li><code>Task</code></li>
+  <li style="margin-left: 30px;">knows: title, description, priority, status</li>
+  <li style="margin-left: 30px;">does: complete(), update_priority()</li>
+  <li><code>TaskService</code> or <code>TaskManager</code></li>
+  <li style="margin-left: 30px;">knows: collection of tasks</li>
+  <li style="margin-left: 30px;">does: add_task(), get_pending_tasks(), search()</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Boundary Rule</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Keep These Separate</h1>
+            <ul>
+  <li><strong>Model</strong>: domain state + invariant-friendly behavior</li>
+  <li><strong>Service layer</strong>: orchestration + use cases</li>
+  <li><strong>UI layer</strong>: <code>print()</code>, <code>input()</code>, menus, prompts</li>
+</ul>
+<h3>Smell to Fix</h3>
+<ul>
+  <li>A <code>Task</code> class that asks for user input directly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Small but Clean Model</h1>
+            <pre data-lang="python"><code>class Task:
+    def __init__(self, title: str, description: str, priority: str = &quot;Medium&quot;) -&gt; None:
+        self.title = title
+        self.description = description
+        self.priority = priority
+        self.is_complete = False
+
+    def complete(self) -&gt; None:
+        self.is_complete = True</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Outside-the-Class Summary</h1>
+            <pre data-lang="python"><code>def display_task_summary(task: Task) -&gt; None:
+    status = &quot;Done&quot; if task.is_complete else &quot;Pending&quot;
+    print(f&quot;[{status}] {task.title} (Priority: {task.priority})&quot;)</code></pre>
+<ul>
+  <li>Logic stays in the model</li>
+  <li>Presentation stays outside the model</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Domain Modeling</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Pick one tracker domain:</li>
+  <li style="margin-left: 30px;">tasks</li>
+  <li style="margin-left: 30px;">contacts</li>
+  <li style="margin-left: 30px;">inventory</li>
+  <li style="margin-left: 30px;">notes</li>
+  <li style="margin-left: 30px;">expenses</li>
+  <li>Write 5–8 requirements</li>
+  <li>Design 3–5 classes</li>
+  <li>Implement at least:</li>
+  <li style="margin-left: 30px;">one domain class</li>
+  <li style="margin-left: 30px;">one coordinating class</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 2)</h1>
+            <p><span class="check">✓</span> Requirements map clearly to classes</p>
+<p><span class="check">✓</span> Attributes and methods are distinct</p>
+<p><span class="check">✓</span> No <code>input()</code> / <code>print()</code> inside domain logic</p>
+<p><span class="check">✓</span> Demo block creates an object and shows a summary externally</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 2)</h1>
+            <ul>
+  <li>Homework expects:</li>
+  <li style="margin-left: 30px;">requirement bullets</li>
+  <li style="margin-left: 30px;">3–5 classes</li>
+  <li style="margin-left: 30px;">one domain class + one coordinating class</li>
+  <li style="margin-left: 30px;">a clear boundary rule</li>
+  <li>Quiz focus:</li>
+  <li style="margin-left: 30px;">what an object knows vs does</li>
+  <li style="margin-left: 30px;">what belongs in a service layer</li>
+  <li style="margin-left: 30px;">where validation should live</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day1_homework.ipynb</code> → <code>## Part 2: Designing Classes from Requirements</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day1_Quiz.html</code> → <code>QUIZ_DATA</code> questions 7–12</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 2)</h1>
+            <p><strong>⚠️</strong> Putting UI prompts into model methods</p>
+<p><strong>⚠️</strong> Designing around globals instead of collaborators</p>
+<p><strong>⚠️</strong> Making classes vague helper buckets</p>
+<p><strong>⚠️</strong> Jumping to inheritance before clarifying responsibilities</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Where should business validation live: UI, service/model, or Git history?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 3: Properties, Invariants, and Custom Exceptions</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Define an invariant for a real domain object</li>
+  <li>Use <code>@property</code> to control attribute access</li>
+  <li>Raise specific exceptions for domain problems</li>
+  <li>Catch errors in the driver/UI layer instead of inside the model</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Core Idea: Valid Objects Stay Valid</h1>
+            <ul>
+  <li>An <strong>invariant</strong> is a rule that must remain true</li>
+  <li>Examples:</li>
+  <li style="margin-left: 30px;">title must not be blank</li>
+  <li style="margin-left: 30px;">amount must be positive</li>
+  <li style="margin-left: 30px;">priority must be an integer in range</li>
+  <li>A model that accepts invalid state becomes harder to trust later</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Custom Exception + Property</h1>
+            <pre data-lang="python"><code>class ValidationError(Exception):
+    pass
+
+
+class Task:
+    def __init__(self, title: str, priority: int = 1) -&gt; None:
+        self.title = title
+        self.priority = priority</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Validated Setter</h1>
+            <pre data-lang="python"><code>    @property
+    def priority(self) -&gt; int:
+        return self._priority
+
+    @priority.setter
+    def priority(self, value: int) -&gt; None:
+        if not isinstance(value, int) or value &lt; 1:
+            raise ValidationError(&quot;Priority must be an integer &gt;= 1&quot;)
+        self._priority = value</code></pre>
+<ul>
+  <li>Backing field uses <code>_priority</code></li>
+  <li>Setter guards the invariant</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Catching Specific Errors</h1>
+            <pre data-lang="python"><code>try:
+    task = Task(&quot;Clean Desk&quot;, priority=-1)
+except ValidationError as error:
+    print(f&quot;ValidationError: {error}&quot;)</code></pre>
+<ul>
+  <li>Specific beats broad</li>
+  <li>Avoid <code>except Exception:</code> for expected domain failures</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Validation + Exceptions</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Convert one important attribute to a validated property</li>
+  <li>Add at least two custom exceptions:</li>
+  <li style="margin-left: 30px;"><code>ValidationError</code></li>
+  <li style="margin-left: 30px;"><code>NotFoundError</code></li>
+  <li>Show:</li>
+  <li style="margin-left: 30px;">invalid data raises <code>ValidationError</code></li>
+  <li style="margin-left: 30px;">missing lookup raises <code>NotFoundError</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 3)</h1>
+            <p><span class="check">✓</span> A real invariant is enforced</p>
+<p><span class="check">✓</span> The setter uses a backing field</p>
+<p><span class="check">✓</span> Specific exceptions are raised intentionally</p>
+<p><span class="check">✓</span> Friendly handling happens in a driver/demo block</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 3)</h1>
+            <ul>
+  <li>Homework expects both <code>ValidationError</code> and <code>NotFoundError</code></li>
+  <li>Canonical outputs include:</li>
+  <li style="margin-left: 30px;"><code>Priority set to: 3</code></li>
+  <li style="margin-left: 30px;"><code>ValidationError: title cannot be empty</code></li>
+  <li style="margin-left: 30px;"><code>NotFoundError: task 404 was not found</code></li>
+  <li>Quiz focus:</li>
+  <li style="margin-left: 30px;">invariant meaning</li>
+  <li style="margin-left: 30px;">why <code>@property</code> helps</li>
+  <li style="margin-left: 30px;">why specific exceptions beat <code>except Exception:</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day1_homework.ipynb</code> → <code>## Part 3: Properties, Invariants, and Custom Exceptions</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day1_Quiz.html</code> → <code>QUIZ_DATA</code> questions 13–18</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 3)</h1>
+            <p><strong>⚠️</strong> Setter assigns to <code>self.priority</code> recursively</p>
+<p><strong>⚠️</strong> Returning <code>False</code> instead of surfacing a real error</p>
+<p><strong>⚠️</strong> Catching every exception and hiding unrelated bugs</p>
+<p><strong>⚠️</strong> Validating only in the UI and not in the model/service</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Why is <code>ValidationError</code> usually better than returning <code>False</code> from validation code?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 4: Composition vs Inheritance + Polymorphism</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Distinguish <strong>is-a</strong> from <strong>has-a</strong></li>
+  <li>Use composition when collaborator behavior may vary</li>
+  <li>Reduce branchy code with shared method names</li>
+  <li>Explain duck typing in practical terms</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Inheritance vs Composition</h1>
+            <h3>Use Inheritance for</h3>
+<ul>
+  <li>real <strong>is-a</strong> relationships</li>
+  <li>stable shared behavior</li>
+</ul>
+<h3>Use Composition for</h3>
+<ul>
+  <li><strong>has-a</strong> relationships</li>
+  <li>swappable collaborators</li>
+  <li>cleaner extension without deep class trees</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Branchy Export Smell</h1>
+            <pre data-lang="python"><code>def export_data(data, format_type):
+    if format_type == &quot;json&quot;:
+        ...
+    elif format_type == &quot;csv&quot;:
+        ...
+    else:
+        raise ValueError(&quot;Unknown format&quot;)</code></pre>
+<ul>
+  <li>Works at first</li>
+  <li>Scales badly as new behaviors appear</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Polymorphic Exporters</h1>
+            <pre data-lang="python"><code>class JSONExporter:
+    def export(self, data):
+        return {&quot;data&quot;: data}
+
+
+class CSVExporter:
+    def export(self, data):
+        return f&quot;data,{data}&quot;</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Composition in the Caller</h1>
+            <pre data-lang="python"><code>class ReportService:
+    def __init__(self, exporter) -&gt; None:
+        self.exporter = exporter
+
+    def generate(self, data):
+        return self.exporter.export(data)</code></pre>
+<ul>
+  <li>Caller depends on a compatible collaborator</li>
+  <li>New exporter types do not require new caller branches</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Refactor a Branchy Design</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Start with a branching scenario:</li>
+  <li style="margin-left: 30px;">exporting</li>
+  <li style="margin-left: 30px;">notifications</li>
+  <li style="margin-left: 30px;">payments</li>
+  <li>Create 2+ implementations with the same method name</li>
+  <li>Add a class that <strong>has a</strong> collaborator</li>
+  <li>Swap collaborators without changing caller structure</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 4)</h1>
+            <p><span class="check">✓</span> A large <code>if/elif</code> chain is reduced or removed</p>
+<p><span class="check">✓</span> Two or more implementations share one method name</p>
+<p><span class="check">✓</span> Composition is visible in the caller</p>
+<p><span class="check">✓</span> A third implementation could be added with minimal change</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 4)</h1>
+            <ul>
+  <li>Homework expects:</li>
+  <li style="margin-left: 30px;">a branchy design replaced</li>
+  <li style="margin-left: 30px;">composition shown clearly</li>
+  <li style="margin-left: 30px;">optional third implementation</li>
+  <li>Canonical output references:</li>
+  <li style="margin-left: 30px;"><code>Composed notifier sent: Task created</code></li>
+  <li style="margin-left: 30px;"><code>Export text: TASK-101 | Draft syllabus</code></li>
+  <li style="margin-left: 30px;"><code>Export dict: {&#x27;id&#x27;: &#x27;TASK-101&#x27;, &#x27;title&#x27;: &#x27;Draft syllabus&#x27;}</code></li>
+  <li>Quiz focus:</li>
+  <li style="margin-left: 30px;">is-a vs has-a</li>
+  <li style="margin-left: 30px;">duck typing</li>
+  <li style="margin-left: 30px;">caller stability when new implementations appear</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day1_homework.ipynb</code> → <code>## Part 4: Composition vs Inheritance + Polymorphism</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day1_Quiz.html</code> → <code>QUIZ_DATA</code> questions 19–24</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 4)</h1>
+            <p><strong>⚠️</strong> Moving the <code>if/elif</code> chain into a new class instead of removing it</p>
+<p><strong>⚠️</strong> Inheriting when the relationship is really has-a</p>
+<p><strong>⚠️</strong> Forgetting that duck typing cares about behavior, not ancestry</p>
+<p><strong>⚠️</strong> Hard-coding collaborator choice inside the caller</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> What is the practical benefit of giving the caller any object with a compatible <code>export()</code> method?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 1 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Built Today</h1>
+            <ul>
+  <li>A stable workspace + Git baseline</li>
+  <li>Cleaner domain boundaries</li>
+  <li>Validated models with specific exceptions</li>
+  <li>Composition-friendly architecture</li>
+</ul>
+<h3>Key Day 1 Rule</h3>
+<p><strong>Professional Python starts with trustworthy structure.</strong></p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 1 Homework / Study Checklist</h1>
+            <ul>
+  <li>Re-run the diagnostic script</li>
+  <li>Refine your requirements list</li>
+  <li>Enforce one invariant with a property</li>
+  <li>Add two specific custom exceptions</li>
+  <li>Refactor one branch-heavy workflow into collaborators</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day1_homework.ipynb</code> → <code>## Reflection and Submission Checklist</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Next Session Preview</h1>
+            <h3>Session 2 (Hours 5–8)</h3>
+<ul>
+  <li>Factory pattern for validated creation</li>
+  <li>Strategy pattern for swappable behavior</li>
+  <li><code>__repr__</code>, <code>__str__</code>, equality, and light type hints</li>
+  <li>Checkpoint 1: domain + service layer milestone</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Save your work.</p>
+<p>Commit the latest good state.</p>
+<p>Be ready to extend the core tomorrow.</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/Advanced/lessons/slides/day-01/day-01-session-1.md
+++ b/Advanced/lessons/slides/day-01/day-01-session-1.md
@@ -113,6 +113,11 @@ class Hello:
 
 
 data = {"status": "ready"}
+
+try:
+    print(data["status"])
+except KeyError:
+    print("Status not found!")
 ```
 
 - Include a class
@@ -501,11 +506,13 @@ class CSVExporter:
 ## Demo: Composition in the Caller
 
 ```python
+from typing import Any
+
 class ReportService:
-    def __init__(self, exporter) -> None:
+    def __init__(self, exporter: Any) -> None:
         self.exporter = exporter
 
-    def generate(self, data):
+    def generate(self, data: Any) -> Any:
         return self.exporter.export(data)
 ```
 

--- a/Advanced/lessons/slides/day-01/day-01-session-1.md
+++ b/Advanced/lessons/slides/day-01/day-01-session-1.md
@@ -1,0 +1,617 @@
+# Advanced Day 1 — Session 1 (Hours 1–4)
+Python Programming (Advanced) • Kickoff, Class Design, Validation, and Composition
+
+---
+
+# Session 1 Overview
+
+## Topics Covered Today
+- Hour 1: Advanced kickoff + baseline diagnostic + Git workflow
+- Hour 2: Designing classes from requirements
+- Hour 3: Properties, invariants, and custom exceptions
+- Hour 4: Composition vs inheritance + polymorphism
+
+### Source Alignment
+- `Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md` → `## Session 1 overview`
+- `Advanced/lessons/lecture/Day1_Hour1_Advanced.md` → `# Day 1, Hour 1: Advanced Kickoff, Baseline Diagnostic, and Git Workflow`
+- `Advanced/lessons/lecture/Day1_Hour2_Advanced.md` → `# Day 1, Hour 2: Designing Classes from Requirements`
+- `Advanced/lessons/lecture/Day1_Hour3_Advanced.md` → `# Day 1, Hour 3: Properties, Invariants, and Custom Exceptions`
+- `Advanced/lessons/lecture/Day1_Hour4_Advanced.md` → `# Day 1, Hour 4: Composition vs Inheritance + Polymorphism`
+
+---
+
+# Session 1 Outcomes
+
+- Set up an advanced-course capstone workspace
+- Use Git for frequent, understandable progress commits
+- Translate requirements into domain models + service boundaries
+- Protect object state with validation and specific exceptions
+- Prefer composition when collaborator behavior may change
+
+---
+
+# Scope Guardrails for Today
+
+## In Scope
+- Project scaffold and workflow habits
+- Responsibility-driven design
+- Properties, invariants, and custom exceptions
+- Lightweight polymorphism and composition
+
+## Not Yet
+- Database persistence
+- GUI or HTTP layers
+- Production auth/security systems
+- Overengineered inheritance hierarchies
+
+---
+
+# Hour 1: Advanced Kickoff + Baseline Diagnostic
+
+## Learning Outcomes
+- Confirm the lab environment is ready for advanced work
+- Create the standard capstone folder layout
+- Initialize Git and make a first meaningful commit
+- Prove baseline readiness with a tiny diagnostic script
+
+---
+
+## Why Day 1 Starts Here
+
+- Advanced Python is about **structure**, not just syntax
+- We will build a capstone across the course
+- Frequent saves and small commits reduce recovery pain
+- The goal is a repeatable workflow before bigger architecture work
+
+### Source Alignment
+- `Advanced/lessons/lecture/Day1_Hour1_Advanced.md` → `## 1. Advanced Kickoff (10 minutes)`
+- `Advanced/assignments/Advanced_Day1_homework.ipynb` → `## Part 1: Setup, Diagnostic Thinking, and Git Workflow`
+
+---
+
+## Standard Capstone Scaffold
+
+```text
+project_root/
+├── src/
+├── tests/
+├── data/
+└── reports/
+```
+
+- Keep course work inside one repo/workspace
+- Save files normally; use lab suspend for longer breaks
+- Build the habit now before the project gets bigger
+
+---
+
+## Demo: Workspace + Git Baseline
+
+```bash
+mkdir capstone_tracker
+cd capstone_tracker
+git init
+python --version
+git status
+```
+
+- Start in a clean project folder
+- Confirm interpreter selection early
+- Commit after a working checkpoint, not after a mystery pile of edits
+
+---
+
+## Demo: Readiness Script
+
+```python
+class Hello:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def greet(self) -> None:
+        print(f"Hello, {self.name}!")
+
+
+data = {"status": "ready"}
+```
+
+- Include a class
+- Touch a dictionary
+- Show exception handling
+- Demonstrate file-aware thinking
+
+---
+
+## Lab: Environment + Diagnostic Check
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Create the project folders: `src`, `tests`, `data`, `reports`
+- Initialize a Git repo
+- Write a short diagnostic script that:
+  - defines a class
+  - uses a dictionary
+  - catches a specific error
+  - ends with `Diagnostic status: ready`
+
+---
+
+## Completion Criteria (Hour 1)
+
+✓ `python --version` succeeds  
+✓ `git init` completed in the project folder  
+✓ Diagnostic script runs cleanly  
+✓ Learner can explain **commit vs push**  
+✓ Folder layout matches the course scaffold
+
+---
+
+## Homework + Quiz Emphasis (Hour 1)
+
+- Homework asks for:
+  - `Student: ...`
+  - `Goal: ...`
+  - `Python Version: ...`
+  - `Project folders: src, tests, data, reports`
+  - `Git workflow: clone -> pull -> status -> add -> commit -> push`
+- Quiz focus:
+  - save vs suspend
+  - `git init`
+  - commit vs push
+  - diagnostic skill mix
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day1_homework.ipynb` → `### Exercise 1.1`, `### Exercise 1.2`, `### Exercise 1.3`
+- `Advanced/quizzes/Advanced_Day1_Quiz.html` → `QUIZ_DATA` questions 1–6
+
+---
+
+## Common Pitfalls (Hour 1)
+
+⚠️ Confusing file save with lab session save  
+⚠️ Waiting too long between commits  
+⚠️ Skipping the readiness script and discovering issues later  
+⚠️ Treating Git as backup instead of workflow
+
+---
+
+## Quick Check
+
+**Question:** What does a commit do that a push does not?
+
+---
+
+# Hour 2: Designing Classes from Requirements
+
+## Learning Outcomes
+- Turn a requirements list into candidate classes
+- Separate what an object **knows** from what it **does**
+- Keep UI concerns out of domain models
+- Introduce a coordinating service layer
+
+---
+
+## Responsibility-Driven Design
+
+- Ask first:
+  - What does this object know?
+  - What does this object do?
+- Keep methods small and testable
+- Let the model protect its own state
+- Let the service layer coordinate workflows
+
+---
+
+## From Requirements to Classes
+
+### Example Tracker Domain
+- `Task`
+  - knows: title, description, priority, status
+  - does: complete(), update_priority()
+- `TaskService` or `TaskManager`
+  - knows: collection of tasks
+  - does: add_task(), get_pending_tasks(), search()
+
+---
+
+## Boundary Rule
+
+## Keep These Separate
+- **Model**: domain state + invariant-friendly behavior
+- **Service layer**: orchestration + use cases
+- **UI layer**: `print()`, `input()`, menus, prompts
+
+### Smell to Fix
+- A `Task` class that asks for user input directly
+
+---
+
+## Demo: Small but Clean Model
+
+```python
+class Task:
+    def __init__(self, title: str, description: str, priority: str = "Medium") -> None:
+        self.title = title
+        self.description = description
+        self.priority = priority
+        self.is_complete = False
+
+    def complete(self) -> None:
+        self.is_complete = True
+```
+
+---
+
+## Demo: Outside-the-Class Summary
+
+```python
+def display_task_summary(task: Task) -> None:
+    status = "Done" if task.is_complete else "Pending"
+    print(f"[{status}] {task.title} (Priority: {task.priority})")
+```
+
+- Logic stays in the model
+- Presentation stays outside the model
+
+---
+
+## Lab: Domain Modeling
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Pick one tracker domain:
+  - tasks
+  - contacts
+  - inventory
+  - notes
+  - expenses
+- Write 5–8 requirements
+- Design 3–5 classes
+- Implement at least:
+  - one domain class
+  - one coordinating class
+
+---
+
+## Completion Criteria (Hour 2)
+
+✓ Requirements map clearly to classes  
+✓ Attributes and methods are distinct  
+✓ No `input()` / `print()` inside domain logic  
+✓ Demo block creates an object and shows a summary externally
+
+---
+
+## Homework + Quiz Emphasis (Hour 2)
+
+- Homework expects:
+  - requirement bullets
+  - 3–5 classes
+  - one domain class + one coordinating class
+  - a clear boundary rule
+- Quiz focus:
+  - what an object knows vs does
+  - what belongs in a service layer
+  - where validation should live
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day1_homework.ipynb` → `## Part 2: Designing Classes from Requirements`
+- `Advanced/quizzes/Advanced_Day1_Quiz.html` → `QUIZ_DATA` questions 7–12
+
+---
+
+## Common Pitfalls (Hour 2)
+
+⚠️ Putting UI prompts into model methods  
+⚠️ Designing around globals instead of collaborators  
+⚠️ Making classes vague helper buckets  
+⚠️ Jumping to inheritance before clarifying responsibilities
+
+---
+
+## Quick Check
+
+**Question:** Where should business validation live: UI, service/model, or Git history?
+
+---
+
+# Hour 3: Properties, Invariants, and Custom Exceptions
+
+## Learning Outcomes
+- Define an invariant for a real domain object
+- Use `@property` to control attribute access
+- Raise specific exceptions for domain problems
+- Catch errors in the driver/UI layer instead of inside the model
+
+---
+
+## Core Idea: Valid Objects Stay Valid
+
+- An **invariant** is a rule that must remain true
+- Examples:
+  - title must not be blank
+  - amount must be positive
+  - priority must be an integer in range
+- A model that accepts invalid state becomes harder to trust later
+
+---
+
+## Demo: Custom Exception + Property
+
+```python
+class ValidationError(Exception):
+    pass
+
+
+class Task:
+    def __init__(self, title: str, priority: int = 1) -> None:
+        self.title = title
+        self.priority = priority
+```
+
+---
+
+## Demo: Validated Setter
+
+```python
+    @property
+    def priority(self) -> int:
+        return self._priority
+
+    @priority.setter
+    def priority(self, value: int) -> None:
+        if not isinstance(value, int) or value < 1:
+            raise ValidationError("Priority must be an integer >= 1")
+        self._priority = value
+```
+
+- Backing field uses `_priority`
+- Setter guards the invariant
+
+---
+
+## Catching Specific Errors
+
+```python
+try:
+    task = Task("Clean Desk", priority=-1)
+except ValidationError as error:
+    print(f"ValidationError: {error}")
+```
+
+- Specific beats broad
+- Avoid `except Exception:` for expected domain failures
+
+---
+
+## Lab: Validation + Exceptions
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Convert one important attribute to a validated property
+- Add at least two custom exceptions:
+  - `ValidationError`
+  - `NotFoundError`
+- Show:
+  - invalid data raises `ValidationError`
+  - missing lookup raises `NotFoundError`
+
+---
+
+## Completion Criteria (Hour 3)
+
+✓ A real invariant is enforced  
+✓ The setter uses a backing field  
+✓ Specific exceptions are raised intentionally  
+✓ Friendly handling happens in a driver/demo block
+
+---
+
+## Homework + Quiz Emphasis (Hour 3)
+
+- Homework expects both `ValidationError` and `NotFoundError`
+- Canonical outputs include:
+  - `Priority set to: 3`
+  - `ValidationError: title cannot be empty`
+  - `NotFoundError: task 404 was not found`
+- Quiz focus:
+  - invariant meaning
+  - why `@property` helps
+  - why specific exceptions beat `except Exception:`
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day1_homework.ipynb` → `## Part 3: Properties, Invariants, and Custom Exceptions`
+- `Advanced/quizzes/Advanced_Day1_Quiz.html` → `QUIZ_DATA` questions 13–18
+
+---
+
+## Common Pitfalls (Hour 3)
+
+⚠️ Setter assigns to `self.priority` recursively  
+⚠️ Returning `False` instead of surfacing a real error  
+⚠️ Catching every exception and hiding unrelated bugs  
+⚠️ Validating only in the UI and not in the model/service
+
+---
+
+## Quick Check
+
+**Question:** Why is `ValidationError` usually better than returning `False` from validation code?
+
+---
+
+# Hour 4: Composition vs Inheritance + Polymorphism
+
+## Learning Outcomes
+- Distinguish **is-a** from **has-a**
+- Use composition when collaborator behavior may vary
+- Reduce branchy code with shared method names
+- Explain duck typing in practical terms
+
+---
+
+## Inheritance vs Composition
+
+### Use Inheritance for
+- real **is-a** relationships
+- stable shared behavior
+
+### Use Composition for
+- **has-a** relationships
+- swappable collaborators
+- cleaner extension without deep class trees
+
+---
+
+## Demo: Branchy Export Smell
+
+```python
+def export_data(data, format_type):
+    if format_type == "json":
+        ...
+    elif format_type == "csv":
+        ...
+    else:
+        raise ValueError("Unknown format")
+```
+
+- Works at first
+- Scales badly as new behaviors appear
+
+---
+
+## Demo: Polymorphic Exporters
+
+```python
+class JSONExporter:
+    def export(self, data):
+        return {"data": data}
+
+
+class CSVExporter:
+    def export(self, data):
+        return f"data,{data}"
+```
+
+---
+
+## Demo: Composition in the Caller
+
+```python
+class ReportService:
+    def __init__(self, exporter) -> None:
+        self.exporter = exporter
+
+    def generate(self, data):
+        return self.exporter.export(data)
+```
+
+- Caller depends on a compatible collaborator
+- New exporter types do not require new caller branches
+
+---
+
+## Lab: Refactor a Branchy Design
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Start with a branching scenario:
+  - exporting
+  - notifications
+  - payments
+- Create 2+ implementations with the same method name
+- Add a class that **has a** collaborator
+- Swap collaborators without changing caller structure
+
+---
+
+## Completion Criteria (Hour 4)
+
+✓ A large `if/elif` chain is reduced or removed  
+✓ Two or more implementations share one method name  
+✓ Composition is visible in the caller  
+✓ A third implementation could be added with minimal change
+
+---
+
+## Homework + Quiz Emphasis (Hour 4)
+
+- Homework expects:
+  - a branchy design replaced
+  - composition shown clearly
+  - optional third implementation
+- Canonical output references:
+  - `Composed notifier sent: Task created`
+  - `Export text: TASK-101 | Draft syllabus`
+  - `Export dict: {'id': 'TASK-101', 'title': 'Draft syllabus'}`
+- Quiz focus:
+  - is-a vs has-a
+  - duck typing
+  - caller stability when new implementations appear
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day1_homework.ipynb` → `## Part 4: Composition vs Inheritance + Polymorphism`
+- `Advanced/quizzes/Advanced_Day1_Quiz.html` → `QUIZ_DATA` questions 19–24
+
+---
+
+## Common Pitfalls (Hour 4)
+
+⚠️ Moving the `if/elif` chain into a new class instead of removing it  
+⚠️ Inheriting when the relationship is really has-a  
+⚠️ Forgetting that duck typing cares about behavior, not ancestry  
+⚠️ Hard-coding collaborator choice inside the caller
+
+---
+
+## Quick Check
+
+**Question:** What is the practical benefit of giving the caller any object with a compatible `export()` method?
+
+---
+
+# Session 1 Wrap-Up
+
+## What We Built Today
+- A stable workspace + Git baseline
+- Cleaner domain boundaries
+- Validated models with specific exceptions
+- Composition-friendly architecture
+
+### Key Day 1 Rule
+**Professional Python starts with trustworthy structure.**
+
+---
+
+## Day 1 Homework / Study Checklist
+
+- Re-run the diagnostic script
+- Refine your requirements list
+- Enforce one invariant with a property
+- Add two specific custom exceptions
+- Refactor one branch-heavy workflow into collaborators
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day1_homework.ipynb` → `## Reflection and Submission Checklist`
+
+---
+
+## Next Session Preview
+
+### Session 2 (Hours 5–8)
+- Factory pattern for validated creation
+- Strategy pattern for swappable behavior
+- `__repr__`, `__str__`, equality, and light type hints
+- Checkpoint 1: domain + service layer milestone
+
+---
+
+# Thank You!
+
+Save your work.  
+Commit the latest good state.  
+Be ready to extend the core tomorrow.

--- a/Advanced/lessons/slides/day-02/day-02-session-2.html
+++ b/Advanced/lessons/slides/day-02/day-02-session-2.html
@@ -1,0 +1,1071 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 2 — Session 2 (Hours 5–8)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 2 — Session 2 (Hours 5–8)</h1>
+            <div class="subtitle">Python Programming (Advanced) • Factory, Strategy, Ergonomics, and Checkpoint 1</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 2 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 5: Pattern: Factory (practical creation + validation)</li>
+  <li>Hour 6: Pattern: Strategy (swap behaviors cleanly)</li>
+  <li>Hour 7: Pythonic class ergonomics (<code>repr</code> / <code>str</code> / equality) + light type hints</li>
+  <li>Hour 8: Checkpoint 1: domain + service layer milestone</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → <code>## Session 2 overview</code></li>
+  <li><code>Advanced/lessons/lecture/Day2_Hour1_Advanced.md</code> → <code># Day 2, Hour 1: Pattern: Factory (practical creation + validation)</code></li>
+  <li><code>Advanced/lessons/lecture/Day2_Hour2_Advanced.md</code> → <code># Day 2, Hour 2: Pattern: Strategy (swap behaviors cleanly)</code></li>
+  <li><code>Advanced/lessons/lecture/Day2_Hour3_Advanced.md</code> → <code># Day 2, Hour 3: Pythonic Class Ergonomics</code></li>
+  <li><code>Advanced/lessons/lecture/Day2_Hour4_Advanced.md</code> → <code># Day 2, Hour 4: Checkpoint 1: Domain + Service Layer Milestone</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session 2 Outcomes</h1>
+            <ul>
+  <li>Centralize creation rules with factories</li>
+  <li>Swap behavior without rewriting callers</li>
+  <li>Make models easier to inspect, print, and compare</li>
+  <li>Deliver a clean headless core for Checkpoint 1</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>In Scope</h1>
+            <ul>
+  <li>Validated object creation</li>
+  <li>Strategy dispatch with functions or collaborators</li>
+  <li>Readable object output and simple type hints</li>
+  <li>Core-only checkpoint work</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Not Yet</h1>
+            <ul>
+  <li>Database persistence</li>
+  <li>GUI callbacks</li>
+  <li>HTTP routes</li>
+  <li>Heavy typing abstractions or framework ceremony</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 5: Factory Pattern</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Move creation + normalization logic out of <code>__init__</code></li>
+  <li>Turn raw payloads into safe domain objects</li>
+  <li>Raise validation errors before bad objects spread</li>
+  <li>Explain why centralized creation improves consistency</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Factories Matter</h1>
+            <ul>
+  <li>External data is messy</li>
+  <li>Repeating validation in every caller causes drift</li>
+  <li><code>__init__</code> should initialize, not become a giant intake pipeline</li>
+  <li>A factory can:</li>
+  <li style="margin-left: 30px;">validate</li>
+  <li style="margin-left: 30px;">normalize</li>
+  <li style="margin-left: 30px;">apply defaults</li>
+  <li style="margin-left: 30px;">return a ready-to-use object</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Factory from Raw Data</h1>
+            <pre data-lang="python"><code>class UserFactory:
+    @classmethod
+    def from_dict(cls, data):
+        if &quot;name&quot; not in data:
+            raise ValidationError(&quot;Missing required field: &#x27;name&#x27;&quot;)
+
+        name = data[&quot;name&quot;].strip().title()
+        role = data.get(&quot;role&quot;, &quot;member&quot;).lower()
+        return User(full_name=name, role=role)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Factory Responsibilities</h1>
+            <ul>
+  <li>Validate required fields</li>
+  <li>Normalize messy input</li>
+  <li>Supply safe defaults</li>
+  <li>Reject unsupported values early</li>
+</ul>
+<h3>Better Than</h3>
+<ul>
+  <li>every route validating differently</li>
+  <li>every CLI prompt building objects ad hoc</li>
+  <li>huge constructors full of branching</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Build a Validated Factory</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create a <code>from_dict()</code> or <code>create_*()</code> factory</li>
+  <li>Validate at least one required field</li>
+  <li>Normalize one messy field</li>
+  <li>Return a safe tracker record or raise <code>ValidationError</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 5)</h1>
+            <p><span class="check">✓</span> Factory builds valid objects from raw payloads</p>
+<p><span class="check">✓</span> Missing or bad data fails clearly</p>
+<p><span class="check">✓</span> Creation logic is not duplicated in multiple callers</p>
+<p><span class="check">✓</span> The returned object is ready for service-layer use</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 5)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> validated factory for safe tracker records</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> use a classmethod factory</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> duplicating validation logic in every caller</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 5 | factory title: Refactor auth flow</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day2_homework.ipynb</code> → <code>## Part 1: Hour 5 - Pattern: Factory</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day2_Quiz.html</code> → <code>QUIZ_DATA</code> questions 1–5</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 5)</h1>
+            <p><strong>⚠️</strong> Letting invalid objects exist &quot;just for now&quot;</p>
+<p><strong>⚠️</strong> Hiding normalization logic in random callers</p>
+<p><strong>⚠️</strong> Making <code>__init__</code> do everything</p>
+<p><strong>⚠️</strong> Using vague exceptions with vague messages</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Why is a factory safer than repeating payload validation in five different places?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 6: Strategy Pattern</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Replace branch-heavy behavior selection</li>
+  <li>Use functions or collaborators as strategies</li>
+  <li>Dispatch dynamically from a small mapping</li>
+  <li>Keep core orchestration stable while behavior changes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Strategy in Plain English</h1>
+            <ul>
+  <li>We have one job with multiple ways to do it</li>
+  <li>We separate <strong>what happens</strong> from <strong>how it happens</strong></li>
+  <li>In Python, a strategy can just be a callable</li>
+</ul>
+<h3>Typical Use Cases</h3>
+<ul>
+  <li>sorting</li>
+  <li>filtering</li>
+  <li>exporting</li>
+  <li>notifications</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Dispatch Map</h1>
+            <pre data-lang="python"><code>def sort_by_name(record):
+    return record[&quot;name&quot;]
+
+
+sorting_strategies = {
+    &quot;name&quot;: sort_by_name,
+    &quot;id&quot;: sort_by_id,
+    &quot;created&quot;: sort_by_date,
+}</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Core Function Stays Simple</h1>
+            <pre data-lang="python"><code>def display_records_strategy(records, strategy_key):
+    strategy_func = sorting_strategies.get(strategy_key, sort_by_id)
+    sorted_records = sorted(records, key=strategy_func)
+    for record in sorted_records:
+        print(record)</code></pre>
+<ul>
+  <li>Caller does not need a giant <code>if/elif</code></li>
+  <li>New strategies are easier to add</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Strategy Selection</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Choose a behavior that varies:</li>
+  <li style="margin-left: 30px;">filter active vs all</li>
+  <li style="margin-left: 30px;">sort by name vs date</li>
+  <li style="margin-left: 30px;">notify via email vs console</li>
+  <li>Implement 2+ strategies</li>
+  <li>Use a dictionary dispatcher or injected collaborator</li>
+  <li>Run the same caller with multiple behaviors</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 6)</h1>
+            <p><span class="check">✓</span> Two or more strategies exist</p>
+<p><span class="check">✓</span> Behavior is selected dynamically</p>
+<p><span class="check">✓</span> Caller logic stays small</p>
+<p><span class="check">✓</span> A new strategy can be added without rewriting the main flow</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 6)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> switch behavior without rewriting the caller</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> inject behavior objects or callables</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> burying every algorithm in one <code>if/elif</code> chain</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 6 | strategy selected: EmailNotifier</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day2_homework.ipynb</code> → <code>## Part 2: Hour 6 - Pattern: Strategy</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day2_Quiz.html</code> → <code>QUIZ_DATA</code> questions 6–10</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 6)</h1>
+            <p><strong>⚠️</strong> Calling a function instead of passing the function object</p>
+<p><strong>⚠️</strong> Keeping the big branch chain in the main routine</p>
+<p><strong>⚠️</strong> Naming strategies unclearly</p>
+<p><strong>⚠️</strong> Mixing strategy selection with unrelated UI complexity</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> What changes when you add a third strategy to a good strategy-based design?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 7: Pythonic Class Ergonomics</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Differentiate <code>__str__</code> from <code>__repr__</code></li>
+  <li>Implement value-based equality with <code>__eq__</code></li>
+  <li>Add light type hints that improve readability and tooling</li>
+  <li>Prepare models for easier debugging and serialization</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Default Objects Are Not Enough</h1>
+            <pre data-lang="python"><code>print(task)
+# &lt;__main__.Task object at 0x...&gt;</code></pre>
+<ul>
+  <li>Not useful for logs</li>
+  <li>Not useful for debugging</li>
+  <li>Not helpful in a CLI or demo script</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Friendly + Developer Views</h1>
+            <pre data-lang="python"><code>class Task:
+    def __init__(self, t_id: int, title: str) -&gt; None:
+        self.id = t_id
+        self.title = title
+
+    def __repr__(self) -&gt; str:
+        return f&quot;Task(t_id={self.id}, title=&#x27;{self.title}&#x27;)&quot;
+
+    def __str__(self) -&gt; str:
+        return f&quot;[{self.id}] {self.title}&quot;</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Equality Matters, Too</h1>
+            <pre data-lang="python"><code>def __eq__(self, other: object) -&gt; bool:
+    if not isinstance(other, Task):
+        return False
+    return self.id == other.id and self.title == other.title</code></pre>
+<ul>
+  <li>Default equality checks identity</li>
+  <li>Custom equality can check useful data equivalence</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Light Type Hinting Rules</h1>
+            <ul>
+  <li>Keep it simple:</li>
+  <li style="margin-left: 30px;"><code>int</code></li>
+  <li style="margin-left: 30px;"><code>str</code></li>
+  <li style="margin-left: 30px;"><code>list</code></li>
+  <li style="margin-left: 30px;"><code>dict</code></li>
+  <li style="margin-left: 30px;"><code>-&gt; None</code></li>
+  <li>Use hints to document intent</li>
+  <li>Do not turn this hour into typing wizardry</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Make the Model Pleasant to Work With</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add <code>__repr__</code></li>
+  <li>Add <code>__str__</code></li>
+  <li>Add <code>__eq__</code> where value comparison helps</li>
+  <li>Add type hints to <code>__init__</code> and 3+ methods/functions</li>
+  <li>Optional: add <code>to_dict()</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 7)</h1>
+            <p><span class="check">✓</span> Model prints helpfully for users and developers</p>
+<p><span class="check">✓</span> Equality behavior is intentional</p>
+<p><span class="check">✓</span> Type hints improve readability without overcomplication</p>
+<p><span class="check">✓</span> <code>__str__</code> and <code>__repr__</code> return strings, not <code>print()</code></p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 7)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> string output and equality that support debugging and testing</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> implement <code>repr</code>, <code>str</code>, and equality clearly</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> unreadable model output</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 7 | repr: Task(title=&#x27;Write tests&#x27;, priority=&#x27;medium&#x27;)</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day2_homework.ipynb</code> → <code>## Part 3: Hour 7 - Pythonic class ergonomics</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day2_Quiz.html</code> → <code>QUIZ_DATA</code> questions 11–15</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 7)</h1>
+            <p><strong>⚠️</strong> <code>__str__</code> uses <code>print()</code> instead of returning a string</p>
+<p><strong>⚠️</strong> Overcomplicating hints with unnecessary imports</p>
+<p><strong>⚠️</strong> Equality based on the wrong fields</p>
+<p><strong>⚠️</strong> Forgetting that <code>repr()</code> serves developers first</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> When would you inspect <code>repr(obj)</code> instead of <code>str(obj)</code>?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 8: Checkpoint 1 — Domain + Service Layer Milestone</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Deliver a stable, headless core package</li>
+  <li>Demonstrate happy-path and sad-path flows</li>
+  <li>Show service-layer CRUD behavior</li>
+  <li>Prepare the codebase for packaging and persistence next</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>What Checkpoint 1 Proves</h1>
+            <ul>
+  <li>Models are real, not placeholder shells</li>
+  <li>Services coordinate use cases cleanly</li>
+  <li>Exceptions communicate invalid operations</li>
+  <li>Objects can serialize to dictionaries</li>
+  <li>The core works without a GUI, DB, or API layer</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Rubric Snapshot</h1>
+            <h3>Expect to Show</h3>
+<ul>
+  <li>at least 2 model/helper classes</li>
+  <li>add, list, search, update, delete behaviors</li>
+  <li>custom exceptions</li>
+  <li><code>to_dict()</code> or similar serialization helper</li>
+  <li>a small demo script that proves the design</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Shape for Grading</h1>
+            <pre data-lang="python"><code>print(&quot;--- Starting Checkpoint 1 Demo ---&quot;)
+print(&quot;1. Happy Path: Adding valid records...&quot;)
+print(&quot;2. Sad Path: Missing required fields...&quot;)
+print(&quot;3. Sad Path: Updating a missing record...&quot;)
+print(&quot;4. Serialization Check...&quot;)</code></pre>
+<ul>
+  <li>Make grading easy</li>
+  <li>Prove both success and failure paths deliberately</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Checkpoint 1 Build</h1>
+            <p><strong>Time: 45–60 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Review model and service separation</li>
+  <li>Fill missing CRUD operations</li>
+  <li>Confirm exceptions are raised intentionally</li>
+  <li>Add or refine <code>to_dict()</code></li>
+  <li>Build a demo script that shows:</li>
+  <li style="margin-left: 30px;">valid creation</li>
+  <li style="margin-left: 30px;">invalid data handling</li>
+  <li style="margin-left: 30px;">missing record handling</li>
+  <li style="margin-left: 30px;">serialization output</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 8)</h1>
+            <p><span class="check">✓</span> Headless core runs end to end</p>
+<p><span class="check">✓</span> Service layer does real work</p>
+<p><span class="check">✓</span> Sad paths fail cleanly</p>
+<p><span class="check">✓</span> Demo script proves the rubric without digging through the whole codebase</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 8)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> milestone that adds, validates, and lists tracker records</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> keep domain logic in the service layer</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> letting UI or raw dicts bypass the service layer</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 8 | checkpoint records: 2</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day2_homework.ipynb</code> → <code>## Part 4: Hour 8 - Checkpoint 1</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day2_Quiz.html</code> → <code>QUIZ_DATA</code> questions 16–20</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 8)</h1>
+            <p><strong>⚠️</strong> UI prompts inside service methods</p>
+<p><strong>⚠️</strong> Global state everywhere</p>
+<p><strong>⚠️</strong> Missing-record crashes turning into <code>IndexError</code> noise</p>
+<p><strong>⚠️</strong> Demo scripts that show only the happy path</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Why is a clean core milestone more valuable right now than adding a flashy interface?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 2 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Extended Today</h1>
+            <ul>
+  <li>Safer creation with factories</li>
+  <li>Cleaner behavior swaps with strategies</li>
+  <li>Better debugging ergonomics</li>
+  <li>A checkpointed service-layer core</li>
+</ul>
+<h3>Key Rule</h3>
+<p><strong>Make the core trustworthy before adding more surfaces.</strong></p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 2 Homework / Study Checklist</h1>
+            <ul>
+  <li>Re-run your factory with good and bad payloads</li>
+  <li>Add one more strategy</li>
+  <li>Confirm <code>repr</code>, <code>str</code>, and equality behavior</li>
+  <li>Verify the checkpoint demo proves both happy and sad paths</li>
+  <li>Match required labels exactly where autograding expects them</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day2_homework.ipynb</code> → <code>## Submission Checklist</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Next Session Preview</h1>
+            <h3>Session 3 (Hours 9–12)</h3>
+<ul>
+  <li>Package structure under <code>src/</code></li>
+  <li>Logging and developer diagnostics</li>
+  <li>Context managers and safe save patterns</li>
+  <li>Decorators for timing, auth, and validation</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Save the notebook.</p>
+<p>Commit the checkpoint.</p>
+<p>Come back ready to package the core properly.</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/Advanced/lessons/slides/day-02/day-02-session-2.md
+++ b/Advanced/lessons/slides/day-02/day-02-session-2.md
@@ -179,6 +179,12 @@ class UserFactory:
 def sort_by_name(record):
     return record["name"]
 
+def sort_by_id(record):
+    return record["id"]
+
+def sort_by_date(record):
+    return record["created"]
+
 
 sorting_strategies = {
     "name": sort_by_name,

--- a/Advanced/lessons/slides/day-02/day-02-session-2.md
+++ b/Advanced/lessons/slides/day-02/day-02-session-2.md
@@ -1,0 +1,522 @@
+# Advanced Day 2 — Session 2 (Hours 5–8)
+Python Programming (Advanced) • Factory, Strategy, Ergonomics, and Checkpoint 1
+
+---
+
+# Session 2 Overview
+
+## Topics Covered Today
+- Hour 5: Pattern: Factory (practical creation + validation)
+- Hour 6: Pattern: Strategy (swap behaviors cleanly)
+- Hour 7: Pythonic class ergonomics (`repr` / `str` / equality) + light type hints
+- Hour 8: Checkpoint 1: domain + service layer milestone
+
+### Source Alignment
+- `Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md` → `## Session 2 overview`
+- `Advanced/lessons/lecture/Day2_Hour1_Advanced.md` → `# Day 2, Hour 1: Pattern: Factory (practical creation + validation)`
+- `Advanced/lessons/lecture/Day2_Hour2_Advanced.md` → `# Day 2, Hour 2: Pattern: Strategy (swap behaviors cleanly)`
+- `Advanced/lessons/lecture/Day2_Hour3_Advanced.md` → `# Day 2, Hour 3: Pythonic Class Ergonomics`
+- `Advanced/lessons/lecture/Day2_Hour4_Advanced.md` → `# Day 2, Hour 4: Checkpoint 1: Domain + Service Layer Milestone`
+
+---
+
+# Session 2 Outcomes
+
+- Centralize creation rules with factories
+- Swap behavior without rewriting callers
+- Make models easier to inspect, print, and compare
+- Deliver a clean headless core for Checkpoint 1
+
+---
+
+# Scope Guardrails for Today
+
+## In Scope
+- Validated object creation
+- Strategy dispatch with functions or collaborators
+- Readable object output and simple type hints
+- Core-only checkpoint work
+
+## Not Yet
+- Database persistence
+- GUI callbacks
+- HTTP routes
+- Heavy typing abstractions or framework ceremony
+
+---
+
+# Hour 5: Factory Pattern
+
+## Learning Outcomes
+- Move creation + normalization logic out of `__init__`
+- Turn raw payloads into safe domain objects
+- Raise validation errors before bad objects spread
+- Explain why centralized creation improves consistency
+
+---
+
+## Why Factories Matter
+
+- External data is messy
+- Repeating validation in every caller causes drift
+- `__init__` should initialize, not become a giant intake pipeline
+- A factory can:
+  - validate
+  - normalize
+  - apply defaults
+  - return a ready-to-use object
+
+---
+
+## Demo: Factory from Raw Data
+
+```python
+class UserFactory:
+    @classmethod
+    def from_dict(cls, data):
+        if "name" not in data:
+            raise ValidationError("Missing required field: 'name'")
+
+        name = data["name"].strip().title()
+        role = data.get("role", "member").lower()
+        return User(full_name=name, role=role)
+```
+
+---
+
+## Factory Responsibilities
+
+- Validate required fields
+- Normalize messy input
+- Supply safe defaults
+- Reject unsupported values early
+
+### Better Than
+- every route validating differently
+- every CLI prompt building objects ad hoc
+- huge constructors full of branching
+
+---
+
+## Lab: Build a Validated Factory
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Create a `from_dict()` or `create_*()` factory
+- Validate at least one required field
+- Normalize one messy field
+- Return a safe tracker record or raise `ValidationError`
+
+---
+
+## Completion Criteria (Hour 5)
+
+✓ Factory builds valid objects from raw payloads  
+✓ Missing or bad data fails clearly  
+✓ Creation logic is not duplicated in multiple callers  
+✓ The returned object is ready for service-layer use
+
+---
+
+## Homework + Quiz Emphasis (Hour 5)
+
+- Homework framing:
+  - **Goal:** validated factory for safe tracker records
+  - **Best practice:** use a classmethod factory
+  - **Pitfall:** duplicating validation logic in every caller
+- Quiz/canonical contract marker:
+  - `Hour 5 | factory title: Refactor auth flow`
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day2_homework.ipynb` → `## Part 1: Hour 5 - Pattern: Factory`
+- `Advanced/quizzes/Advanced_Day2_Quiz.html` → `QUIZ_DATA` questions 1–5
+
+---
+
+## Common Pitfalls (Hour 5)
+
+⚠️ Letting invalid objects exist "just for now"  
+⚠️ Hiding normalization logic in random callers  
+⚠️ Making `__init__` do everything  
+⚠️ Using vague exceptions with vague messages
+
+---
+
+## Quick Check
+
+**Question:** Why is a factory safer than repeating payload validation in five different places?
+
+---
+
+# Hour 6: Strategy Pattern
+
+## Learning Outcomes
+- Replace branch-heavy behavior selection
+- Use functions or collaborators as strategies
+- Dispatch dynamically from a small mapping
+- Keep core orchestration stable while behavior changes
+
+---
+
+## Strategy in Plain English
+
+- We have one job with multiple ways to do it
+- We separate **what happens** from **how it happens**
+- In Python, a strategy can just be a callable
+
+### Typical Use Cases
+- sorting
+- filtering
+- exporting
+- notifications
+
+---
+
+## Demo: Dispatch Map
+
+```python
+def sort_by_name(record):
+    return record["name"]
+
+
+sorting_strategies = {
+    "name": sort_by_name,
+    "id": sort_by_id,
+    "created": sort_by_date,
+}
+```
+
+---
+
+## Demo: Core Function Stays Simple
+
+```python
+def display_records_strategy(records, strategy_key):
+    strategy_func = sorting_strategies.get(strategy_key, sort_by_id)
+    sorted_records = sorted(records, key=strategy_func)
+    for record in sorted_records:
+        print(record)
+```
+
+- Caller does not need a giant `if/elif`
+- New strategies are easier to add
+
+---
+
+## Lab: Strategy Selection
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Choose a behavior that varies:
+  - filter active vs all
+  - sort by name vs date
+  - notify via email vs console
+- Implement 2+ strategies
+- Use a dictionary dispatcher or injected collaborator
+- Run the same caller with multiple behaviors
+
+---
+
+## Completion Criteria (Hour 6)
+
+✓ Two or more strategies exist  
+✓ Behavior is selected dynamically  
+✓ Caller logic stays small  
+✓ A new strategy can be added without rewriting the main flow
+
+---
+
+## Homework + Quiz Emphasis (Hour 6)
+
+- Homework framing:
+  - **Goal:** switch behavior without rewriting the caller
+  - **Best practice:** inject behavior objects or callables
+  - **Pitfall:** burying every algorithm in one `if/elif` chain
+- Quiz/canonical contract marker:
+  - `Hour 6 | strategy selected: EmailNotifier`
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day2_homework.ipynb` → `## Part 2: Hour 6 - Pattern: Strategy`
+- `Advanced/quizzes/Advanced_Day2_Quiz.html` → `QUIZ_DATA` questions 6–10
+
+---
+
+## Common Pitfalls (Hour 6)
+
+⚠️ Calling a function instead of passing the function object  
+⚠️ Keeping the big branch chain in the main routine  
+⚠️ Naming strategies unclearly  
+⚠️ Mixing strategy selection with unrelated UI complexity
+
+---
+
+## Quick Check
+
+**Question:** What changes when you add a third strategy to a good strategy-based design?
+
+---
+
+# Hour 7: Pythonic Class Ergonomics
+
+## Learning Outcomes
+- Differentiate `__str__` from `__repr__`
+- Implement value-based equality with `__eq__`
+- Add light type hints that improve readability and tooling
+- Prepare models for easier debugging and serialization
+
+---
+
+## Why Default Objects Are Not Enough
+
+```python
+print(task)
+# <__main__.Task object at 0x...>
+```
+
+- Not useful for logs
+- Not useful for debugging
+- Not helpful in a CLI or demo script
+
+---
+
+## Demo: Friendly + Developer Views
+
+```python
+class Task:
+    def __init__(self, t_id: int, title: str) -> None:
+        self.id = t_id
+        self.title = title
+
+    def __repr__(self) -> str:
+        return f"Task(t_id={self.id}, title='{self.title}')"
+
+    def __str__(self) -> str:
+        return f"[{self.id}] {self.title}"
+```
+
+---
+
+## Demo: Equality Matters, Too
+
+```python
+def __eq__(self, other: object) -> bool:
+    if not isinstance(other, Task):
+        return False
+    return self.id == other.id and self.title == other.title
+```
+
+- Default equality checks identity
+- Custom equality can check useful data equivalence
+
+---
+
+## Light Type Hinting Rules
+
+- Keep it simple:
+  - `int`
+  - `str`
+  - `list`
+  - `dict`
+  - `-> None`
+- Use hints to document intent
+- Do not turn this hour into typing wizardry
+
+---
+
+## Lab: Make the Model Pleasant to Work With
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Add `__repr__`
+- Add `__str__`
+- Add `__eq__` where value comparison helps
+- Add type hints to `__init__` and 3+ methods/functions
+- Optional: add `to_dict()`
+
+---
+
+## Completion Criteria (Hour 7)
+
+✓ Model prints helpfully for users and developers  
+✓ Equality behavior is intentional  
+✓ Type hints improve readability without overcomplication  
+✓ `__str__` and `__repr__` return strings, not `print()`
+
+---
+
+## Homework + Quiz Emphasis (Hour 7)
+
+- Homework framing:
+  - **Goal:** string output and equality that support debugging and testing
+  - **Best practice:** implement `repr`, `str`, and equality clearly
+  - **Pitfall:** unreadable model output
+- Quiz/canonical contract marker:
+  - `Hour 7 | repr: Task(title='Write tests', priority='medium')`
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day2_homework.ipynb` → `## Part 3: Hour 7 - Pythonic class ergonomics`
+- `Advanced/quizzes/Advanced_Day2_Quiz.html` → `QUIZ_DATA` questions 11–15
+
+---
+
+## Common Pitfalls (Hour 7)
+
+⚠️ `__str__` uses `print()` instead of returning a string  
+⚠️ Overcomplicating hints with unnecessary imports  
+⚠️ Equality based on the wrong fields  
+⚠️ Forgetting that `repr()` serves developers first
+
+---
+
+## Quick Check
+
+**Question:** When would you inspect `repr(obj)` instead of `str(obj)`?
+
+---
+
+# Hour 8: Checkpoint 1 — Domain + Service Layer Milestone
+
+## Learning Outcomes
+- Deliver a stable, headless core package
+- Demonstrate happy-path and sad-path flows
+- Show service-layer CRUD behavior
+- Prepare the codebase for packaging and persistence next
+
+---
+
+## What Checkpoint 1 Proves
+
+- Models are real, not placeholder shells
+- Services coordinate use cases cleanly
+- Exceptions communicate invalid operations
+- Objects can serialize to dictionaries
+- The core works without a GUI, DB, or API layer
+
+---
+
+## Rubric Snapshot
+
+### Expect to Show
+- at least 2 model/helper classes
+- add, list, search, update, delete behaviors
+- custom exceptions
+- `to_dict()` or similar serialization helper
+- a small demo script that proves the design
+
+---
+
+## Demo Shape for Grading
+
+```python
+print("--- Starting Checkpoint 1 Demo ---")
+print("1. Happy Path: Adding valid records...")
+print("2. Sad Path: Missing required fields...")
+print("3. Sad Path: Updating a missing record...")
+print("4. Serialization Check...")
+```
+
+- Make grading easy
+- Prove both success and failure paths deliberately
+
+---
+
+## Lab: Checkpoint 1 Build
+
+**Time: 45–60 minutes**
+
+### Tasks
+- Review model and service separation
+- Fill missing CRUD operations
+- Confirm exceptions are raised intentionally
+- Add or refine `to_dict()`
+- Build a demo script that shows:
+  - valid creation
+  - invalid data handling
+  - missing record handling
+  - serialization output
+
+---
+
+## Completion Criteria (Hour 8)
+
+✓ Headless core runs end to end  
+✓ Service layer does real work  
+✓ Sad paths fail cleanly  
+✓ Demo script proves the rubric without digging through the whole codebase
+
+---
+
+## Homework + Quiz Emphasis (Hour 8)
+
+- Homework framing:
+  - **Goal:** milestone that adds, validates, and lists tracker records
+  - **Best practice:** keep domain logic in the service layer
+  - **Pitfall:** letting UI or raw dicts bypass the service layer
+- Quiz/canonical contract marker:
+  - `Hour 8 | checkpoint records: 2`
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day2_homework.ipynb` → `## Part 4: Hour 8 - Checkpoint 1`
+- `Advanced/quizzes/Advanced_Day2_Quiz.html` → `QUIZ_DATA` questions 16–20
+
+---
+
+## Common Pitfalls (Hour 8)
+
+⚠️ UI prompts inside service methods  
+⚠️ Global state everywhere  
+⚠️ Missing-record crashes turning into `IndexError` noise  
+⚠️ Demo scripts that show only the happy path
+
+---
+
+## Quick Check
+
+**Question:** Why is a clean core milestone more valuable right now than adding a flashy interface?
+
+---
+
+# Session 2 Wrap-Up
+
+## What We Extended Today
+- Safer creation with factories
+- Cleaner behavior swaps with strategies
+- Better debugging ergonomics
+- A checkpointed service-layer core
+
+### Key Rule
+**Make the core trustworthy before adding more surfaces.**
+
+---
+
+## Day 2 Homework / Study Checklist
+
+- Re-run your factory with good and bad payloads
+- Add one more strategy
+- Confirm `repr`, `str`, and equality behavior
+- Verify the checkpoint demo proves both happy and sad paths
+- Match required labels exactly where autograding expects them
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day2_homework.ipynb` → `## Submission Checklist`
+
+---
+
+## Next Session Preview
+
+### Session 3 (Hours 9–12)
+- Package structure under `src/`
+- Logging and developer diagnostics
+- Context managers and safe save patterns
+- Decorators for timing, auth, and validation
+
+---
+
+# Thank You!
+
+Save the notebook.  
+Commit the checkpoint.  
+Come back ready to package the core properly.

--- a/Advanced/lessons/slides/day-03/day-03-session-3.html
+++ b/Advanced/lessons/slides/day-03/day-03-session-3.html
@@ -1,0 +1,1129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 3 — Session 3 (Hours 9–12)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 3 — Session 3 (Hours 9–12)</h1>
+            <div class="subtitle">Python Programming (Advanced) • Packages, Logging, Safe Saves, and Decorators</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 3 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 9: Project structure, packages, imports, and config</li>
+  <li>Hour 10: Logging and error reporting (practical)</li>
+  <li>Hour 11: Context managers + safer file operations</li>
+  <li>Hour 12: Decorators (timing / authorization / validation)</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → <code>## Session 3 overview</code></li>
+  <li><code>Advanced/lessons/lecture/Day3_Hour1_Advanced.md</code> → <code># Advanced Day 3, Hour 1: Project Structure, Packages, Imports, and Config</code></li>
+  <li><code>Advanced/lessons/lecture/Day3_Hour2_Advanced.md</code> → <code># Day 3, Hour 2: Logging and Error Reporting (Practical)</code></li>
+  <li><code>Advanced/lessons/lecture/Day3_Hour3_Advanced.md</code> → <code># Day 3, Hour 3: Context Managers + Safer File Operations</code></li>
+  <li><code>Advanced/lessons/lecture/Day3_Hour4_Advanced.md</code> → <code># Day 3, Hour 4: Decorators (Timing / Authorization / Validation)</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session 3 Outcomes</h1>
+            <ul>
+  <li>Package the core under <code>src/</code></li>
+  <li>Add logging that helps developers without spamming users</li>
+  <li>Save JSON more safely with temp-then-replace thinking</li>
+  <li>Use decorators for repeated edge behavior</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>In Scope</h1>
+            <ul>
+  <li>Packaging and import hygiene</li>
+  <li>File-based logging</li>
+  <li>Context managers and safe saves</li>
+  <li>Small, readable decorators</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Not Yet</h1>
+            <ul>
+  <li>Full production config systems</li>
+  <li>Secret-heavy deployment workflows</li>
+  <li>Decorator metaprogramming tricks</li>
+  <li>Database transactions</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 9: Project Structure + Imports + Config</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Move from a loose script pile to a usable package layout</li>
+  <li>Explain the role of <code>__init__.py</code></li>
+  <li>Avoid common import headaches</li>
+  <li>Centralize simple configuration</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Structure Matters Now</h1>
+            <ul>
+  <li>Yesterday&#x27;s checkpoint core needs a cleaner home</li>
+  <li>New layers are coming:</li>
+  <li style="margin-left: 30px;">logging</li>
+  <li style="margin-left: 30px;">persistence</li>
+  <li style="margin-left: 30px;">APIs</li>
+  <li style="margin-left: 30px;">tests</li>
+  <li>Brittle imports slow every later step</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Practical `src/` Layout</h1>
+            <pre data-lang="text"><code>project_root/
+    src/
+        tracker/
+            __init__.py
+            models.py
+            services.py
+            exceptions.py
+            config.py
+    demo.py
+    README.md</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Import Rules to Remember</h1>
+            <ul>
+  <li>Relative imports can help <strong>inside</strong> a package</li>
+  <li>Absolute imports are clearer <strong>from outside</strong> the package</li>
+  <li>Run from the project root or use <code>python -m ...</code></li>
+</ul>
+<h3>Three Headaches to Avoid</h3>
+<ol>
+  <li>Wrong entry file</li>
+  <li>Circular imports</li>
+  <li>Naming collisions like <code>json.py</code> or <code>logging.py</code></li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Clean Package Move</h1>
+            <pre data-lang="python"><code>from tracker.exceptions import ValidationError
+
+
+class Task:
+    def __init__(self, task_id: int, title: str, priority: str = &quot;medium&quot;) -&gt; None:
+        ...</code></pre>
+<ul>
+  <li>Move related files together</li>
+  <li>Fix imports intentionally</li>
+  <li>Re-run the demo after restructuring</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Light Configuration</h1>
+            <ul>
+  <li>Move hard-coded paths into <code>config.py</code></li>
+  <li>Good early config values:</li>
+  <li style="margin-left: 30px;">data directory</li>
+  <li style="margin-left: 30px;">log path</li>
+  <li style="margin-left: 30px;">default save filename</li>
+  <li>Keep it small and practical</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Restructure the Core</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create <code>src/tracker/</code></li>
+  <li>Add <code>__init__.py</code></li>
+  <li>Move models and services into the package</li>
+  <li>Update imports</li>
+  <li>Add a simple <code>config.py</code></li>
+  <li>Prove the demo still runs</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 9)</h1>
+            <p><span class="check">✓</span> Package layout exists</p>
+<p><span class="check">✓</span> Imports are consistent</p>
+<p><span class="check">✓</span> Demo runs from the intended entry point</p>
+<p><span class="check">✓</span> Config values are not scattered across random files</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 9)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> package layout + config module</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> packages + dedicated settings module</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> relative imports everywhere without discipline</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 9 | package root: tracker_app</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day3_homework.ipynb</code> → <code>## Part 1: Hour 9 - Project structure: packages, imports, and config</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day3_Quiz.html</code> → <code>QUIZ_DATA</code> questions 1–5</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 9)</h1>
+            <p><strong>⚠️</strong> Running modules directly from inside the package</p>
+<p><strong>⚠️</strong> Circular imports between services and models</p>
+<p><strong>⚠️</strong> Shadowing standard library module names</p>
+<p><strong>⚠️</strong> Hard-coded paths in multiple files</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> What usually causes <code>ModuleNotFoundError</code> right after a student &quot;cleans up&quot; project structure?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 10: Logging and Error Reporting</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Use <code>logging</code> instead of scattered <code>print()</code> debugging</li>
+  <li>Choose practical levels: DEBUG, INFO, WARNING, ERROR</li>
+  <li>Keep user messages separate from developer diagnostics</li>
+  <li>Write logs to <code>logs/app.log</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Big Idea</h1>
+            <p><strong>Logs are for developers. Error messages are for users.</strong></p>
+<ul>
+  <li>Users need calm, clear feedback</li>
+  <li>Developers need timestamps, context, and failure detail</li>
+  <li>More output is not the same as better diagnostics</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Practical Log Levels</h1>
+            <ul>
+  <li><code>DEBUG</code> → detailed development tracing</li>
+  <li><code>INFO</code> → normal important events</li>
+  <li><code>WARNING</code> → something odd happened, but recovery is possible</li>
+  <li><code>ERROR</code> → an operation failed</li>
+</ul>
+<h3>Example Signals</h3>
+<ul>
+  <li>&quot;created task 7&quot; → INFO</li>
+  <li>&quot;task 999 missing&quot; → WARNING</li>
+  <li>&quot;failed to save file&quot; → ERROR</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Configure Logging</h1>
+            <pre data-lang="python"><code>import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    filename=&quot;logs/app.log&quot;,
+)</code></pre>
+<pre data-lang="python"><code>logger = logging.getLogger(__name__)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Friendly User Message, Richer Log</h1>
+            <pre data-lang="python"><code>try:
+    service.get_task(999)
+except NotFoundError:
+    logger.warning(&quot;Attempted lookup for missing task_id=%s&quot;, 999)
+    print(&quot;Task 999 was not found.&quot;)</code></pre>
+<ul>
+  <li>Same event</li>
+  <li>Different audiences</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Add Logging</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create <code>logs/</code></li>
+  <li>Configure file logging</li>
+  <li>Add at least three log calls</li>
+  <li>Trigger one failure on purpose</li>
+  <li>Inspect <code>logs/app.log</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 10)</h1>
+            <p><span class="check">✓</span> <code>app.log</code> is created</p>
+<p><span class="check">✓</span> Logs show useful events, not noise</p>
+<p><span class="check">✓</span> User-facing messages stay readable</p>
+<p><span class="check">✓</span> Failures leave a developer trail</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 10)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> structured log messages for service events and failures</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> use logging levels instead of <code>print()</code> debugging</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> dumping raw secrets or stack noise into ordinary logs</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 10 | logger name: tracker.service</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day3_homework.ipynb</code> → <code>## Part 2: Hour 10 - Logging and error reporting</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day3_Quiz.html</code> → <code>QUIZ_DATA</code> questions 6–10</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 10)</h1>
+            <p><strong>⚠️</strong> Using logs as a substitute for clear code</p>
+<p><strong>⚠️</strong> Logging too little or too much</p>
+<p><strong>⚠️</strong> Showing full tracebacks to end users</p>
+<p><strong>⚠️</strong> Forgetting to create the log directory</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> When should you log at <code>WARNING</code> instead of <code>ERROR</code>?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 11: Context Managers + Safer File Operations</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain what a context manager really guarantees</li>
+  <li>Use <code>with</code> for safer resource handling</li>
+  <li>Understand why naive overwrites can corrupt data</li>
+  <li>Apply a write-temp-then-replace save pattern</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>The Mental Model for `with`</h1>
+            <ul>
+  <li>setup on entry</li>
+  <li>cleanup on exit</li>
+  <li>cleanup still happens if an exception occurs</li>
+</ul>
+<h3>Common Uses</h3>
+<ul>
+  <li>files</li>
+  <li>locks</li>
+  <li>database connections</li>
+  <li>temporary resources</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Direct Overwrites Are Risky</h1>
+            <pre data-lang="python"><code>with open(&quot;tasks.json&quot;, &quot;w&quot;) as file:
+    file.write(json_text)</code></pre>
+<ul>
+  <li>Better than manual close</li>
+  <li>Still risky if the write fails midway</li>
+  <li>Can leave a good file half-written or corrupted</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Safe Save Pattern</h1>
+            <ol>
+  <li>Resolve the real target path</li>
+  <li>Make sure the parent directory exists</li>
+  <li>Write new content to a temp file</li>
+  <li>Close it successfully</li>
+  <li>Replace the original file</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: `save_json_safe`</h1>
+            <pre data-lang="python"><code>from pathlib import Path
+import json
+
+
+def save_json_safe(path: str | Path, data: list[dict]) -&gt; None:
+    target_path = Path(path)
+    temp_path = target_path.with_suffix(target_path.suffix + &quot;.tmp&quot;)
+    with temp_path.open(&quot;w&quot;, encoding=&quot;utf-8&quot;) as file:
+        json.dump(data, file, indent=2)
+        file.write(&quot;\n&quot;)
+    temp_path.replace(target_path)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Safe Save Utility</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Implement <code>save_json_safe(path, data)</code></li>
+  <li>Use <code>with</code></li>
+  <li>Write a <code>.tmp</code> file next to the real file</li>
+  <li>Replace only after success</li>
+  <li>Simulate a failure and compare outcomes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 11)</h1>
+            <p><span class="check">✓</span> File work uses context managers</p>
+<p><span class="check">✓</span> Save logic writes to temp first</p>
+<p><span class="check">✓</span> Replace happens after success</p>
+<p><span class="check">✓</span> Student can explain why the pattern is safer</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 11)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> safe file operation flow that writes and reads tracker data</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> wrap file work in context managers</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> opening files without <code>with</code></li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 11 | file mode: context manager used</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day3_homework.ipynb</code> → <code>## Part 3: Hour 11 - Context managers + safer file operations</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day3_Quiz.html</code> → <code>QUIZ_DATA</code> questions 11–15</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 11)</h1>
+            <p><strong>⚠️</strong> Writing directly to the final file first</p>
+<p><strong>⚠️</strong> Putting temp files in unrelated locations</p>
+<p><strong>⚠️</strong> Forgetting to create the parent directory</p>
+<p><strong>⚠️</strong> Teaching &quot;it probably works&quot; instead of failure simulation</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> What is the main advantage of writing to a temporary file first?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 12: Decorators</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain decorators in plain language</li>
+  <li>Build a wrapper with <code><em>args</code> and <code></em>*kwargs</code></li>
+  <li>Add timing or authorization behavior without rewriting core functions</li>
+  <li>Use <code>functools.wraps</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Decorator Idea</h1>
+            <ul>
+  <li>A decorator takes a function</li>
+  <li>Wraps it</li>
+  <li>Returns a new function</li>
+</ul>
+<h3>Good Course Use Cases</h3>
+<ul>
+  <li>timing</li>
+  <li>logging entry/exit</li>
+  <li>toy auth checks</li>
+  <li>lightweight validation</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Essential Shape</h1>
+            <pre data-lang="python"><code>def my_decorator(func):
+    def wrapper(*args, **kwargs):
+        result = func(*args, **kwargs)
+        return result
+    return wrapper</code></pre>
+<ul>
+  <li>Accept the function</li>
+  <li>Pass through arguments</li>
+  <li>Return the result</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: `@timed`</h1>
+            <pre data-lang="python"><code>import time
+from functools import wraps
+
+
+def timed(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        start = time.perf_counter()
+        result = func(*args, **kwargs)
+        duration = time.perf_counter() - start
+        print(f&quot;{func.__name__} took {duration:.6f} seconds&quot;)
+        return result
+    return wrapper</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Readability Rule</h1>
+            <ul>
+  <li>Decorators should handle repeated edge behavior</li>
+  <li>They should stay small</li>
+  <li>They should not hide the main business story</li>
+</ul>
+<h3>Stop If...</h3>
+<ul>
+  <li>the wrapper is longer than the function it decorates</li>
+  <li>the decorator becomes a black box of business logic</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Decorator Practice</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Build a <code>@timed</code> decorator</li>
+  <li>Attach it to 2 service methods</li>
+  <li>Log the timing result</li>
+  <li>Preserve metadata with <code>@wraps</code></li>
+  <li>Optional: sketch a toy auth or validation decorator</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 12)</h1>
+            <p><span class="check">✓</span> Decorated functions still return the right result</p>
+<p><span class="check">✓</span> Timing or validation behavior is visible</p>
+<p><span class="check">✓</span> <code>@wraps</code> preserves helpful metadata</p>
+<p><span class="check">✓</span> Core function purpose remains clear</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 12)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> decorated service function with reusable wrappers</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> use decorators for cross-cutting concerns</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> stuffing business logic into decorators</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 12 | timing decorator: add_task took 0.002s</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day3_homework.ipynb</code> → <code>## Part 4: Hour 12 - Decorators</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day3_Quiz.html</code> → <code>QUIZ_DATA</code> questions 16–20</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 12)</h1>
+            <p><strong>⚠️</strong> Forgetting to <code>return result</code></p>
+<p><strong>⚠️</strong> Ignoring <code><em>args</code> / <code></em>*kwargs</code> pass-through</p>
+<p><strong>⚠️</strong> Losing function metadata without <code>@wraps</code></p>
+<p><strong>⚠️</strong> Hiding too much logic in the decorator</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> What breaks if the wrapper forgets to return the original function result?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 3 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Added Today</h1>
+            <ul>
+  <li>Package structure under <code>src/</code></li>
+  <li>Real logging habits</li>
+  <li>Safer JSON save patterns</li>
+  <li>Reusable wrappers through decorators</li>
+</ul>
+<h3>Key Rule</h3>
+<p><strong>Operational habits are part of software design, not an afterthought.</strong></p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 3 Homework / Study Checklist</h1>
+            <ul>
+  <li>Run the project from the intended entry point</li>
+  <li>Inspect <code>logs/app.log</code></li>
+  <li>Test a simulated save failure</li>
+  <li>Re-run a decorated service call</li>
+  <li>Match canonical labels where the notebook expects them</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day3_homework.ipynb</code> → <code>## Submission Checklist</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Next Session Preview</h1>
+            <h3>Session 4 (Hours 13–16)</h3>
+<ul>
+  <li>HTTP clients with <code>requests</code></li>
+  <li>Environment-variable and secrets habits</li>
+  <li>Capstone planning workshop</li>
+  <li>Checkpoint 2: persistence-ready core + JSON save/load</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Package it cleanly.</p>
+<p>Log what matters.</p>
+<p>Save data safely.</p>
+<p>Keep the wrappers readable.</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/Advanced/lessons/slides/day-03/day-03-session-3.md
+++ b/Advanced/lessons/slides/day-03/day-03-session-3.md
@@ -1,0 +1,581 @@
+# Advanced Day 3 — Session 3 (Hours 9–12)
+Python Programming (Advanced) • Packages, Logging, Safe Saves, and Decorators
+
+---
+
+# Session 3 Overview
+
+## Topics Covered Today
+- Hour 9: Project structure, packages, imports, and config
+- Hour 10: Logging and error reporting (practical)
+- Hour 11: Context managers + safer file operations
+- Hour 12: Decorators (timing / authorization / validation)
+
+### Source Alignment
+- `Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md` → `## Session 3 overview`
+- `Advanced/lessons/lecture/Day3_Hour1_Advanced.md` → `# Advanced Day 3, Hour 1: Project Structure, Packages, Imports, and Config`
+- `Advanced/lessons/lecture/Day3_Hour2_Advanced.md` → `# Day 3, Hour 2: Logging and Error Reporting (Practical)`
+- `Advanced/lessons/lecture/Day3_Hour3_Advanced.md` → `# Day 3, Hour 3: Context Managers + Safer File Operations`
+- `Advanced/lessons/lecture/Day3_Hour4_Advanced.md` → `# Day 3, Hour 4: Decorators (Timing / Authorization / Validation)`
+
+---
+
+# Session 3 Outcomes
+
+- Package the core under `src/`
+- Add logging that helps developers without spamming users
+- Save JSON more safely with temp-then-replace thinking
+- Use decorators for repeated edge behavior
+
+---
+
+# Scope Guardrails for Today
+
+## In Scope
+- Packaging and import hygiene
+- File-based logging
+- Context managers and safe saves
+- Small, readable decorators
+
+## Not Yet
+- Full production config systems
+- Secret-heavy deployment workflows
+- Decorator metaprogramming tricks
+- Database transactions
+
+---
+
+# Hour 9: Project Structure + Imports + Config
+
+## Learning Outcomes
+- Move from a loose script pile to a usable package layout
+- Explain the role of `__init__.py`
+- Avoid common import headaches
+- Centralize simple configuration
+
+---
+
+## Why Structure Matters Now
+
+- Yesterday's checkpoint core needs a cleaner home
+- New layers are coming:
+  - logging
+  - persistence
+  - APIs
+  - tests
+- Brittle imports slow every later step
+
+---
+
+## Practical `src/` Layout
+
+```text
+project_root/
+    src/
+        tracker/
+            __init__.py
+            models.py
+            services.py
+            exceptions.py
+            config.py
+    demo.py
+    README.md
+```
+
+---
+
+## Import Rules to Remember
+
+- Relative imports can help **inside** a package
+- Absolute imports are clearer **from outside** the package
+- Run from the project root or use `python -m ...`
+
+### Three Headaches to Avoid
+1. Wrong entry file
+2. Circular imports
+3. Naming collisions like `json.py` or `logging.py`
+
+---
+
+## Demo: Clean Package Move
+
+```python
+from tracker.exceptions import ValidationError
+
+
+class Task:
+    def __init__(self, task_id: int, title: str, priority: str = "medium") -> None:
+        ...
+```
+
+- Move related files together
+- Fix imports intentionally
+- Re-run the demo after restructuring
+
+---
+
+## Light Configuration
+
+- Move hard-coded paths into `config.py`
+- Good early config values:
+  - data directory
+  - log path
+  - default save filename
+- Keep it small and practical
+
+---
+
+## Lab: Restructure the Core
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Create `src/tracker/`
+- Add `__init__.py`
+- Move models and services into the package
+- Update imports
+- Add a simple `config.py`
+- Prove the demo still runs
+
+---
+
+## Completion Criteria (Hour 9)
+
+✓ Package layout exists  
+✓ Imports are consistent  
+✓ Demo runs from the intended entry point  
+✓ Config values are not scattered across random files
+
+---
+
+## Homework + Quiz Emphasis (Hour 9)
+
+- Homework framing:
+  - **Goal:** package layout + config module
+  - **Best practice:** packages + dedicated settings module
+  - **Pitfall:** relative imports everywhere without discipline
+- Quiz/canonical contract marker:
+  - `Hour 9 | package root: tracker_app`
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day3_homework.ipynb` → `## Part 1: Hour 9 - Project structure: packages, imports, and config`
+- `Advanced/quizzes/Advanced_Day3_Quiz.html` → `QUIZ_DATA` questions 1–5
+
+---
+
+## Common Pitfalls (Hour 9)
+
+⚠️ Running modules directly from inside the package  
+⚠️ Circular imports between services and models  
+⚠️ Shadowing standard library module names  
+⚠️ Hard-coded paths in multiple files
+
+---
+
+## Quick Check
+
+**Question:** What usually causes `ModuleNotFoundError` right after a student "cleans up" project structure?
+
+---
+
+# Hour 10: Logging and Error Reporting
+
+## Learning Outcomes
+- Use `logging` instead of scattered `print()` debugging
+- Choose practical levels: DEBUG, INFO, WARNING, ERROR
+- Keep user messages separate from developer diagnostics
+- Write logs to `logs/app.log`
+
+---
+
+## Big Idea
+
+**Logs are for developers. Error messages are for users.**
+
+- Users need calm, clear feedback
+- Developers need timestamps, context, and failure detail
+- More output is not the same as better diagnostics
+
+---
+
+## Practical Log Levels
+
+- `DEBUG` → detailed development tracing
+- `INFO` → normal important events
+- `WARNING` → something odd happened, but recovery is possible
+- `ERROR` → an operation failed
+
+### Example Signals
+- "created task 7" → INFO
+- "task 999 missing" → WARNING
+- "failed to save file" → ERROR
+
+---
+
+## Demo: Configure Logging
+
+```python
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    filename="logs/app.log",
+)
+```
+
+```python
+logger = logging.getLogger(__name__)
+```
+
+---
+
+## Demo: Friendly User Message, Richer Log
+
+```python
+try:
+    service.get_task(999)
+except NotFoundError:
+    logger.warning("Attempted lookup for missing task_id=%s", 999)
+    print("Task 999 was not found.")
+```
+
+- Same event
+- Different audiences
+
+---
+
+## Lab: Add Logging
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Create `logs/`
+- Configure file logging
+- Add at least three log calls
+- Trigger one failure on purpose
+- Inspect `logs/app.log`
+
+---
+
+## Completion Criteria (Hour 10)
+
+✓ `app.log` is created  
+✓ Logs show useful events, not noise  
+✓ User-facing messages stay readable  
+✓ Failures leave a developer trail
+
+---
+
+## Homework + Quiz Emphasis (Hour 10)
+
+- Homework framing:
+  - **Goal:** structured log messages for service events and failures
+  - **Best practice:** use logging levels instead of `print()` debugging
+  - **Pitfall:** dumping raw secrets or stack noise into ordinary logs
+- Quiz/canonical contract marker:
+  - `Hour 10 | logger name: tracker.service`
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day3_homework.ipynb` → `## Part 2: Hour 10 - Logging and error reporting`
+- `Advanced/quizzes/Advanced_Day3_Quiz.html` → `QUIZ_DATA` questions 6–10
+
+---
+
+## Common Pitfalls (Hour 10)
+
+⚠️ Using logs as a substitute for clear code  
+⚠️ Logging too little or too much  
+⚠️ Showing full tracebacks to end users  
+⚠️ Forgetting to create the log directory
+
+---
+
+## Quick Check
+
+**Question:** When should you log at `WARNING` instead of `ERROR`?
+
+---
+
+# Hour 11: Context Managers + Safer File Operations
+
+## Learning Outcomes
+- Explain what a context manager really guarantees
+- Use `with` for safer resource handling
+- Understand why naive overwrites can corrupt data
+- Apply a write-temp-then-replace save pattern
+
+---
+
+## The Mental Model for `with`
+
+- setup on entry
+- cleanup on exit
+- cleanup still happens if an exception occurs
+
+### Common Uses
+- files
+- locks
+- database connections
+- temporary resources
+
+---
+
+## Why Direct Overwrites Are Risky
+
+```python
+with open("tasks.json", "w") as file:
+    file.write(json_text)
+```
+
+- Better than manual close
+- Still risky if the write fails midway
+- Can leave a good file half-written or corrupted
+
+---
+
+## Safe Save Pattern
+
+1. Resolve the real target path
+2. Make sure the parent directory exists
+3. Write new content to a temp file
+4. Close it successfully
+5. Replace the original file
+
+---
+
+## Demo: `save_json_safe`
+
+```python
+from pathlib import Path
+import json
+
+
+def save_json_safe(path: str | Path, data: list[dict]) -> None:
+    target_path = Path(path)
+    temp_path = target_path.with_suffix(target_path.suffix + ".tmp")
+    with temp_path.open("w", encoding="utf-8") as file:
+        json.dump(data, file, indent=2)
+        file.write("\n")
+    temp_path.replace(target_path)
+```
+
+---
+
+## Lab: Safe Save Utility
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Implement `save_json_safe(path, data)`
+- Use `with`
+- Write a `.tmp` file next to the real file
+- Replace only after success
+- Simulate a failure and compare outcomes
+
+---
+
+## Completion Criteria (Hour 11)
+
+✓ File work uses context managers  
+✓ Save logic writes to temp first  
+✓ Replace happens after success  
+✓ Student can explain why the pattern is safer
+
+---
+
+## Homework + Quiz Emphasis (Hour 11)
+
+- Homework framing:
+  - **Goal:** safe file operation flow that writes and reads tracker data
+  - **Best practice:** wrap file work in context managers
+  - **Pitfall:** opening files without `with`
+- Quiz/canonical contract marker:
+  - `Hour 11 | file mode: context manager used`
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day3_homework.ipynb` → `## Part 3: Hour 11 - Context managers + safer file operations`
+- `Advanced/quizzes/Advanced_Day3_Quiz.html` → `QUIZ_DATA` questions 11–15
+
+---
+
+## Common Pitfalls (Hour 11)
+
+⚠️ Writing directly to the final file first  
+⚠️ Putting temp files in unrelated locations  
+⚠️ Forgetting to create the parent directory  
+⚠️ Teaching "it probably works" instead of failure simulation
+
+---
+
+## Quick Check
+
+**Question:** What is the main advantage of writing to a temporary file first?
+
+---
+
+# Hour 12: Decorators
+
+## Learning Outcomes
+- Explain decorators in plain language
+- Build a wrapper with `*args` and `**kwargs`
+- Add timing or authorization behavior without rewriting core functions
+- Use `functools.wraps`
+
+---
+
+## Decorator Idea
+
+- A decorator takes a function
+- Wraps it
+- Returns a new function
+
+### Good Course Use Cases
+- timing
+- logging entry/exit
+- toy auth checks
+- lightweight validation
+
+---
+
+## Demo: Essential Shape
+
+```python
+def my_decorator(func):
+    def wrapper(*args, **kwargs):
+        result = func(*args, **kwargs)
+        return result
+    return wrapper
+```
+
+- Accept the function
+- Pass through arguments
+- Return the result
+
+---
+
+## Demo: `@timed`
+
+```python
+import time
+from functools import wraps
+
+
+def timed(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        start = time.perf_counter()
+        result = func(*args, **kwargs)
+        duration = time.perf_counter() - start
+        print(f"{func.__name__} took {duration:.6f} seconds")
+        return result
+    return wrapper
+```
+
+---
+
+## Readability Rule
+
+- Decorators should handle repeated edge behavior
+- They should stay small
+- They should not hide the main business story
+
+### Stop If...
+- the wrapper is longer than the function it decorates
+- the decorator becomes a black box of business logic
+
+---
+
+## Lab: Decorator Practice
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Build a `@timed` decorator
+- Attach it to 2 service methods
+- Log the timing result
+- Preserve metadata with `@wraps`
+- Optional: sketch a toy auth or validation decorator
+
+---
+
+## Completion Criteria (Hour 12)
+
+✓ Decorated functions still return the right result  
+✓ Timing or validation behavior is visible  
+✓ `@wraps` preserves helpful metadata  
+✓ Core function purpose remains clear
+
+---
+
+## Homework + Quiz Emphasis (Hour 12)
+
+- Homework framing:
+  - **Goal:** decorated service function with reusable wrappers
+  - **Best practice:** use decorators for cross-cutting concerns
+  - **Pitfall:** stuffing business logic into decorators
+- Quiz/canonical contract marker:
+  - `Hour 12 | timing decorator: add_task took 0.002s`
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day3_homework.ipynb` → `## Part 4: Hour 12 - Decorators`
+- `Advanced/quizzes/Advanced_Day3_Quiz.html` → `QUIZ_DATA` questions 16–20
+
+---
+
+## Common Pitfalls (Hour 12)
+
+⚠️ Forgetting to `return result`  
+⚠️ Ignoring `*args` / `**kwargs` pass-through  
+⚠️ Losing function metadata without `@wraps`  
+⚠️ Hiding too much logic in the decorator
+
+---
+
+## Quick Check
+
+**Question:** What breaks if the wrapper forgets to return the original function result?
+
+---
+
+# Session 3 Wrap-Up
+
+## What We Added Today
+- Package structure under `src/`
+- Real logging habits
+- Safer JSON save patterns
+- Reusable wrappers through decorators
+
+### Key Rule
+**Operational habits are part of software design, not an afterthought.**
+
+---
+
+## Day 3 Homework / Study Checklist
+
+- Run the project from the intended entry point
+- Inspect `logs/app.log`
+- Test a simulated save failure
+- Re-run a decorated service call
+- Match canonical labels where the notebook expects them
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day3_homework.ipynb` → `## Submission Checklist`
+
+---
+
+## Next Session Preview
+
+### Session 4 (Hours 13–16)
+- HTTP clients with `requests`
+- Environment-variable and secrets habits
+- Capstone planning workshop
+- Checkpoint 2: persistence-ready core + JSON save/load
+
+---
+
+# Thank You!
+
+Package it cleanly.  
+Log what matters.  
+Save data safely.  
+Keep the wrappers readable.

--- a/Advanced/lessons/slides/day-04/day-04-session-4.html
+++ b/Advanced/lessons/slides/day-04/day-04-session-4.html
@@ -1,0 +1,1226 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 4 — Session 4 (Hours 13–16)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 4 — Session 4 (Hours 13–16)</h1>
+            <div class="subtitle">Python Programming (Advanced) • HTTP Clients, Security Habits, Capstone Planning, and Checkpoint 2</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 4 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 13: HTTP client work: <code>requests</code> + JSON contracts</li>
+  <li>Hour 14: Security basics — environment variables, safe secrets habits, and hashing concepts</li>
+  <li>Hour 15: Capstone planning workshop — scope, milestones, and delivery path</li>
+  <li>Hour 16: Checkpoint 2 — persistence-ready core + JSON save/load</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → <code>## Session 4 overview</code></li>
+  <li><code>Advanced/lessons/lecture/Day4_Hour1_Advanced.md</code> → <code># Day 4, Hour 1: HTTP Client Work – requests + JSON Contracts</code></li>
+  <li><code>Advanced/lessons/lecture/Day4_Hour2_Advanced.md</code> → <code># Day 4, Hour 2: Security Basics – Environment Variables, Safe Secrets Habits, and Hashing Concepts</code></li>
+  <li><code>Advanced/lessons/lecture/Day4_Hour3_Advanced.md</code> → <code># Day 4, Hour 3: Capstone Planning Workshop – Scope, Milestones, and Delivery Path</code></li>
+  <li><code>Advanced/lessons/lecture/Day4_Hour4_Advanced.md</code> → <code># Day 4, Hour 4: Checkpoint 2 – Persistence-Ready Core + JSON Save/Load</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session 4 Outcomes</h1>
+            <ul>
+  <li>Treat outside data as untrusted until checked</li>
+  <li>Keep secrets out of source control</li>
+  <li>Choose a realistic capstone path</li>
+  <li>Deliver a persistence-ready core that can survive restart</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>In Scope</h1>
+            <ul>
+  <li>HTTP client fundamentals</li>
+  <li>JSON contract validation</li>
+  <li>Environment-variable habits</li>
+  <li>Concept-level hashing discussion</li>
+  <li>Capstone MVP planning</li>
+  <li>JSON persistence checkpoint</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Not Yet</h1>
+            <ul>
+  <li>Production auth systems</li>
+  <li>Full deployment workflows</li>
+  <li>Enterprise schema tooling</li>
+  <li>Database integration beyond persistence-ready design</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 13: HTTP Client Work + JSON Contracts</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Send a <code>GET</code> request with <code>requests</code></li>
+  <li>Always set a timeout</li>
+  <li>Use <code>raise_for_status()</code></li>
+  <li>Validate the JSON shape before trusting it</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Big Shift for This Hour</h1>
+            <ul>
+  <li>Up to now, most data has lived inside our program</li>
+  <li>Today the program talks to something outside itself</li>
+  <li>Outside data may be:</li>
+  <li style="margin-left: 30px;">slow</li>
+  <li style="margin-left: 30px;">missing</li>
+  <li style="margin-left: 30px;">malformed</li>
+  <li style="margin-left: 30px;">structurally different from what we expected</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>HTTP Client Fundamentals</h1>
+            <ul>
+  <li>Client sends request</li>
+  <li>Server sends response</li>
+</ul>
+<h3>High-Level Pieces</h3>
+<ul>
+  <li>method</li>
+  <li>URL</li>
+  <li>optional params/headers/body</li>
+  <li>status code</li>
+  <li>response body</li>
+</ul>
+<h3>Today</h3>
+<ul>
+  <li>mainly <code>GET</code></li>
+  <li>JSON responses</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Reliability Habits</h1>
+            <ul>
+  <li><strong>Always set a timeout</strong></li>
+  <li>Prefer <code>raise_for_status()</code></li>
+  <li>Catch failure categories cleanly:</li>
+  <li style="margin-left: 30px;">timeout</li>
+  <li style="margin-left: 30px;">connection problem</li>
+  <li style="margin-left: 30px;">HTTP error</li>
+  <li style="margin-left: 30px;">invalid JSON</li>
+  <li style="margin-left: 30px;">contract mismatch</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>JSON Is a Contract</h1>
+            <h3>Check the Minimum Shape You Need</h3>
+<ul>
+  <li>payload type</li>
+  <li>required keys</li>
+  <li>expected value types</li>
+</ul>
+<pre data-lang="python"><code>response = requests.get(url, timeout=5)
+response.raise_for_status()
+data = response.json()</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Small Wrapper Function</h1>
+            <pre data-lang="python"><code>def fetch_task(url: str) -&gt; dict:
+    response = requests.get(url, timeout=5)
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict) or &quot;title&quot; not in data:
+        raise ValueError(&quot;Response contract mismatch&quot;)
+    return data</code></pre>
+<ul>
+  <li>Centralize request behavior</li>
+  <li>Avoid copy/paste request logic everywhere</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: API Consumer</h1>
+            <p><strong>Time: 15–25 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Send a <code>GET</code> request to a sample endpoint</li>
+  <li>Use <code>timeout=...</code></li>
+  <li>Call <code>raise_for_status()</code></li>
+  <li>Parse JSON</li>
+  <li>Validate required keys before use</li>
+  <li>Show a friendly failure message for one error case</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 13)</h1>
+            <p><span class="check">✓</span> Request uses a timeout</p>
+<p><span class="check">✓</span> Happy path parses JSON safely</p>
+<p><span class="check">✓</span> Failure handling is intentional</p>
+<p><span class="check">✓</span> Contract validation happens before downstream use</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 13)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> client call that reads JSON safely and prints labeled checks</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> check status codes and JSON keys</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> assuming every response has the shape you want</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 13 | request url: https://api.example.test/tasks</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day4_homework.ipynb</code> → <code>## Part 1: Hour 13 - HTTP client work</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day4_Quiz.html</code> → <code>QUIZ_DATA</code> questions 1–5</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 13)</h1>
+            <p><strong>⚠️</strong> No timeout</p>
+<p><strong>⚠️</strong> Parsing JSON before checking status</p>
+<p><strong>⚠️</strong> Trusting missing keys blindly</p>
+<p><strong>⚠️</strong> Returning raw error noise to end users</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Why is &quot;the service returned valid JSON&quot; not the same as &quot;the response matches our contract&quot;?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 14: Security Basics</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain why secrets should not live in source files</li>
+  <li>Load sensitive values from environment variables</li>
+  <li>Distinguish hashing from encryption conceptually</li>
+  <li>Keep this hour in appropriate scope</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Security Mindset Reset</h1>
+            <ul>
+  <li>We are teaching <strong>habits</strong>, not full security engineering</li>
+  <li>Good boundaries matter</li>
+</ul>
+<h3>Not This Hour</h3>
+<ul>
+  <li>OAuth</li>
+  <li>JWT flows</li>
+  <li>production identity systems</li>
+</ul>
+<h3>This Hour</h3>
+<ul>
+  <li>secret hygiene</li>
+  <li>env vars</li>
+  <li><code>.env.example</code></li>
+  <li>hashing concept demo</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hard-Coded Secrets Are a Trap</h1>
+            <pre data-lang="python"><code>ADMIN_KEY = &quot;super-secret-real-key&quot;</code></pre>
+<h3>Problems</h3>
+<ol>
+  <li>Secrets end up in version control</li>
+  <li>Rotation becomes painful</li>
+  <li>Unsafe sharing habits spread</li>
+  <li>Commit history keeps the mistake around</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Environment Variable Pattern</h1>
+            <pre data-lang="python"><code>import os
+
+
+def get_required_env(name: str) -&gt; str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f&quot;Missing required environment variable: {name}&quot;)
+    return value</code></pre>
+<ul>
+  <li>Code names what it needs</li>
+  <li>Environment supplies the real value</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>`.env.example` vs `.env`</h1>
+            <pre data-lang="env"><code>APP_API_KEY=your-api-key-here
+APP_ADMIN_KEY=replace-with-local-admin-key
+APP_ENV=development</code></pre>
+<ul>
+  <li><code>.env.example</code> may be committed</li>
+  <li><code>.env</code> should usually be ignored</li>
+  <li>placeholders only — never real secrets</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hashing vs Encryption</h1>
+            <ul>
+  <li><strong>Encryption</strong> is meant to be reversible with the right key</li>
+  <li><strong>Hashing</strong> is meant to be one-way</li>
+</ul>
+<h3>Classroom-Safe Demo Idea</h3>
+<ul>
+  <li>compute a digest</li>
+  <li>compare digests</li>
+  <li>do <strong>not</strong> claim this solves production auth</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Gated Admin Action</h1>
+            <pre data-lang="python"><code>import hashlib
+import secrets
+
+
+def sha256_digest(value: str) -&gt; str:
+    return hashlib.sha256(value.encode(&quot;utf-8&quot;)).hexdigest()
+
+
+authorized = secrets.compare_digest(
+    sha256_digest(expected_key),
+    sha256_digest(provided_key),
+)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Secure-ish Configuration</h1>
+            <p><strong>Time: 18–25 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Read one required value from the environment</li>
+  <li>Add a <code>.env.example</code> template plan</li>
+  <li>Add <code>.gitignore</code> guidance for local secret files</li>
+  <li>Gate one admin action using configuration, not a hard-coded literal</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 14)</h1>
+            <p><span class="check">✓</span> Secret value is not hard-coded in the source</p>
+<p><span class="check">✓</span> Missing env var fails clearly</p>
+<p><span class="check">✓</span> Learner can explain hashing vs encryption at a high level</p>
+<p><span class="check">✓</span> Scope stays disciplined and honest</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 14)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> secure config pattern that separates secrets from code</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> read secrets from env vars, store only hashes when appropriate</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> checking secrets into source control</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 14 | secret source: environment variable</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day4_homework.ipynb</code> → <code>## Part 2: Hour 14 - Security basics</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day4_Quiz.html</code> → <code>QUIZ_DATA</code> questions 6–10</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 14)</h1>
+            <p><strong>⚠️</strong> Real secrets in demo files</p>
+<p><strong>⚠️</strong> Committing <code>.env</code></p>
+<p><strong>⚠️</strong> Treating hashing and encryption as synonyms</p>
+<p><strong>⚠️</strong> Promising production-grade security from a classroom-safe example</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Why is a <code>.env.example</code> helpful even though it contains no real secret values?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 15: Capstone Planning Workshop</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Lock an MVP scope</li>
+  <li>Choose a delivery path</li>
+  <li>Break the project into milestones</li>
+  <li>Define &quot;done&quot; before the build gets bigger</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>What This Workshop Is Really For</h1>
+            <ul>
+  <li>Replace vague enthusiasm with a delivery plan</li>
+  <li>Protect the project from scope drift</li>
+  <li>Decide what proves value earliest</li>
+</ul>
+<h3>Strong Planning Questions</h3>
+<ul>
+  <li>Who is the user?</li>
+  <li>What is the primary workflow?</li>
+  <li>What is the smallest useful version?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Recommended Milestone Path</h1>
+            <ol>
+  <li>Core</li>
+  <li>Persistence</li>
+  <li>UI</li>
+  <li>Analytics</li>
+  <li>Tests</li>
+  <li>Package</li>
+</ol>
+<ul>
+  <li>Do not jump to a flashy shell around unstable logic</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Definition of Done Examples</h1>
+            <h3>Core</h3>
+<ul>
+  <li>service logic works in isolation</li>
+</ul>
+<h3>Persistence</h3>
+<ul>
+  <li>data survives restart</li>
+</ul>
+<h3>UI</h3>
+<ul>
+  <li>primary workflow works through the chosen surface</li>
+</ul>
+<h3>Tests</h3>
+<ul>
+  <li>major business rules and failure paths have repeatable checks</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Delivery Path Decision</h1>
+            <h3>GUI-First</h3>
+<ul>
+  <li>tangible demo quickly</li>
+  <li>risk: logic hides in callbacks</li>
+</ul>
+<h3>API-First</h3>
+<ul>
+  <li>clearer service boundaries</li>
+  <li>risk: less visually exciting at first</li>
+</ul>
+<h3>Non-Negotiable</h3>
+<ul>
+  <li>core logic still lives in reusable services</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Artifact Shape</h1>
+            <pre data-lang="text"><code>capstone_project/
+├── README.md
+├── src/
+├── tests/
+└── data/</code></pre>
+<h3>README Needs</h3>
+<ul>
+  <li>project goal</li>
+  <li>MVP features</li>
+  <li>setup steps</li>
+  <li>run steps</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Workshop: One-Page Capstone Plan</h1>
+            <p><strong>Time: 20 minutes</strong></p>
+<h3>Include</h3>
+<ul>
+  <li>chosen domain</li>
+  <li>primary user workflow</li>
+  <li>GUI-first or API-first decision</li>
+  <li>milestone list</li>
+  <li>persistence plan</li>
+  <li>key risks</li>
+  <li>test targets</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 15)</h1>
+            <p><span class="check">✓</span> Scope is realistic</p>
+<p><span class="check">✓</span> Delivery path is chosen and justified</p>
+<p><span class="check">✓</span> Milestones are sequenced clearly</p>
+<p><span class="check">✓</span> README skeleton or plan notes exist</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 15)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> milestone plan with one domain, one interface, and staged deliverables</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> keep scope narrow enough to finish</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> trying to build every optional feature before core CRUD is stable</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 15 | chosen domain: tracker</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day4_homework.ipynb</code> → <code>## Part 3: Hour 15 - Capstone planning workshop</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day4_Quiz.html</code> → <code>QUIZ_DATA</code> questions 11–15</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 15)</h1>
+            <p><strong>⚠️</strong> Wish-list scope instead of MVP scope</p>
+<p><strong>⚠️</strong> README postponed until the final hour</p>
+<p><strong>⚠️</strong> UI selected before the core is stable</p>
+<p><strong>⚠️</strong> No persistence or test plan in the roadmap</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Which milestone do students most often try to jump to too early, and why is that risky?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 16: Checkpoint 2 — Persistence-Ready Core</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Separate domain, service, and persistence responsibilities</li>
+  <li>Save JSON using a safe-save pattern</li>
+  <li>Load saved state back into application objects</li>
+  <li>Handle missing files, invalid JSON, and validation failures cleanly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>What Checkpoint 2 Proves</h1>
+            <ul>
+  <li>The core survives beyond one run</li>
+  <li>The package layout under <code>src/</code> is intentional</li>
+  <li>State can be saved and restored</li>
+  <li>Logging captures meaningful persistence events</li>
+  <li>Custom exceptions still communicate domain and persistence issues</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Sample Persistence-Ready Layout</h1>
+            <pre data-lang="text"><code>project_root/
+├── demo_persistence.py
+├── logs/app.log
+├── data/state.json
+└── src/reading_tracker/
+    ├── errors.py
+    ├── logging_config.py
+    ├── models.py
+    ├── persistence.py
+    └── services.py</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Separation of Concerns</h1>
+            <ul>
+  <li><strong>models.py</strong> → structured domain data</li>
+  <li><strong>services.py</strong> → business rules</li>
+  <li><strong>persistence.py</strong> → JSON save/load</li>
+  <li><strong>errors.py</strong> → custom exceptions</li>
+  <li><strong>logging_config.py</strong> → file logging setup</li>
+</ul>
+<h3>Why It Matters</h3>
+<ul>
+  <li>JSON today</li>
+  <li>database later</li>
+  <li>less rewiring when storage changes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Safe Save + Load Shape</h1>
+            <pre data-lang="python"><code>class PersistenceError(Exception):
+    pass
+
+
+class JSONStateStore:
+    def save(self, state):
+        ...
+
+    def load(self):
+        ...</code></pre>
+<ul>
+  <li>save started</li>
+  <li>save succeeded</li>
+  <li>load started</li>
+  <li>file missing handled</li>
+  <li>invalid JSON handled</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Workflow</h1>
+            <h3>Save → Restart → Load</h3>
+<ol>
+  <li>Create a few records</li>
+  <li>Save to JSON safely</li>
+  <li>Recreate the service/store</li>
+  <li>Load state back in</li>
+  <li>Confirm records still exist</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Hands-On Checkpoint Build</h1>
+            <p><strong>Time: 15–25 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Organize or confirm package layout</li>
+  <li>Add a persistence layer</li>
+  <li>Implement safe save behavior</li>
+  <li>Load JSON back into objects</li>
+  <li>Log the key events</li>
+  <li>Demonstrate one failure case and one happy path</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 16)</h1>
+            <p><span class="check">✓</span> Core state round-trips through JSON</p>
+<p><span class="check">✓</span> Save path is safer than direct overwrite</p>
+<p><span class="check">✓</span> Load handles missing/bad files intentionally</p>
+<p><span class="check">✓</span> The project is visibly more persistence-ready than it was yesterday</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 16)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> core app that can add records and round-trip them through JSON</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> checkpoint save/load before expanding the interface</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> delaying persistence checks until after major UI work</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 16 | checkpoint model: Task</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day4_homework.ipynb</code> → <code>## Part 4: Hour 16 - Checkpoint 2</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day4_Quiz.html</code> → <code>QUIZ_DATA</code> questions 16–20</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 16)</h1>
+            <p><strong>⚠️</strong> Dumping JSON logic everywhere instead of using a persistence layer</p>
+<p><strong>⚠️</strong> Direct overwrite with no safety net</p>
+<p><strong>⚠️</strong> Treating file absence as a crash-only situation</p>
+<p><strong>⚠️</strong> Adding more features before proving save/load works</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> If the app works beautifully in memory but loses state after restart, what milestone is still incomplete?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 4 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Locked In Today</h1>
+            <ul>
+  <li>Reliable HTTP client habits</li>
+  <li>Safer secret/config practices</li>
+  <li>A concrete capstone roadmap</li>
+  <li>Persistence-ready core architecture</li>
+</ul>
+<h3>Key Rule</h3>
+<p><strong>Trustworthy software plans for failure, scope, and restart behavior.</strong></p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 4 Homework / Study Checklist</h1>
+            <ul>
+  <li>Re-run the HTTP wrapper with a failure case in mind</li>
+  <li>Remove any hard-coded secret from demo code</li>
+  <li>Finalize the one-page capstone plan</li>
+  <li>Test save -&gt; load round-trip behavior</li>
+  <li>Match the canonical output labels expected by the notebook</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day4_homework.ipynb</code> → <code>## Submission Checklist</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Next Step Framing</h1>
+            <h3>After Session 4</h3>
+<ul>
+  <li>keep the core stable</li>
+  <li>preserve scope discipline</li>
+  <li>carry forward logging and safe-save habits</li>
+  <li>use the capstone plan as the default decision filter</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Validate outside data.</p>
+<p>Keep secrets out of source.</p>
+<p>Plan the MVP.</p>
+<p>Prove persistence before expanding.</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/Advanced/lessons/slides/day-04/day-04-session-4.md
+++ b/Advanced/lessons/slides/day-04/day-04-session-4.md
@@ -1,0 +1,663 @@
+# Advanced Day 4 — Session 4 (Hours 13–16)
+Python Programming (Advanced) • HTTP Clients, Security Habits, Capstone Planning, and Checkpoint 2
+
+---
+
+# Session 4 Overview
+
+## Topics Covered Today
+- Hour 13: HTTP client work: `requests` + JSON contracts
+- Hour 14: Security basics — environment variables, safe secrets habits, and hashing concepts
+- Hour 15: Capstone planning workshop — scope, milestones, and delivery path
+- Hour 16: Checkpoint 2 — persistence-ready core + JSON save/load
+
+### Source Alignment
+- `Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md` → `## Session 4 overview`
+- `Advanced/lessons/lecture/Day4_Hour1_Advanced.md` → `# Day 4, Hour 1: HTTP Client Work – requests + JSON Contracts`
+- `Advanced/lessons/lecture/Day4_Hour2_Advanced.md` → `# Day 4, Hour 2: Security Basics – Environment Variables, Safe Secrets Habits, and Hashing Concepts`
+- `Advanced/lessons/lecture/Day4_Hour3_Advanced.md` → `# Day 4, Hour 3: Capstone Planning Workshop – Scope, Milestones, and Delivery Path`
+- `Advanced/lessons/lecture/Day4_Hour4_Advanced.md` → `# Day 4, Hour 4: Checkpoint 2 – Persistence-Ready Core + JSON Save/Load`
+
+---
+
+# Session 4 Outcomes
+
+- Treat outside data as untrusted until checked
+- Keep secrets out of source control
+- Choose a realistic capstone path
+- Deliver a persistence-ready core that can survive restart
+
+---
+
+# Scope Guardrails for Today
+
+## In Scope
+- HTTP client fundamentals
+- JSON contract validation
+- Environment-variable habits
+- Concept-level hashing discussion
+- Capstone MVP planning
+- JSON persistence checkpoint
+
+## Not Yet
+- Production auth systems
+- Full deployment workflows
+- Enterprise schema tooling
+- Database integration beyond persistence-ready design
+
+---
+
+# Hour 13: HTTP Client Work + JSON Contracts
+
+## Learning Outcomes
+- Send a `GET` request with `requests`
+- Always set a timeout
+- Use `raise_for_status()`
+- Validate the JSON shape before trusting it
+
+---
+
+## Big Shift for This Hour
+
+- Up to now, most data has lived inside our program
+- Today the program talks to something outside itself
+- Outside data may be:
+  - slow
+  - missing
+  - malformed
+  - structurally different from what we expected
+
+---
+
+## HTTP Client Fundamentals
+
+- Client sends request
+- Server sends response
+
+### High-Level Pieces
+- method
+- URL
+- optional params/headers/body
+- status code
+- response body
+
+### Today
+- mainly `GET`
+- JSON responses
+
+---
+
+## Reliability Habits
+
+- **Always set a timeout**
+- Prefer `raise_for_status()`
+- Catch failure categories cleanly:
+  - timeout
+  - connection problem
+  - HTTP error
+  - invalid JSON
+  - contract mismatch
+
+---
+
+## JSON Is a Contract
+
+### Check the Minimum Shape You Need
+- payload type
+- required keys
+- expected value types
+
+```python
+response = requests.get(url, timeout=5)
+response.raise_for_status()
+data = response.json()
+```
+
+---
+
+## Demo: Small Wrapper Function
+
+```python
+def fetch_task(url: str) -> dict:
+    response = requests.get(url, timeout=5)
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict) or "title" not in data:
+        raise ValueError("Response contract mismatch")
+    return data
+```
+
+- Centralize request behavior
+- Avoid copy/paste request logic everywhere
+
+---
+
+## Lab: API Consumer
+
+**Time: 15–25 minutes**
+
+### Tasks
+- Send a `GET` request to a sample endpoint
+- Use `timeout=...`
+- Call `raise_for_status()`
+- Parse JSON
+- Validate required keys before use
+- Show a friendly failure message for one error case
+
+---
+
+## Completion Criteria (Hour 13)
+
+✓ Request uses a timeout  
+✓ Happy path parses JSON safely  
+✓ Failure handling is intentional  
+✓ Contract validation happens before downstream use
+
+---
+
+## Homework + Quiz Emphasis (Hour 13)
+
+- Homework framing:
+  - **Goal:** client call that reads JSON safely and prints labeled checks
+  - **Best practice:** check status codes and JSON keys
+  - **Pitfall:** assuming every response has the shape you want
+- Quiz/canonical contract marker:
+  - `Hour 13 | request url: https://api.example.test/tasks`
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day4_homework.ipynb` → `## Part 1: Hour 13 - HTTP client work`
+- `Advanced/quizzes/Advanced_Day4_Quiz.html` → `QUIZ_DATA` questions 1–5
+
+---
+
+## Common Pitfalls (Hour 13)
+
+⚠️ No timeout  
+⚠️ Parsing JSON before checking status  
+⚠️ Trusting missing keys blindly  
+⚠️ Returning raw error noise to end users
+
+---
+
+## Quick Check
+
+**Question:** Why is "the service returned valid JSON" not the same as "the response matches our contract"?
+
+---
+
+# Hour 14: Security Basics
+
+## Learning Outcomes
+- Explain why secrets should not live in source files
+- Load sensitive values from environment variables
+- Distinguish hashing from encryption conceptually
+- Keep this hour in appropriate scope
+
+---
+
+## Security Mindset Reset
+
+- We are teaching **habits**, not full security engineering
+- Good boundaries matter
+
+### Not This Hour
+- OAuth
+- JWT flows
+- production identity systems
+
+### This Hour
+- secret hygiene
+- env vars
+- `.env.example`
+- hashing concept demo
+
+---
+
+## Hard-Coded Secrets Are a Trap
+
+```python
+ADMIN_KEY = "super-secret-real-key"
+```
+
+### Problems
+1. Secrets end up in version control
+2. Rotation becomes painful
+3. Unsafe sharing habits spread
+4. Commit history keeps the mistake around
+
+---
+
+## Environment Variable Pattern
+
+```python
+import os
+
+
+def get_required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+```
+
+- Code names what it needs
+- Environment supplies the real value
+
+---
+
+## `.env.example` vs `.env`
+
+```env
+APP_API_KEY=your-api-key-here
+APP_ADMIN_KEY=replace-with-local-admin-key
+APP_ENV=development
+```
+
+- `.env.example` may be committed
+- `.env` should usually be ignored
+- placeholders only — never real secrets
+
+---
+
+## Hashing vs Encryption
+
+- **Encryption** is meant to be reversible with the right key
+- **Hashing** is meant to be one-way
+
+### Classroom-Safe Demo Idea
+- compute a digest
+- compare digests
+- do **not** claim this solves production auth
+
+---
+
+## Demo: Gated Admin Action
+
+```python
+import hashlib
+import secrets
+
+
+def sha256_digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+authorized = secrets.compare_digest(
+    sha256_digest(expected_key),
+    sha256_digest(provided_key),
+)
+```
+
+---
+
+## Lab: Secure-ish Configuration
+
+**Time: 18–25 minutes**
+
+### Tasks
+- Read one required value from the environment
+- Add a `.env.example` template plan
+- Add `.gitignore` guidance for local secret files
+- Gate one admin action using configuration, not a hard-coded literal
+
+---
+
+## Completion Criteria (Hour 14)
+
+✓ Secret value is not hard-coded in the source  
+✓ Missing env var fails clearly  
+✓ Learner can explain hashing vs encryption at a high level  
+✓ Scope stays disciplined and honest
+
+---
+
+## Homework + Quiz Emphasis (Hour 14)
+
+- Homework framing:
+  - **Goal:** secure config pattern that separates secrets from code
+  - **Best practice:** read secrets from env vars, store only hashes when appropriate
+  - **Pitfall:** checking secrets into source control
+- Quiz/canonical contract marker:
+  - `Hour 14 | secret source: environment variable`
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day4_homework.ipynb` → `## Part 2: Hour 14 - Security basics`
+- `Advanced/quizzes/Advanced_Day4_Quiz.html` → `QUIZ_DATA` questions 6–10
+
+---
+
+## Common Pitfalls (Hour 14)
+
+⚠️ Real secrets in demo files  
+⚠️ Committing `.env`  
+⚠️ Treating hashing and encryption as synonyms  
+⚠️ Promising production-grade security from a classroom-safe example
+
+---
+
+## Quick Check
+
+**Question:** Why is a `.env.example` helpful even though it contains no real secret values?
+
+---
+
+# Hour 15: Capstone Planning Workshop
+
+## Learning Outcomes
+- Lock an MVP scope
+- Choose a delivery path
+- Break the project into milestones
+- Define "done" before the build gets bigger
+
+---
+
+## What This Workshop Is Really For
+
+- Replace vague enthusiasm with a delivery plan
+- Protect the project from scope drift
+- Decide what proves value earliest
+
+### Strong Planning Questions
+- Who is the user?
+- What is the primary workflow?
+- What is the smallest useful version?
+
+---
+
+## Recommended Milestone Path
+
+1. Core
+2. Persistence
+3. UI
+4. Analytics
+5. Tests
+6. Package
+
+- Do not jump to a flashy shell around unstable logic
+
+---
+
+## Definition of Done Examples
+
+### Core
+- service logic works in isolation
+
+### Persistence
+- data survives restart
+
+### UI
+- primary workflow works through the chosen surface
+
+### Tests
+- major business rules and failure paths have repeatable checks
+
+---
+
+## Delivery Path Decision
+
+### GUI-First
+- tangible demo quickly
+- risk: logic hides in callbacks
+
+### API-First
+- clearer service boundaries
+- risk: less visually exciting at first
+
+### Non-Negotiable
+- core logic still lives in reusable services
+
+---
+
+## Demo Artifact Shape
+
+```text
+capstone_project/
+├── README.md
+├── src/
+├── tests/
+└── data/
+```
+
+### README Needs
+- project goal
+- MVP features
+- setup steps
+- run steps
+
+---
+
+## Workshop: One-Page Capstone Plan
+
+**Time: 20 minutes**
+
+### Include
+- chosen domain
+- primary user workflow
+- GUI-first or API-first decision
+- milestone list
+- persistence plan
+- key risks
+- test targets
+
+---
+
+## Completion Criteria (Hour 15)
+
+✓ Scope is realistic  
+✓ Delivery path is chosen and justified  
+✓ Milestones are sequenced clearly  
+✓ README skeleton or plan notes exist
+
+---
+
+## Homework + Quiz Emphasis (Hour 15)
+
+- Homework framing:
+  - **Goal:** milestone plan with one domain, one interface, and staged deliverables
+  - **Best practice:** keep scope narrow enough to finish
+  - **Pitfall:** trying to build every optional feature before core CRUD is stable
+- Quiz/canonical contract marker:
+  - `Hour 15 | chosen domain: tracker`
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day4_homework.ipynb` → `## Part 3: Hour 15 - Capstone planning workshop`
+- `Advanced/quizzes/Advanced_Day4_Quiz.html` → `QUIZ_DATA` questions 11–15
+
+---
+
+## Common Pitfalls (Hour 15)
+
+⚠️ Wish-list scope instead of MVP scope  
+⚠️ README postponed until the final hour  
+⚠️ UI selected before the core is stable  
+⚠️ No persistence or test plan in the roadmap
+
+---
+
+## Quick Check
+
+**Question:** Which milestone do students most often try to jump to too early, and why is that risky?
+
+---
+
+# Hour 16: Checkpoint 2 — Persistence-Ready Core
+
+## Learning Outcomes
+- Separate domain, service, and persistence responsibilities
+- Save JSON using a safe-save pattern
+- Load saved state back into application objects
+- Handle missing files, invalid JSON, and validation failures cleanly
+
+---
+
+## What Checkpoint 2 Proves
+
+- The core survives beyond one run
+- The package layout under `src/` is intentional
+- State can be saved and restored
+- Logging captures meaningful persistence events
+- Custom exceptions still communicate domain and persistence issues
+
+---
+
+## Sample Persistence-Ready Layout
+
+```text
+project_root/
+├── demo_persistence.py
+├── logs/app.log
+├── data/state.json
+└── src/reading_tracker/
+    ├── errors.py
+    ├── logging_config.py
+    ├── models.py
+    ├── persistence.py
+    └── services.py
+```
+
+---
+
+## Separation of Concerns
+
+- **models.py** → structured domain data
+- **services.py** → business rules
+- **persistence.py** → JSON save/load
+- **errors.py** → custom exceptions
+- **logging_config.py** → file logging setup
+
+### Why It Matters
+- JSON today
+- database later
+- less rewiring when storage changes
+
+---
+
+## Demo: Safe Save + Load Shape
+
+```python
+class PersistenceError(Exception):
+    pass
+
+
+class JSONStateStore:
+    def save(self, state):
+        ...
+
+    def load(self):
+        ...
+```
+
+- save started
+- save succeeded
+- load started
+- file missing handled
+- invalid JSON handled
+
+---
+
+## Demo Workflow
+
+### Save → Restart → Load
+1. Create a few records
+2. Save to JSON safely
+3. Recreate the service/store
+4. Load state back in
+5. Confirm records still exist
+
+---
+
+## Hands-On Checkpoint Build
+
+**Time: 15–25 minutes**
+
+### Tasks
+- Organize or confirm package layout
+- Add a persistence layer
+- Implement safe save behavior
+- Load JSON back into objects
+- Log the key events
+- Demonstrate one failure case and one happy path
+
+---
+
+## Completion Criteria (Hour 16)
+
+✓ Core state round-trips through JSON  
+✓ Save path is safer than direct overwrite  
+✓ Load handles missing/bad files intentionally  
+✓ The project is visibly more persistence-ready than it was yesterday
+
+---
+
+## Homework + Quiz Emphasis (Hour 16)
+
+- Homework framing:
+  - **Goal:** core app that can add records and round-trip them through JSON
+  - **Best practice:** checkpoint save/load before expanding the interface
+  - **Pitfall:** delaying persistence checks until after major UI work
+- Quiz/canonical contract marker:
+  - `Hour 16 | checkpoint model: Task`
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day4_homework.ipynb` → `## Part 4: Hour 16 - Checkpoint 2`
+- `Advanced/quizzes/Advanced_Day4_Quiz.html` → `QUIZ_DATA` questions 16–20
+
+---
+
+## Common Pitfalls (Hour 16)
+
+⚠️ Dumping JSON logic everywhere instead of using a persistence layer  
+⚠️ Direct overwrite with no safety net  
+⚠️ Treating file absence as a crash-only situation  
+⚠️ Adding more features before proving save/load works
+
+---
+
+## Quick Check
+
+**Question:** If the app works beautifully in memory but loses state after restart, what milestone is still incomplete?
+
+---
+
+# Session 4 Wrap-Up
+
+## What We Locked In Today
+- Reliable HTTP client habits
+- Safer secret/config practices
+- A concrete capstone roadmap
+- Persistence-ready core architecture
+
+### Key Rule
+**Trustworthy software plans for failure, scope, and restart behavior.**
+
+---
+
+## Day 4 Homework / Study Checklist
+
+- Re-run the HTTP wrapper with a failure case in mind
+- Remove any hard-coded secret from demo code
+- Finalize the one-page capstone plan
+- Test save -> load round-trip behavior
+- Match the canonical output labels expected by the notebook
+
+### Source Alignment
+- `Advanced/assignments/Advanced_Day4_homework.ipynb` → `## Submission Checklist`
+
+---
+
+## Next Step Framing
+
+### After Session 4
+- keep the core stable
+- preserve scope discipline
+- carry forward logging and safe-save habits
+- use the capstone plan as the default decision filter
+
+---
+
+# Thank You!
+
+Validate outside data.  
+Keep secrets out of source.  
+Plan the MVP.  
+Prove persistence before expanding.

--- a/Advanced/lessons/slides/day-05/day-05-session-5.html
+++ b/Advanced/lessons/slides/day-05/day-05-session-5.html
@@ -1,0 +1,1073 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 5 — Session 5 (Hours 17–20)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 5 — Session 5 (Hours 17–20)</h1>
+            <div class="subtitle">Python Programming (Advanced) • GUI Foundations for the Tracker Capstone</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 5 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 17: GUI fundamentals with Tkinter / <code>ttk</code></li>
+  <li>Hour 18: Layout, spacing, and resizing</li>
+  <li>Hour 19: Forms, validation, and user feedback</li>
+  <li>Hour 20: Record lists, selection, and refresh</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Today&#x27;s Capstone Milestone</h1>
+            <ul>
+  <li>Move from CLI-style flow to event-driven desktop workflow</li>
+  <li>Keep the <strong>service layer</strong> as the home for business rules</li>
+  <li>Start building a tracker UI that can grow into CRUD workflows</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 5 overview (Hours 17–20); Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Section 1: Recap and Transition --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis</h1>
+            <ul>
+  <li>Build one working GUI action first</li>
+  <li>Use <code>grid()</code> intentionally for readable forms</li>
+  <li>Show validation feedback without crashes</li>
+  <li>Bind record selection to a <strong>stable ID</strong>, not display order</li>
+</ul>
+<h3>Canonical quiz/contracts to recognize</h3>
+<ul>
+  <li><code>Hour 17 | root window: tracker app</code></li>
+  <li><code>Hour 18 | layout manager: grid</code></li>
+  <li><code>Hour 19 | field read: title entry</code></li>
+  <li><code>Hour 20 | list widget: treeview</code></li>
+</ul>
+<p>&lt;!-- Sources: Advanced/assignments/Advanced_Day5_homework.ipynb — Part 1 through Part 4; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 17 through Hour 20 canonical contract questions --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 17: GUI Fundamentals</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain why GUI programs are <strong>event-driven</strong></li>
+  <li>Create a small window with labels, entries, and buttons</li>
+  <li>Wire a button to a callback</li>
+  <li>Route validation through the service layer</li>
+  <li>Show visible success/error feedback</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 17: GUI fundamentals (Tkinter/ttk): event loop, widgets, callbacks; Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>The Mental Model Shift</h1>
+            <h3>CLI mindset</h3>
+<ol>
+  <li>Start</li>
+  <li>Read input</li>
+  <li>Do work</li>
+  <li>Print output</li>
+  <li>Exit</li>
+</ol>
+<h3>GUI mindset</h3>
+<ul>
+  <li>Open a window</li>
+  <li>Wait for events</li>
+  <li>React through callbacks</li>
+  <li>Stay responsive until the user closes the app</li>
+</ul>
+<p><strong>Key phrase</strong>: The GUI handles interaction; the service layer handles rules.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Section 1: Recap and Transition; Section 2: The GUI Mental Model --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Core Building Blocks</h1>
+            <ul>
+  <li><code>mainloop()</code> keeps the app alive and listening</li>
+  <li><code>Label</code> shows text</li>
+  <li><code>Entry</code> captures user input</li>
+  <li><code>Button</code> triggers a callback</li>
+  <li><code>messagebox</code> gives simple popup feedback</li>
+  <li><code>StringVar</code> helps connect UI state to Python values</li>
+</ul>
+<h3>Keep callbacks short</h3>
+<ul>
+  <li>Read form values</li>
+  <li>Call the service</li>
+  <li>Update the interface</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour1_Advanced.md — What mainloop() Does; Widgets and Callbacks; Demo Teaching Points to Repeat --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Thin Callback Pattern</h1>
+            <pre data-lang="python"><code>def on_add(self) -&gt; None:
+    try:
+        record = self.service.add_record(
+            self.name_var.get(),
+            self.email_var.get(),
+        )
+    except ValidationError as exc:
+        self.status_var.set(f&quot;Error: {exc}&quot;)
+        return
+
+    self.status_var.set(f&quot;Added {record.name}&quot;)</code></pre>
+<h3>Why this pattern works</h3>
+<ul>
+  <li>UI gathers input</li>
+  <li>Service validates and stores</li>
+  <li>UI presents the outcome</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Section 3: Core Design Pattern for This Hour; Demo Code --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Hello GUI + Add Form</h1>
+            <h3>Instructor flow</h3>
+<ol>
+  <li>Create the service class first</li>
+  <li>Build a small <code>ContactApp</code> / tracker app class</li>
+  <li>Add two fields and an <strong>Add</strong> button</li>
+  <li>Wire <code>command=self.on_add</code></li>
+  <li>Show one bad submission and one good submission</li>
+  <li>Point directly to <code>root.mainloop()</code></li>
+</ol>
+<h3>Watch for</h3>
+<ul>
+  <li>Where the widgets live</li>
+  <li>Where the callback lives</li>
+  <li>Where the validation rule lives</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Live demo (Hour 17); Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Demo Steps --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: First Working GUI Action</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create a Tkinter window for your tracker domain</li>
+  <li>Add at least two inputs</li>
+  <li>Add one working action button</li>
+  <li>Show status or messagebox feedback</li>
+  <li>Keep business rules outside the widget-building code</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> GUI launches reliably</p>
+<p><span class="check">✓</span> One callback works end to end</p>
+<p><span class="check">✓</span> Validation comes from a service/helper</p>
+<p><span class="check">✓</span> User sees success or error clearly</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Hello GUI + Add form; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 1: Hour 17 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 17)</h1>
+            <p><strong>⚠️</strong> Forgetting <code>mainloop()</code></p>
+<p><strong>⚠️</strong> Writing <code>command=self.on_add()</code> instead of <code>command=self.on_add</code></p>
+<p><strong>⚠️</strong> Burying business rules directly in callbacks</p>
+<p><strong>⚠️</strong> Clicking a button and giving the user no visible feedback</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What does <code>mainloop()</code> do, and why should callbacks stay small?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 17 best practice and pitfall --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 18: Layout and Usability</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Use <code>grid()</code> for form-style layouts</li>
+  <li>Group related controls with frames</li>
+  <li>Add consistent spacing and alignment</li>
+  <li>Configure the layout to resize sensibly</li>
+  <li>Avoid mixing geometry managers in the same parent</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 18: Layout and usability; Advanced/lessons/lecture/Day5_Hour2_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>`pack()` vs `grid()`</h1>
+            <h3>Use `pack()` when</h3>
+<ul>
+  <li>You want simple stacking</li>
+</ul>
+<h3>Use `grid()` when</h3>
+<ul>
+  <li>You need rows + columns</li>
+  <li>You are building a form</li>
+  <li>Labels and inputs should line up cleanly</li>
+</ul>
+<blockquote>Do not mix `pack()` and `grid()` in the same parent widget.</blockquote>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour2_Advanced.md — <code>pack()</code> and <code>grid()</code>; The Rule About Mixing Geometry Managers --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Layout Rules That Matter</h1>
+            <ul>
+  <li>Use frames as layout boundaries</li>
+  <li>Add consistent <code>padx</code> / <code>pady</code></li>
+  <li>Use <code>sticky=&quot;w&quot;</code> or <code>sticky=&quot;ew&quot;</code> intentionally</li>
+  <li>Give growing columns a weight</li>
+</ul>
+<pre data-lang="python"><code>main_frame.columnconfigure(1, weight=1)
+ttk.Entry(form_frame).grid(row=0, column=1, sticky=&quot;ew&quot;)</code></pre>
+<h3>Usability checklist</h3>
+<ol>
+  <li>Are related items grouped?</li>
+  <li>Is spacing consistent?</li>
+  <li>Is the main action easy to find?</li>
+  <li>Does resize behavior make sense?</li>
+</ol>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour2_Advanced.md — Usability Principles for Basic Desktop GUIs; Column Weights and Resizing --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Refactor a Messy Layout</h1>
+            <h3>Demo target</h3>
+<ul>
+  <li>One main frame</li>
+  <li>Two visual regions</li>
+  <li style="margin-left: 30px;">Form area</li>
+  <li style="margin-left: 30px;">Preview/list area</li>
+  <li><code>grid()</code> for the form</li>
+  <li>Safe nested <code>pack()</code> only inside a different parent such as a button bar</li>
+</ul>
+<h3>Success signal</h3>
+<ul>
+  <li>The app looks intentional</li>
+  <li>Resize behavior is acceptable</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Live demo (Hour 18); Advanced/lessons/lecture/Day5_Hour2_Advanced.md — Live Demo — Refactoring a Messy Layout --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Improve Layout and Resizing</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Rebuild the GUI using at least one frame</li>
+  <li>Convert the form area to <code>grid()</code></li>
+  <li>Add consistent spacing</li>
+  <li>Test the window at more than one size</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> UI is readable and aligned</p>
+<p><span class="check">✓</span> Resizing does not break the layout</p>
+<p><span class="check">✓</span> One layout strategy per container</p>
+<p><span class="check">✓</span> Main action stays obvious</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Improve layout; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 2: Hour 18 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 18)</h1>
+            <p><strong>⚠️</strong> Mixing <code>pack</code> and <code>grid</code> in the same container</p>
+<p><strong>⚠️</strong> Forgetting <code>sticky</code>, so fields do not align or stretch</p>
+<p><strong>⚠️</strong> Inconsistent padding</p>
+<p><strong>⚠️</strong> Never testing resize behavior</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is <code>grid()</code> usually a better fit for forms?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 18 canonical contract and pitfall --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 19: Forms, Validation, and Feedback</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Validate before saving</li>
+  <li>Normalize input before checking rules</li>
+  <li>Show friendly, actionable feedback</li>
+  <li>Keep predictable validation out of crash paths</li>
+  <li>Separate service validation from UI presentation</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 19: Forms + validation feedback patterns; Advanced/lessons/lecture/Day5_Hour3_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Good Validation Helps the User Succeed</h1>
+            <h3>Weak message</h3>
+<p><code>Invalid input</code></p>
+<h3>Better message</h3>
+<p><code>Email is required</code></p>
+<h3>Best message</h3>
+<p><code>Enter an email address such as name@example.com</code></p>
+<h3>Normalize first</h3>
+<ul>
+  <li><code>strip()</code> whitespace</li>
+  <li>lowercase email-like fields</li>
+  <li>clean obvious formatting noise before validation</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour3_Advanced.md — Validation Should Be Helpful, Not Punitive; Normalize Before You Validate --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Service vs UI Responsibilities</h1>
+            <h3>Service layer</h3>
+<ul>
+  <li>Decides whether data is valid</li>
+  <li>Returns structured errors or raises the right exception</li>
+</ul>
+<h3>UI layer</h3>
+<ul>
+  <li>Places messages near the right field</li>
+  <li>Moves focus to the first invalid control</li>
+  <li>Clears old errors</li>
+  <li>Resets the form after success</li>
+</ul>
+<pre data-lang="python"><code>errors = {
+    &quot;name&quot;: &quot;Name is required.&quot;,
+    &quot;email&quot;: &quot;Enter an email address such as name@example.com.&quot;,
+}</code></pre>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour3_Advanced.md — Service Errors vs UI Errors; A Clean Validation Pattern --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Validated Tracker Form</h1>
+            <h3>Demo highlights</h3>
+<ul>
+  <li>Inline field-level errors</li>
+  <li>Summary status message</li>
+  <li>Disabled/re-enabled Save button during submit</li>
+  <li>Focus moved to the first invalid field</li>
+  <li>App stays stable after bad input</li>
+</ul>
+<h3>Instructor prompt</h3>
+<p>Ask learners to identify:</p>
+<ol>
+  <li>Where <code>.strip()</code> happens</li>
+  <li>Where errors are structured</li>
+  <li>Why inline feedback often beats a popup</li>
+</ol>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Live demo (Hour 19); Advanced/lessons/lecture/Day5_Hour3_Advanced.md — Live Demo — Inline Validation and Actionable Feedback --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Validation Feedback Without Crashing</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add required-field checks</li>
+  <li>Normalize user input</li>
+  <li>Display at least one inline error</li>
+  <li>Add a summary status message</li>
+  <li>Keep the app available for immediate correction</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> Missing data is rejected clearly</p>
+<p><span class="check">✓</span> Errors are actionable</p>
+<p><span class="check">✓</span> No raw traceback shown to the user</p>
+<p><span class="check">✓</span> Valid entries save successfully</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Add validation UI; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 3: Hour 19 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 19)</h1>
+            <p><strong>⚠️</strong> Silent failure after bad input</p>
+<p><strong>⚠️</strong> Vague messages with no next step</p>
+<p><strong>⚠️</strong> Treating predictable validation as a crash-worthy exception</p>
+<p><strong>⚠️</strong> Forgetting to clear old errors before the next save</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is “Enter an email address such as name@example.com” better than “Invalid email”?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 19 best practice and pitfall --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 20: Record Lists and Selection</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Show multiple records in a list or table</li>
+  <li>Use <code>Treeview</code> or <code>Listbox</code> appropriately</li>
+  <li>Refresh safely without duplicate stale rows</li>
+  <li>React to selection events</li>
+  <li>Map selection to a stable record ID</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 20: Record list UI; Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>`Listbox` vs `Treeview`</h1>
+            <h3>`Listbox`</h3>
+<ul>
+  <li>Lightweight</li>
+  <li>Good for one visible string per row</li>
+</ul>
+<h3>`Treeview`</h3>
+<ul>
+  <li>Better for multi-column records</li>
+  <li>Good fit for tracker-style data</li>
+  <li>Easier to grow into sorting and richer browsing</li>
+</ul>
+<h3>Selection rule</h3>
+<p>Selection should lead to a <strong>record ID</strong>, not just a row position.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Choosing the Right List Widget; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 4: Hour 20 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Safe Refresh Pattern</h1>
+            <ol>
+  <li>Clear existing rows</li>
+  <li>Fetch current records</li>
+  <li>Insert fresh rows</li>
+  <li>Reset or refresh the details pane</li>
+</ol>
+<pre data-lang="python"><code>self.tree.delete(*self.tree.get_children())
+for record in records:
+    self.tree.insert(&quot;&quot;, &quot;end&quot;, iid=str(record.record_id), values=(...))</code></pre>
+<h3>Why this matters</h3>
+<ul>
+  <li>No duplicated rows</li>
+  <li>No stale details</li>
+  <li>No “selection points at the wrong thing” bug</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Refreshing Safely; Demo Code --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: List + Details Browser</h1>
+            <h3>Demo flow</h3>
+<ul>
+  <li>Add a <code>Treeview</code></li>
+  <li>Bind <code>&lt;&lt;TreeviewSelect&gt;&gt;</code></li>
+  <li>Show details for the selected record</li>
+  <li>Add a Refresh button</li>
+  <li>Handle empty-state cases safely</li>
+</ul>
+<h3>Empty-state behavior</h3>
+<ul>
+  <li>Empty list is still a valid state</li>
+  <li>No selection should clear or reset details</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: Treeview showing records; Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Live Demo — Treeview with Selection and Details Pane --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Record Browser</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add a list area for saved records</li>
+  <li>Add a details pane</li>
+  <li>Bind selection to a callback</li>
+  <li>Add Refresh</li>
+  <li>Show safe behavior when there are no records</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> List populates and updates</p>
+<p><span class="check">✓</span> Details follow the selected record</p>
+<p><span class="check">✓</span> No crash on empty selection</p>
+<p><span class="check">✓</span> Refresh clears stale rows first</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: List + details; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 4: Hour 20 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 20)</h1>
+            <p><strong>⚠️</strong> Using display order as identity</p>
+<p><strong>⚠️</strong> Not clearing old rows before refresh</p>
+<p><strong>⚠️</strong> Crashing when no selection exists</p>
+<p><strong>⚠️</strong> Leaving stale details visible after the list changes</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What should happen if the user clicks Refresh when there are zero records?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 20 best practice and pitfall --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 5 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Built Toward</h1>
+            <ul>
+  <li>Event-driven thinking instead of CLI-only flow</li>
+  <li>A cleaner form layout with <code>grid()</code> and frames</li>
+  <li>Validation that helps users recover</li>
+  <li>A record browser that is safe to refresh and select</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Capstone checkpoint coming next</h1>
+            <ul>
+  <li>Update + delete workflows</li>
+  <li>Cleaner controller architecture</li>
+  <li>JSON persistence + polish</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 5 overview; Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Wrap-Up --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails</h1>
+            <h3>Stay in scope today</h3>
+<p><span class="check">✓</span> Tkinter / <code>ttk</code> fundamentals</p>
+<p><span class="check">✓</span> Small, maintainable callbacks</p>
+<p><span class="check">✓</span> Service-layer validation</p>
+<p><span class="check">✓</span> Stable IDs for selection</p>
+<h3>Not today&#x27;s goal</h3>
+<p><span class="cross">✗</span> Fancy theming</p>
+<p><span class="cross">✗</span> Framework switching</p>
+<p><span class="cross">✗</span> ORM/database work</p>
+<p><span class="cross">✗</span> Big “all-features-at-once” refactors</p>
+<h3>Homework / quiz prep</h3>
+<ul>
+  <li>Be able to explain <strong>why</strong> <code>mainloop()</code> matters</li>
+  <li>Be able to justify <code>grid()</code> for forms</li>
+  <li>Be able to show a friendly validation path</li>
+  <li>Be able to explain why stable IDs beat list positions</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Wrap-Up; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 17 through Hour 20 explanations --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Session 6 next:</p>
+<ul>
+  <li>Update + delete through the GUI</li>
+  <li>Controller cleanup</li>
+  <li>JSON persistence and checkpoint demo</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 6 overview (Hours 21–24) --&gt;</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/Advanced/lessons/slides/day-05/day-05-session-5.md
+++ b/Advanced/lessons/slides/day-05/day-05-session-5.md
@@ -1,0 +1,539 @@
+# Advanced Day 5 — Session 5 (Hours 17–20)
+Python Programming (Advanced) • GUI Foundations for the Tracker Capstone
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 5 overview (Hours 17–20); Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Instructor Notes -->
+
+---
+
+# Session 5 Overview
+
+## Topics Covered Today
+- Hour 17: GUI fundamentals with Tkinter / `ttk`
+- Hour 18: Layout, spacing, and resizing
+- Hour 19: Forms, validation, and user feedback
+- Hour 20: Record lists, selection, and refresh
+
+## Today's Capstone Milestone
+- Move from CLI-style flow to event-driven desktop workflow
+- Keep the **service layer** as the home for business rules
+- Start building a tracker UI that can grow into CRUD workflows
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 5 overview (Hours 17–20); Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Section 1: Recap and Transition -->
+
+---
+
+## Homework + Quiz Emphasis
+
+- Build one working GUI action first
+- Use `grid()` intentionally for readable forms
+- Show validation feedback without crashes
+- Bind record selection to a **stable ID**, not display order
+
+### Canonical quiz/contracts to recognize
+- `Hour 17 | root window: tracker app`
+- `Hour 18 | layout manager: grid`
+- `Hour 19 | field read: title entry`
+- `Hour 20 | list widget: treeview`
+
+<!-- Sources: Advanced/assignments/Advanced_Day5_homework.ipynb — Part 1 through Part 4; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 17 through Hour 20 canonical contract questions -->
+
+---
+
+# Hour 17: GUI Fundamentals
+
+## Learning Outcomes
+- Explain why GUI programs are **event-driven**
+- Create a small window with labels, entries, and buttons
+- Wire a button to a callback
+- Route validation through the service layer
+- Show visible success/error feedback
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 17: GUI fundamentals (Tkinter/ttk): event loop, widgets, callbacks; Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Learning Outcomes for This Hour -->
+
+---
+
+## The Mental Model Shift
+
+### CLI mindset
+1. Start
+2. Read input
+3. Do work
+4. Print output
+5. Exit
+
+### GUI mindset
+- Open a window
+- Wait for events
+- React through callbacks
+- Stay responsive until the user closes the app
+
+**Key phrase**: The GUI handles interaction; the service layer handles rules.
+
+<!-- Sources: Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Section 1: Recap and Transition; Section 2: The GUI Mental Model -->
+
+---
+
+## Core Building Blocks
+
+- `mainloop()` keeps the app alive and listening
+- `Label` shows text
+- `Entry` captures user input
+- `Button` triggers a callback
+- `messagebox` gives simple popup feedback
+- `StringVar` helps connect UI state to Python values
+
+### Keep callbacks short
+- Read form values
+- Call the service
+- Update the interface
+
+<!-- Sources: Advanced/lessons/lecture/Day5_Hour1_Advanced.md — What mainloop() Does; Widgets and Callbacks; Demo Teaching Points to Repeat -->
+
+---
+
+## Thin Callback Pattern
+
+```python
+def on_add(self) -> None:
+    try:
+        record = self.service.add_record(
+            self.name_var.get(),
+            self.email_var.get(),
+        )
+    except ValidationError as exc:
+        self.status_var.set(f"Error: {exc}")
+        return
+
+    self.status_var.set(f"Added {record.name}")
+```
+
+### Why this pattern works
+- UI gathers input
+- Service validates and stores
+- UI presents the outcome
+
+<!-- Sources: Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Section 3: Core Design Pattern for This Hour; Demo Code -->
+
+---
+
+## Demo: Hello GUI + Add Form
+
+### Instructor flow
+1. Create the service class first
+2. Build a small `ContactApp` / tracker app class
+3. Add two fields and an **Add** button
+4. Wire `command=self.on_add`
+5. Show one bad submission and one good submission
+6. Point directly to `root.mainloop()`
+
+### Watch for
+- Where the widgets live
+- Where the callback lives
+- Where the validation rule lives
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Live demo (Hour 17); Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Demo Steps -->
+
+---
+
+## Lab: First Working GUI Action
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Create a Tkinter window for your tracker domain
+- Add at least two inputs
+- Add one working action button
+- Show status or messagebox feedback
+- Keep business rules outside the widget-building code
+
+### Completion Criteria
+✓ GUI launches reliably  
+✓ One callback works end to end  
+✓ Validation comes from a service/helper  
+✓ User sees success or error clearly
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Hello GUI + Add form; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 1: Hour 17 -->
+
+---
+
+## Common Pitfalls (Hour 17)
+
+⚠️ Forgetting `mainloop()`  
+⚠️ Writing `command=self.on_add()` instead of `command=self.on_add`  
+⚠️ Burying business rules directly in callbacks  
+⚠️ Clicking a button and giving the user no visible feedback
+
+## Quick Check
+**Question**: What does `mainloop()` do, and why should callbacks stay small?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 17 best practice and pitfall -->
+
+---
+
+# Hour 18: Layout and Usability
+
+## Learning Outcomes
+- Use `grid()` for form-style layouts
+- Group related controls with frames
+- Add consistent spacing and alignment
+- Configure the layout to resize sensibly
+- Avoid mixing geometry managers in the same parent
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 18: Layout and usability; Advanced/lessons/lecture/Day5_Hour2_Advanced.md — Learning Outcomes for This Hour -->
+
+---
+
+## `pack()` vs `grid()`
+
+### Use `pack()` when
+- You want simple stacking
+
+### Use `grid()` when
+- You need rows + columns
+- You are building a form
+- Labels and inputs should line up cleanly
+
+> Do not mix `pack()` and `grid()` in the same parent widget.
+
+<!-- Sources: Advanced/lessons/lecture/Day5_Hour2_Advanced.md — `pack()` and `grid()`; The Rule About Mixing Geometry Managers -->
+
+---
+
+## Layout Rules That Matter
+
+- Use frames as layout boundaries
+- Add consistent `padx` / `pady`
+- Use `sticky="w"` or `sticky="ew"` intentionally
+- Give growing columns a weight
+
+```python
+main_frame.columnconfigure(1, weight=1)
+ttk.Entry(form_frame).grid(row=0, column=1, sticky="ew")
+```
+
+### Usability checklist
+1. Are related items grouped?
+2. Is spacing consistent?
+3. Is the main action easy to find?
+4. Does resize behavior make sense?
+
+<!-- Sources: Advanced/lessons/lecture/Day5_Hour2_Advanced.md — Usability Principles for Basic Desktop GUIs; Column Weights and Resizing -->
+
+---
+
+## Demo: Refactor a Messy Layout
+
+### Demo target
+- One main frame
+- Two visual regions
+  - Form area
+  - Preview/list area
+- `grid()` for the form
+- Safe nested `pack()` only inside a different parent such as a button bar
+
+### Success signal
+- The app looks intentional
+- Resize behavior is acceptable
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Live demo (Hour 18); Advanced/lessons/lecture/Day5_Hour2_Advanced.md — Live Demo — Refactoring a Messy Layout -->
+
+---
+
+## Lab: Improve Layout and Resizing
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Rebuild the GUI using at least one frame
+- Convert the form area to `grid()`
+- Add consistent spacing
+- Test the window at more than one size
+
+### Completion Criteria
+✓ UI is readable and aligned  
+✓ Resizing does not break the layout  
+✓ One layout strategy per container  
+✓ Main action stays obvious
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Improve layout; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 2: Hour 18 -->
+
+---
+
+## Common Pitfalls (Hour 18)
+
+⚠️ Mixing `pack` and `grid` in the same container  
+⚠️ Forgetting `sticky`, so fields do not align or stretch  
+⚠️ Inconsistent padding  
+⚠️ Never testing resize behavior
+
+## Quick Check
+**Question**: Why is `grid()` usually a better fit for forms?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 18 canonical contract and pitfall -->
+
+---
+
+# Hour 19: Forms, Validation, and Feedback
+
+## Learning Outcomes
+- Validate before saving
+- Normalize input before checking rules
+- Show friendly, actionable feedback
+- Keep predictable validation out of crash paths
+- Separate service validation from UI presentation
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 19: Forms + validation feedback patterns; Advanced/lessons/lecture/Day5_Hour3_Advanced.md — Learning Outcomes for This Hour -->
+
+---
+
+## Good Validation Helps the User Succeed
+
+### Weak message
+`Invalid input`
+
+### Better message
+`Email is required`
+
+### Best message
+`Enter an email address such as name@example.com`
+
+### Normalize first
+- `strip()` whitespace
+- lowercase email-like fields
+- clean obvious formatting noise before validation
+
+<!-- Sources: Advanced/lessons/lecture/Day5_Hour3_Advanced.md — Validation Should Be Helpful, Not Punitive; Normalize Before You Validate -->
+
+---
+
+## Service vs UI Responsibilities
+
+### Service layer
+- Decides whether data is valid
+- Returns structured errors or raises the right exception
+
+### UI layer
+- Places messages near the right field
+- Moves focus to the first invalid control
+- Clears old errors
+- Resets the form after success
+
+```python
+errors = {
+    "name": "Name is required.",
+    "email": "Enter an email address such as name@example.com.",
+}
+```
+
+<!-- Sources: Advanced/lessons/lecture/Day5_Hour3_Advanced.md — Service Errors vs UI Errors; A Clean Validation Pattern -->
+
+---
+
+## Demo: Validated Tracker Form
+
+### Demo highlights
+- Inline field-level errors
+- Summary status message
+- Disabled/re-enabled Save button during submit
+- Focus moved to the first invalid field
+- App stays stable after bad input
+
+### Instructor prompt
+Ask learners to identify:
+1. Where `.strip()` happens
+2. Where errors are structured
+3. Why inline feedback often beats a popup
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Live demo (Hour 19); Advanced/lessons/lecture/Day5_Hour3_Advanced.md — Live Demo — Inline Validation and Actionable Feedback -->
+
+---
+
+## Lab: Validation Feedback Without Crashing
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Add required-field checks
+- Normalize user input
+- Display at least one inline error
+- Add a summary status message
+- Keep the app available for immediate correction
+
+### Completion Criteria
+✓ Missing data is rejected clearly  
+✓ Errors are actionable  
+✓ No raw traceback shown to the user  
+✓ Valid entries save successfully
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Add validation UI; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 3: Hour 19 -->
+
+---
+
+## Common Pitfalls (Hour 19)
+
+⚠️ Silent failure after bad input  
+⚠️ Vague messages with no next step  
+⚠️ Treating predictable validation as a crash-worthy exception  
+⚠️ Forgetting to clear old errors before the next save
+
+## Quick Check
+**Question**: Why is “Enter an email address such as name@example.com” better than “Invalid email”?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 19 best practice and pitfall -->
+
+---
+
+# Hour 20: Record Lists and Selection
+
+## Learning Outcomes
+- Show multiple records in a list or table
+- Use `Treeview` or `Listbox` appropriately
+- Refresh safely without duplicate stale rows
+- React to selection events
+- Map selection to a stable record ID
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 20: Record list UI; Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Learning Outcomes for This Hour -->
+
+---
+
+## `Listbox` vs `Treeview`
+
+### `Listbox`
+- Lightweight
+- Good for one visible string per row
+
+### `Treeview`
+- Better for multi-column records
+- Good fit for tracker-style data
+- Easier to grow into sorting and richer browsing
+
+### Selection rule
+Selection should lead to a **record ID**, not just a row position.
+
+<!-- Sources: Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Choosing the Right List Widget; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 4: Hour 20 -->
+
+---
+
+## Safe Refresh Pattern
+
+1. Clear existing rows
+2. Fetch current records
+3. Insert fresh rows
+4. Reset or refresh the details pane
+
+```python
+self.tree.delete(*self.tree.get_children())
+for record in records:
+    self.tree.insert("", "end", iid=str(record.record_id), values=(...))
+```
+
+### Why this matters
+- No duplicated rows
+- No stale details
+- No “selection points at the wrong thing” bug
+
+<!-- Sources: Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Refreshing Safely; Demo Code -->
+
+---
+
+## Demo: List + Details Browser
+
+### Demo flow
+- Add a `Treeview`
+- Bind `<<TreeviewSelect>>`
+- Show details for the selected record
+- Add a Refresh button
+- Handle empty-state cases safely
+
+### Empty-state behavior
+- Empty list is still a valid state
+- No selection should clear or reset details
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: Treeview showing records; Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Live Demo — Treeview with Selection and Details Pane -->
+
+---
+
+## Lab: Record Browser
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Add a list area for saved records
+- Add a details pane
+- Bind selection to a callback
+- Add Refresh
+- Show safe behavior when there are no records
+
+### Completion Criteria
+✓ List populates and updates  
+✓ Details follow the selected record  
+✓ No crash on empty selection  
+✓ Refresh clears stale rows first
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: List + details; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 4: Hour 20 -->
+
+---
+
+## Common Pitfalls (Hour 20)
+
+⚠️ Using display order as identity  
+⚠️ Not clearing old rows before refresh  
+⚠️ Crashing when no selection exists  
+⚠️ Leaving stale details visible after the list changes
+
+## Quick Check
+**Question**: What should happen if the user clicks Refresh when there are zero records?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 20 best practice and pitfall -->
+
+---
+
+# Session 5 Wrap-Up
+
+## What We Built Toward
+- Event-driven thinking instead of CLI-only flow
+- A cleaner form layout with `grid()` and frames
+- Validation that helps users recover
+- A record browser that is safe to refresh and select
+
+## Capstone checkpoint coming next
+- Update + delete workflows
+- Cleaner controller architecture
+- JSON persistence + polish
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 5 overview; Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Wrap-Up -->
+
+---
+
+## Scope Guardrails
+
+### Stay in scope today
+✓ Tkinter / `ttk` fundamentals  
+✓ Small, maintainable callbacks  
+✓ Service-layer validation  
+✓ Stable IDs for selection
+
+### Not today's goal
+✗ Fancy theming  
+✗ Framework switching  
+✗ ORM/database work  
+✗ Big “all-features-at-once” refactors
+
+### Homework / quiz prep
+- Be able to explain **why** `mainloop()` matters
+- Be able to justify `grid()` for forms
+- Be able to show a friendly validation path
+- Be able to explain why stable IDs beat list positions
+
+<!-- Sources: Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Wrap-Up; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 17 through Hour 20 explanations -->
+
+---
+
+# Thank You!
+
+Session 6 next:
+- Update + delete through the GUI
+- Controller cleanup
+- JSON persistence and checkpoint demo
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 6 overview (Hours 21–24) -->

--- a/Advanced/lessons/slides/day-06/day-06-session-6.html
+++ b/Advanced/lessons/slides/day-06/day-06-session-6.html
@@ -1,0 +1,1006 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 6 — Session 6 (Hours 21–24)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 6 — Session 6 (Hours 21–24)</h1>
+            <div class="subtitle">Python Programming (Advanced) • GUI CRUD Wiring, Architecture, and Milestone Readiness</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 6 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 21: Update and delete workflows in the GUI</li>
+  <li>Hour 22: Controller separation and callback cleanup</li>
+  <li>Hour 23: JSON persistence and GUI polish</li>
+  <li>Hour 24: Checkpoint 3 GUI milestone demo</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day goal</h1>
+            <ul>
+  <li>Turn a promising interface into a trustworthy mini-application</li>
+  <li>Keep stable IDs as the bridge between UI state and domain operations</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 6 overview (Hours 21–24); Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Session context --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis</h1>
+            <ul>
+  <li>Round-trip update/delete through the current source of truth</li>
+  <li>Refactor into a controller-style app structure</li>
+  <li>Add JSON load/save before the GUI checkpoint</li>
+  <li>Practice the demo path, not just isolated screenshots</li>
+</ul>
+<h3>Canonical quiz/contracts to recognize</h3>
+<ul>
+  <li><code>Hour 21 | selected id: task-002</code></li>
+  <li><code>Hour 22 | ui class: TrackerApp</code></li>
+  <li><code>Hour 23 | persistence hook: save on demand</code></li>
+  <li><code>Hour 24 | demo start: app opens cleanly</code></li>
+</ul>
+<p>&lt;!-- Sources: Advanced/assignments/Advanced_Day6_homework.ipynb — Part 1 through Part 4; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 21 through Hour 24 canonical contract questions --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 21: Update and Delete Workflows</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Use <strong>select → load → edit → save update</strong></li>
+  <li>Delete with confirmation</li>
+  <li>Refresh after each change</li>
+  <li>Handle missing-record cases cleanly</li>
+  <li>Target records by <strong>stable ID</strong>, not list index</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 21: CRUD wiring in GUI: update and delete workflows; Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Learning objectives --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Why Update/Delete Are Harder Than Add</h1>
+            <h3>Create</h3>
+<ul>
+  <li>Read form</li>
+  <li>Validate</li>
+  <li>Save new record</li>
+  <li>Refresh</li>
+</ul>
+<h3>Update/Delete</h3>
+<ul>
+  <li>Identify the correct record</li>
+  <li>Keep selection state accurate</li>
+  <li>Avoid stale widgets after refresh</li>
+  <li>Recover if the record is already gone</li>
+</ul>
+<blockquote>Display order is not identity. Stable IDs are.</blockquote>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Why add is easy and update/delete are trickier; Stable IDs: the core design choice --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Standard Update Flow</h1>
+            <ol>
+  <li>User selects a record</li>
+  <li>UI loads that record into the form</li>
+  <li>User edits fields</li>
+  <li>UI sends <code>selected_id</code> + form values to the service</li>
+  <li>Service updates the correct record</li>
+  <li>UI refreshes the list and resets state intentionally</li>
+</ol>
+<pre data-lang="python"><code>service.update_item(selected_id, name, category, status, notes)</code></pre>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Editing pattern: select -&gt; load into form -&gt; save update; Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Implement the standard GUI update flow --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Delete Flow and Confirmation</h1>
+            <h3>Delete path</h3>
+<ul>
+  <li>Detect a valid selection</li>
+  <li>Ask for confirmation</li>
+  <li>Delete by ID</li>
+  <li>Refresh the list</li>
+  <li>Clear stale form values and selection</li>
+</ul>
+<h3>User-facing rule</h3>
+<ul>
+  <li>Destructive actions should be explicit</li>
+  <li>“No selection” is a normal state to handle</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Confirm delete with messagebox; Delete workflow, step by step; Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Graceful error handling with <code>messagebox</code> --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Wiring Update + Delete</h1>
+            <h3>Instructor flow</h3>
+<ol>
+  <li>Select a record in <code>Treeview</code></li>
+  <li>Load values into the form</li>
+  <li>Update one field</li>
+  <li>Refresh and prove the correct record changed</li>
+  <li>Delete another record with confirmation</li>
+  <li>Show <code>NotFoundError</code> or missing-record handling gracefully</li>
+</ol>
+<h3>Watch for</h3>
+<ul>
+  <li>Which value is the true ID</li>
+  <li>What refresh does after each operation</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: update flow and delete confirmation; Show handling NotFoundError gracefully; Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Live demo guidance --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: GUI Update/Delete Round Trip</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Implement Update using the selected record</li>
+  <li>Implement Delete with confirmation</li>
+  <li>Refresh the list after each change</li>
+  <li>Clear or reset stale form state</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> Update works reliably</p>
+<p><span class="check">✓</span> Delete works reliably</p>
+<p><span class="check">✓</span> UI stays in sync after each change</p>
+<p><span class="check">✓</span> Selection maps to a stable ID</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Update/Delete; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 1: Hour 21 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 21)</h1>
+            <p><strong>⚠️</strong> Mutating stale widget state without reloading</p>
+<p><strong>⚠️</strong> Using list index as the real ID</p>
+<p><strong>⚠️</strong> Deleting while the UI still points at stale selection</p>
+<p><strong>⚠️</strong> Forgetting to refresh after update/delete</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is a stable ID better than relying on a visual row index?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 21 best practice and pitfall --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 22: GUI Architecture and Controller Separation</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Recognize callback spaghetti</li>
+  <li>Refactor toward an <code>App</code> / controller class</li>
+  <li>Keep callbacks thin</li>
+  <li>Separate widget creation from service logic</li>
+  <li>Manage selection and status state clearly</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 22: GUI architecture; Advanced/lessons/lecture/Day6_Hour2_Advanced.md — Learning objectives --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>What Callback Spaghetti Looks Like</h1>
+            <ul>
+  <li>Top-level functions with unclear ownership</li>
+  <li>Globals for widgets and selection state</li>
+  <li>Duplicate form-reading code</li>
+  <li>Duplicate refresh code</li>
+  <li>Business rules embedded directly in callbacks</li>
+  <li>Fragile bugs when state changes in one place but not another</li>
+</ul>
+<h3>Smell test</h3>
+<p>If adding one button means editing scattered unrelated code, structure is the problem.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day6_Hour2_Advanced.md — What callback spaghetti looks like --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Target Architecture</h1>
+            <h3>Model / domain</h3>
+<ul>
+  <li><code>TrackerItem</code></li>
+  <li>Exceptions</li>
+</ul>
+<h3>Service layer</h3>
+<ul>
+  <li>Add, update, delete, list, get by ID</li>
+</ul>
+<h3>UI / controller class</h3>
+<ul>
+  <li>Builds widgets</li>
+  <li>Reads form values</li>
+  <li>Calls the service</li>
+  <li>Refreshes the screen</li>
+  <li>Owns selection + status state</li>
+</ul>
+<pre data-lang="text"><code>widgets -&gt; App/controller -&gt; service -&gt; model</code></pre>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Thin UI callbacks call service layer; Advanced/lessons/lecture/Day6_Hour2_Advanced.md — The target structure for this capstone --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Refactor into `TrackerApp`</h1>
+            <h3>Refactor target methods</h3>
+<ul>
+  <li><code>build_ui()</code></li>
+  <li><code>refresh()</code></li>
+  <li><code>on_add()</code></li>
+  <li><code>on_update()</code></li>
+  <li><code>on_delete()</code></li>
+  <li><code>load_selected_record()</code></li>
+</ul>
+<h3>Key rule</h3>
+<ul>
+  <li>Change one boundary at a time</li>
+  <li>Preserve working behavior while cleaning structure</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Refactor to an App class with methods: build_ui(), refresh(), on_add(), on_delete(); Advanced/lessons/lecture/Day6_Hour2_Advanced.md — Refactoring into an <code>App</code> controller class --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Refactor Without Breaking Behavior</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create an <code>App</code> class that owns the UI</li>
+  <li>Move service calls out of widget construction code</li>
+  <li>Keep callbacks small and readable</li>
+  <li>Verify that behavior is unchanged after the refactor</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> Code is easier to read</p>
+<p><span class="check">✓</span> Functionality is preserved</p>
+<p><span class="check">✓</span> State ownership is clearer</p>
+<p><span class="check">✓</span> Circular imports are avoided</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Refactor GUI; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 2: Hour 22 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 22)</h1>
+            <p><strong>⚠️</strong> Over-refactoring midstream and breaking working code</p>
+<p><strong>⚠️</strong> Callback spaghetti hidden inside a class instead of removed</p>
+<p><strong>⚠️</strong> Circular imports between UI and service modules</p>
+<p><strong>⚠️</strong> Letting the controller become the business brain</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What is one sign that your GUI code needs refactoring?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 22 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 23: Persistence + Polish Sprint</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Load JSON on startup</li>
+  <li>Save after add/update/delete</li>
+  <li>Handle missing or invalid JSON gracefully</li>
+  <li>Add one small usability improvement</li>
+  <li>Prepare for a confident checkpoint demo</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 23: GUI mini-project sprint: persistence + polish; Advanced/lessons/lecture/Day6_Hour3_Advanced.md — Learning objectives --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Why JSON Is the Right Milestone Here</h1>
+            <ul>
+  <li>JSON is transparent and easy to inspect</li>
+  <li>JSON is portable and simple to debug</li>
+  <li>JSON is enough for <strong>this</strong> milestone</li>
+  <li>SQLite comes next session</li>
+</ul>
+<h3>Sequencing matters</h3>
+<ul>
+  <li>Good architecture today makes the storage swap easier tomorrow</li>
+  <li>Stability beats novelty in a checkpoint week</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day6_Hour3_Advanced.md — Why JSON now instead of SQLite now --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Persistence Hook Pattern</h1>
+            <h3>Minimum behavior</h3>
+<ul>
+  <li>Load on startup</li>
+  <li>Save after add</li>
+  <li>Save after update</li>
+  <li>Save after delete</li>
+</ul>
+<h3>Optional polish</h3>
+<ul>
+  <li>File menu</li>
+  <li>About/help dialog</li>
+  <li>Status bar message</li>
+  <li>Save shortcut such as <code>Ctrl+S</code></li>
+</ul>
+<p><strong>Quiz/homework cue</strong>: <code>Hour 23 | persistence hook: save on demand</code></p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Load data on startup; save after changes; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 3: Hour 23; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 23 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Load → Change → Save → Restart</h1>
+            <h3>Instructor flow</h3>
+<ol>
+  <li>Start the app and load records</li>
+  <li>Add or update one record</li>
+  <li>Save automatically or on demand</li>
+  <li>Restart the app</li>
+  <li>Prove data persisted</li>
+  <li>Show a calm error path for malformed JSON</li>
+</ol>
+<h3>Design takeaway</h3>
+<ul>
+  <li>Persistence is part of user trust</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: start app -&gt; load -&gt; add -&gt; save -&gt; restart -&gt; load; Advanced/lessons/lecture/Day6_Hour3_Advanced.md — Opening: why persistence changes the feel of an app --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Mini-Project Sprint</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add load on startup and save after CRUD</li>
+  <li>Handle missing/corrupt JSON without crashing</li>
+  <li>Add one usability improvement</li>
+  <li>Prepare a short milestone demo path</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> GUI persists data across runs</p>
+<p><span class="check">✓</span> User feedback is clear</p>
+<p><span class="check">✓</span> Core workflow works before visual polish</p>
+<p><span class="check">✓</span> Restart behavior is demonstrable</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: GUI milestone sprint; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 3: Hour 23 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 23)</h1>
+            <p><strong>⚠️</strong> Polishing visuals before save/load actually works</p>
+<p><strong>⚠️</strong> Forgetting to save after update/delete</p>
+<p><strong>⚠️</strong> Crashing on malformed JSON</p>
+<p><strong>⚠️</strong> Treating JSON as “temporary” and never testing restart behavior</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What usability improvement did you add that you would want in a real tool?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 23 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 24: Checkpoint 3 — GUI Milestone Demo</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Checkpoint outcome</h1>
+            <ul>
+  <li>Launch the GUI</li>
+  <li>Perform CRUD through the interface</li>
+  <li>Prove JSON persistence across restart</li>
+  <li>Explain where the service layer lives</li>
+  <li>Explain how the app finds the correct record for update/delete</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 24: Checkpoint 3: GUI milestone demo; Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Learning objectives --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Required Demo Path</h1>
+            <h3>Part A — Launch and orient</h3>
+<ul>
+  <li>Open the app cleanly</li>
+  <li>Point out form, list, and feedback area</li>
+</ul>
+<h3>Part B — CRUD</h3>
+<ul>
+  <li>Add a record</li>
+  <li>Update the correct record</li>
+  <li>Delete a record with confirmation</li>
+</ul>
+<h3>Part C — Persistence</h3>
+<ul>
+  <li>Save if needed</li>
+  <li>Close and reopen</li>
+  <li>Show that records reload</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Concrete learner demo prompt; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 24 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>What the Checkpoint Rubric Rewards</h1>
+            <ul>
+  <li>GUI works reliably</li>
+  <li>Persistence works reliably</li>
+  <li>Errors are handled reasonably</li>
+  <li>Callbacks are not doing all the business logic</li>
+  <li>Stable IDs are used instead of list positions</li>
+  <li>Learner can explain one next improvement</li>
+</ul>
+<h3>Best practice reminder</h3>
+<p>Checkpoint the <strong>full path</strong>, not isolated screenshots.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Concrete grading rubric; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 4: Hour 24 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Failure Modes to Triage</h1>
+            <h3>If restart loses data</h3>
+<ul>
+  <li>Check save path</li>
+  <li>Check JSON write timing</li>
+  <li>Check that list reloads from saved data</li>
+</ul>
+<h3>If update/delete hits the wrong record</h3>
+<ul>
+  <li>Print the selected ID</li>
+  <li>Verify the service method uses that ID</li>
+  <li>Confirm the UI cleared stale selection after refresh</li>
+</ul>
+<h3>If the demo feels fragile</h3>
+<ul>
+  <li>Simplify the path</li>
+  <li>Stabilize the required features first</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Common failure modes and triage guidance --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 6 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Strengthened</h1>
+            <ul>
+  <li>Real update/delete workflows</li>
+  <li>Cleaner GUI architecture</li>
+  <li>Persistence that survives restart</li>
+  <li>A concrete checkpoint story</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails</h1>
+            <p><span class="check">✓</span> Stable CRUD path</p>
+<p><span class="check">✓</span> JSON persistence for this milestone</p>
+<p><span class="check">✓</span> Clean UI/service boundary</p>
+<p><span class="check">✓</span> Demo-ready behavior</p>
+<p><span class="cross">✗</span> Not yet: database backend swap</p>
+<p><span class="cross">✗</span> Not required: heavy visual theming</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 6 overview; Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Debrief and next-step reflection --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Session 7 next:</p>
+<ul>
+  <li>From objects to tables</li>
+  <li>SQLite CRUD with safe queries</li>
+  <li>Row mapping and database hardening</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 7 overview (Hours 25–28) --&gt;</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/Advanced/lessons/slides/day-06/day-06-session-6.md
+++ b/Advanced/lessons/slides/day-06/day-06-session-6.md
@@ -1,0 +1,461 @@
+# Advanced Day 6 — Session 6 (Hours 21–24)
+Python Programming (Advanced) • GUI CRUD Wiring, Architecture, and Milestone Readiness
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 6 overview (Hours 21–24); Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Session context -->
+
+---
+
+# Session 6 Overview
+
+## Topics Covered Today
+- Hour 21: Update and delete workflows in the GUI
+- Hour 22: Controller separation and callback cleanup
+- Hour 23: JSON persistence and GUI polish
+- Hour 24: Checkpoint 3 GUI milestone demo
+
+## Day goal
+- Turn a promising interface into a trustworthy mini-application
+- Keep stable IDs as the bridge between UI state and domain operations
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 6 overview (Hours 21–24); Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Session context -->
+
+---
+
+## Homework + Quiz Emphasis
+
+- Round-trip update/delete through the current source of truth
+- Refactor into a controller-style app structure
+- Add JSON load/save before the GUI checkpoint
+- Practice the demo path, not just isolated screenshots
+
+### Canonical quiz/contracts to recognize
+- `Hour 21 | selected id: task-002`
+- `Hour 22 | ui class: TrackerApp`
+- `Hour 23 | persistence hook: save on demand`
+- `Hour 24 | demo start: app opens cleanly`
+
+<!-- Sources: Advanced/assignments/Advanced_Day6_homework.ipynb — Part 1 through Part 4; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 21 through Hour 24 canonical contract questions -->
+
+---
+
+# Hour 21: Update and Delete Workflows
+
+## Learning Outcomes
+- Use **select → load → edit → save update**
+- Delete with confirmation
+- Refresh after each change
+- Handle missing-record cases cleanly
+- Target records by **stable ID**, not list index
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 21: CRUD wiring in GUI: update and delete workflows; Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Learning objectives -->
+
+---
+
+## Why Update/Delete Are Harder Than Add
+
+### Create
+- Read form
+- Validate
+- Save new record
+- Refresh
+
+### Update/Delete
+- Identify the correct record
+- Keep selection state accurate
+- Avoid stale widgets after refresh
+- Recover if the record is already gone
+
+> Display order is not identity. Stable IDs are.
+
+<!-- Sources: Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Why add is easy and update/delete are trickier; Stable IDs: the core design choice -->
+
+---
+
+## Standard Update Flow
+
+1. User selects a record
+2. UI loads that record into the form
+3. User edits fields
+4. UI sends `selected_id` + form values to the service
+5. Service updates the correct record
+6. UI refreshes the list and resets state intentionally
+
+```python
+service.update_item(selected_id, name, category, status, notes)
+```
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Editing pattern: select -> load into form -> save update; Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Implement the standard GUI update flow -->
+
+---
+
+## Delete Flow and Confirmation
+
+### Delete path
+- Detect a valid selection
+- Ask for confirmation
+- Delete by ID
+- Refresh the list
+- Clear stale form values and selection
+
+### User-facing rule
+- Destructive actions should be explicit
+- “No selection” is a normal state to handle
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Confirm delete with messagebox; Delete workflow, step by step; Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Graceful error handling with `messagebox` -->
+
+---
+
+## Demo: Wiring Update + Delete
+
+### Instructor flow
+1. Select a record in `Treeview`
+2. Load values into the form
+3. Update one field
+4. Refresh and prove the correct record changed
+5. Delete another record with confirmation
+6. Show `NotFoundError` or missing-record handling gracefully
+
+### Watch for
+- Which value is the true ID
+- What refresh does after each operation
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: update flow and delete confirmation; Show handling NotFoundError gracefully; Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Live demo guidance -->
+
+---
+
+## Lab: GUI Update/Delete Round Trip
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Implement Update using the selected record
+- Implement Delete with confirmation
+- Refresh the list after each change
+- Clear or reset stale form state
+
+### Completion Criteria
+✓ Update works reliably  
+✓ Delete works reliably  
+✓ UI stays in sync after each change  
+✓ Selection maps to a stable ID
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Update/Delete; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 1: Hour 21 -->
+
+---
+
+## Common Pitfalls (Hour 21)
+
+⚠️ Mutating stale widget state without reloading  
+⚠️ Using list index as the real ID  
+⚠️ Deleting while the UI still points at stale selection  
+⚠️ Forgetting to refresh after update/delete
+
+## Quick Check
+**Question**: Why is a stable ID better than relying on a visual row index?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 21 best practice and pitfall -->
+
+---
+
+# Hour 22: GUI Architecture and Controller Separation
+
+## Learning Outcomes
+- Recognize callback spaghetti
+- Refactor toward an `App` / controller class
+- Keep callbacks thin
+- Separate widget creation from service logic
+- Manage selection and status state clearly
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 22: GUI architecture; Advanced/lessons/lecture/Day6_Hour2_Advanced.md — Learning objectives -->
+
+---
+
+## What Callback Spaghetti Looks Like
+
+- Top-level functions with unclear ownership
+- Globals for widgets and selection state
+- Duplicate form-reading code
+- Duplicate refresh code
+- Business rules embedded directly in callbacks
+- Fragile bugs when state changes in one place but not another
+
+### Smell test
+If adding one button means editing scattered unrelated code, structure is the problem.
+
+<!-- Sources: Advanced/lessons/lecture/Day6_Hour2_Advanced.md — What callback spaghetti looks like -->
+
+---
+
+## Target Architecture
+
+### Model / domain
+- `TrackerItem`
+- Exceptions
+
+### Service layer
+- Add, update, delete, list, get by ID
+
+### UI / controller class
+- Builds widgets
+- Reads form values
+- Calls the service
+- Refreshes the screen
+- Owns selection + status state
+
+```text
+widgets -> App/controller -> service -> model
+```
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Thin UI callbacks call service layer; Advanced/lessons/lecture/Day6_Hour2_Advanced.md — The target structure for this capstone -->
+
+---
+
+## Demo: Refactor into `TrackerApp`
+
+### Refactor target methods
+- `build_ui()`
+- `refresh()`
+- `on_add()`
+- `on_update()`
+- `on_delete()`
+- `load_selected_record()`
+
+### Key rule
+- Change one boundary at a time
+- Preserve working behavior while cleaning structure
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Refactor to an App class with methods: build_ui(), refresh(), on_add(), on_delete(); Advanced/lessons/lecture/Day6_Hour2_Advanced.md — Refactoring into an `App` controller class -->
+
+---
+
+## Lab: Refactor Without Breaking Behavior
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Create an `App` class that owns the UI
+- Move service calls out of widget construction code
+- Keep callbacks small and readable
+- Verify that behavior is unchanged after the refactor
+
+### Completion Criteria
+✓ Code is easier to read  
+✓ Functionality is preserved  
+✓ State ownership is clearer  
+✓ Circular imports are avoided
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Refactor GUI; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 2: Hour 22 -->
+
+---
+
+## Common Pitfalls (Hour 22)
+
+⚠️ Over-refactoring midstream and breaking working code  
+⚠️ Callback spaghetti hidden inside a class instead of removed  
+⚠️ Circular imports between UI and service modules  
+⚠️ Letting the controller become the business brain
+
+## Quick Check
+**Question**: What is one sign that your GUI code needs refactoring?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 22 explanation -->
+
+---
+
+# Hour 23: Persistence + Polish Sprint
+
+## Learning Outcomes
+- Load JSON on startup
+- Save after add/update/delete
+- Handle missing or invalid JSON gracefully
+- Add one small usability improvement
+- Prepare for a confident checkpoint demo
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 23: GUI mini-project sprint: persistence + polish; Advanced/lessons/lecture/Day6_Hour3_Advanced.md — Learning objectives -->
+
+---
+
+## Why JSON Is the Right Milestone Here
+
+- JSON is transparent and easy to inspect
+- JSON is portable and simple to debug
+- JSON is enough for **this** milestone
+- SQLite comes next session
+
+### Sequencing matters
+- Good architecture today makes the storage swap easier tomorrow
+- Stability beats novelty in a checkpoint week
+
+<!-- Sources: Advanced/lessons/lecture/Day6_Hour3_Advanced.md — Why JSON now instead of SQLite now -->
+
+---
+
+## Persistence Hook Pattern
+
+### Minimum behavior
+- Load on startup
+- Save after add
+- Save after update
+- Save after delete
+
+### Optional polish
+- File menu
+- About/help dialog
+- Status bar message
+- Save shortcut such as `Ctrl+S`
+
+**Quiz/homework cue**: `Hour 23 | persistence hook: save on demand`
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Load data on startup; save after changes; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 3: Hour 23; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 23 canonical contract -->
+
+---
+
+## Demo: Load → Change → Save → Restart
+
+### Instructor flow
+1. Start the app and load records
+2. Add or update one record
+3. Save automatically or on demand
+4. Restart the app
+5. Prove data persisted
+6. Show a calm error path for malformed JSON
+
+### Design takeaway
+- Persistence is part of user trust
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: start app -> load -> add -> save -> restart -> load; Advanced/lessons/lecture/Day6_Hour3_Advanced.md — Opening: why persistence changes the feel of an app -->
+
+---
+
+## Lab: Mini-Project Sprint
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Add load on startup and save after CRUD
+- Handle missing/corrupt JSON without crashing
+- Add one usability improvement
+- Prepare a short milestone demo path
+
+### Completion Criteria
+✓ GUI persists data across runs  
+✓ User feedback is clear  
+✓ Core workflow works before visual polish  
+✓ Restart behavior is demonstrable
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: GUI milestone sprint; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 3: Hour 23 -->
+
+---
+
+## Common Pitfalls (Hour 23)
+
+⚠️ Polishing visuals before save/load actually works  
+⚠️ Forgetting to save after update/delete  
+⚠️ Crashing on malformed JSON  
+⚠️ Treating JSON as “temporary” and never testing restart behavior
+
+## Quick Check
+**Question**: What usability improvement did you add that you would want in a real tool?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 23 explanation -->
+
+---
+
+# Hour 24: Checkpoint 3 — GUI Milestone Demo
+
+## Checkpoint outcome
+- Launch the GUI
+- Perform CRUD through the interface
+- Prove JSON persistence across restart
+- Explain where the service layer lives
+- Explain how the app finds the correct record for update/delete
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 24: Checkpoint 3: GUI milestone demo; Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Learning objectives -->
+
+---
+
+## Required Demo Path
+
+### Part A — Launch and orient
+- Open the app cleanly
+- Point out form, list, and feedback area
+
+### Part B — CRUD
+- Add a record
+- Update the correct record
+- Delete a record with confirmation
+
+### Part C — Persistence
+- Save if needed
+- Close and reopen
+- Show that records reload
+
+<!-- Sources: Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Concrete learner demo prompt; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 24 canonical contract -->
+
+---
+
+## What the Checkpoint Rubric Rewards
+
+- GUI works reliably
+- Persistence works reliably
+- Errors are handled reasonably
+- Callbacks are not doing all the business logic
+- Stable IDs are used instead of list positions
+- Learner can explain one next improvement
+
+### Best practice reminder
+Checkpoint the **full path**, not isolated screenshots.
+
+<!-- Sources: Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Concrete grading rubric; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 4: Hour 24 -->
+
+---
+
+## Common Failure Modes to Triage
+
+### If restart loses data
+- Check save path
+- Check JSON write timing
+- Check that list reloads from saved data
+
+### If update/delete hits the wrong record
+- Print the selected ID
+- Verify the service method uses that ID
+- Confirm the UI cleared stale selection after refresh
+
+### If the demo feels fragile
+- Simplify the path
+- Stabilize the required features first
+
+<!-- Sources: Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Common failure modes and triage guidance -->
+
+---
+
+# Session 6 Wrap-Up
+
+## What We Strengthened
+- Real update/delete workflows
+- Cleaner GUI architecture
+- Persistence that survives restart
+- A concrete checkpoint story
+
+## Scope Guardrails
+✓ Stable CRUD path  
+✓ JSON persistence for this milestone  
+✓ Clean UI/service boundary  
+✓ Demo-ready behavior
+
+✗ Not yet: database backend swap  
+✗ Not required: heavy visual theming
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 6 overview; Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Debrief and next-step reflection -->
+
+---
+
+# Thank You!
+
+Session 7 next:
+- From objects to tables
+- SQLite CRUD with safe queries
+- Row mapping and database hardening
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 7 overview (Hours 25–28) -->

--- a/Advanced/lessons/slides/day-07/day-07-session-7.html
+++ b/Advanced/lessons/slides/day-07/day-07-session-7.html
@@ -1,0 +1,1007 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 7 — Session 7 (Hours 25–28)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 7 — Session 7 (Hours 25–28)</h1>
+            <div class="subtitle">Python Programming (Advanced) • From Objects to Tables with SQLite</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 7 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 25: Schema thinking + repository boundary</li>
+  <li>Hour 26: <code>sqlite3</code> CRUD with parameterized queries</li>
+  <li>Hour 27: Row mapping back into domain objects</li>
+  <li>Hour 28: Transactions, integrity, and <code>init_db()</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Today&#x27;s milestone</h1>
+            <ul>
+  <li>Move from JSON-ready architecture to database-ready architecture</li>
+  <li>Keep the service layer clean while the repository absorbs SQL details</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 7 overview (Hours 25–28); Advanced/lessons/lecture/Day7_Hour2_Advanced.md — Opening Script --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis</h1>
+            <ul>
+  <li>Design the table from the domain model before coding</li>
+  <li>Use parameter placeholders for every query with values</li>
+  <li>Centralize row-to-object mapping</li>
+  <li>Make startup safe with <code>init_db()</code> and meaningful constraints</li>
+</ul>
+<h3>Canonical quiz/contracts to recognize</h3>
+<ul>
+  <li><code>Hour 25 | table name: tasks</code></li>
+  <li><code>Hour 26 | insert result: task-101 saved</code></li>
+  <li><code>Hour 27 | row type: sqlite3.Row</code></li>
+  <li><code>Hour 28 | init script: schema ready</code></li>
+</ul>
+<p>&lt;!-- Sources: Advanced/assignments/Advanced_Day7_homework.ipynb — Part 1 through Part 4; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 25 through Hour 28 canonical contract questions --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 25: Schema Thinking + Repository Idea</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Map object attributes to table columns</li>
+  <li>Choose a stable primary key</li>
+  <li>Decide what is required vs optional</li>
+  <li>Name the CRUD operations before writing SQL</li>
+  <li>Define a repository interface for the core record type</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 25: From objects to tables: schema thinking + repository idea; Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Learning Outcomes --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>From Object Shape to Table Shape</h1>
+            <h3>Python view</h3>
+<pre data-lang="python"><code>@dataclass(slots=True)
+class Expense:
+    expense_id: int
+    title: str
+    amount: float
+    category: str
+    spent_on: date
+    notes: str | None = None</code></pre>
+<h3>Database view</h3>
+<ul>
+  <li>One object ≈ one row</li>
+  <li>Attributes ≈ columns</li>
+  <li>Collection ≈ table</li>
+  <li>Stable ID ≈ primary key</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Schema Thinking: From One Object to One Row --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Draft the Schema Before the CRUD Code</h1>
+            <pre data-lang="sql"><code>CREATE TABLE expenses (
+    expense_id INTEGER PRIMARY KEY,
+    title TEXT NOT NULL,
+    amount REAL NOT NULL,
+    category TEXT NOT NULL,
+    spent_on TEXT NOT NULL,
+    notes TEXT
+);</code></pre>
+<h3>Design questions to answer first</h3>
+<ul>
+  <li>Which fields are required?</li>
+  <li>Which fields are optional?</li>
+  <li>Which field is true identity?</li>
+  <li>Which values are derived vs stored?</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Table Design: Columns, Primary Keys, and Constraints --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Why a Repository Boundary Helps</h1>
+            <ul>
+  <li>Service code should ask for behaviors, not write SQL directly</li>
+  <li>Repository isolates DB details</li>
+  <li>Later storage changes are less disruptive</li>
+  <li>Tests can target repository or service behavior more cleanly</li>
+</ul>
+<h3>Repository sketch</h3>
+<pre data-lang="python"><code>class ExpenseRepository(Protocol):
+    def add(self, item: NewExpense) -&gt; Expense: ...
+    def list_all(self) -&gt; list[Expense]: ...
+    def get_by_id(self, expense_id: int) -&gt; Expense | None: ...</code></pre>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Repository isolates DB details; Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Repository idea --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Design Schema + Interface</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Draft a schema for your tracker&#x27;s main record</li>
+  <li>Choose a stable ID type</li>
+  <li>List the CRUD methods the app will need</li>
+  <li>Write a repository interface or stub class</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> Schema draft exists</p>
+<p><span class="check">✓</span> Repository methods are defined</p>
+<p><span class="check">✓</span> Required vs optional fields are explicit</p>
+<p><span class="check">✓</span> Update/delete are planned around IDs</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Design schema; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 1: Hour 25 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>DB Quality Gate (Starts Now)</h1>
+            <ul>
+  <li>All SQL uses <code>?</code> placeholders — no string concatenation</li>
+  <li>DB writes are committed via context manager or explicit <code>commit()</code></li>
+  <li>Every table has a stable primary key</li>
+  <li>Update/delete always target IDs</li>
+  <li>Log or print the target ID during early debugging</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is a repository useful even for a small project?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — DB Quality Gate; Quick check / exit ticket; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 25 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 26: `sqlite3` CRUD with Parameterized Queries</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Create/connect to a database file</li>
+  <li>Use <code>CREATE TABLE IF NOT EXISTS</code></li>
+  <li>Insert and list records safely</li>
+  <li>Understand why <code>?</code> placeholders matter</li>
+  <li>Debug missing commits and DB-path mistakes</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 26: sqlite3 CRUD with parameterized queries; Advanced/lessons/lecture/Day7_Hour2_Advanced.md — Learning Outcomes --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>`sqlite3` Fundamentals</h1>
+            <pre data-lang="python"><code>from pathlib import Path
+import sqlite3
+
+db_path = Path(&quot;data&quot;) / &quot;expenses.db&quot;
+db_path.parent.mkdir(exist_ok=True)
+
+with sqlite3.connect(db_path) as connection:
+    print(&quot;Connected.&quot;)</code></pre>
+<h3>Key ideas</h3>
+<ul>
+  <li>SQLite is just a file on disk</li>
+  <li>Use <code>pathlib</code> for paths</li>
+  <li>Use a context manager for safer commit/rollback behavior</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour2_Advanced.md — sqlite3 Fundamentals --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Safe SQL: Use Parameters, Not String Building</h1>
+            <h3>Avoid</h3>
+<pre data-lang="python"><code>unsafe_sql = f&quot;SELECT * FROM expenses WHERE title = &#x27;{user_title}&#x27;&quot;</code></pre>
+<h3>Prefer</h3>
+<pre data-lang="python"><code>safe_sql = &quot;SELECT * FROM expenses WHERE title = ?&quot;
+rows = connection.execute(safe_sql, (&quot;Lunch&quot;,)).fetchall()</code></pre>
+<h3>Why</h3>
+<ul>
+  <li>Safer quoting/escaping</li>
+  <li>Lower injection risk</li>
+  <li>More predictable query structure</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour2_Advanced.md — Parameterized Queries: The Safety Rule of the Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: First SQLite Repository Methods</h1>
+            <h3>Demo flow</h3>
+<ol>
+  <li>Create the DB file</li>
+  <li>Create the table with <code>IF NOT EXISTS</code></li>
+  <li>Implement <code>add()</code></li>
+  <li>Implement <code>list_all()</code></li>
+  <li>Print the DB path and inserted result</li>
+</ol>
+<p><strong>Quiz/homework cue</strong>: <code>Hour 26 | insert result: task-101 saved</code></p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: create db file; create table; insert one row; select rows; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 2: Hour 26; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 26 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: First SQLite Integration</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create a DB file in <code>data/</code></li>
+  <li>Create the table</li>
+  <li>Implement <code>repo.add()</code></li>
+  <li>Implement <code>repo.list_all()</code></li>
+  <li>Print results to confirm real persistence</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> DB file created</p>
+<p><span class="check">✓</span> Insert and list work</p>
+<p><span class="check">✓</span> Queries use parameters</p>
+<p><span class="check">✓</span> Writes are committed</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: First SQLite integration; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 2: Hour 26 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 26)</h1>
+            <p><strong>⚠️</strong> Forgetting <code>commit()</code> / assuming the write stuck</p>
+<p><strong>⚠️</strong> String-formatting SQL</p>
+<p><strong>⚠️</strong> Writing to one DB file and reading from another</p>
+<p><strong>⚠️</strong> Skipping the DB path print during debugging</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What does the <code>?</code> placeholder do in <code>sqlite3</code>?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 26 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 27: Row Mapping Back into Objects</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Convert rows into dataclass/domain objects</li>
+  <li>Use <code>sqlite3.Row</code> for readable mapping</li>
+  <li>Implement <code>get_by_id</code>, <code>update</code>, and <code>delete</code></li>
+  <li>Convert stored text back into richer Python types</li>
+  <li>Surface missing-record errors clearly</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 27: Row mapping: converting rows to objects; Advanced/lessons/lecture/Day7_Hour3_Advanced.md — Learning Outcomes --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Why Raw Rows Are Not Enough</h1>
+            <pre data-lang="python"><code>(1, &quot;Coffee beans&quot;, 18.5, &quot;Groceries&quot;, &quot;2026-01-13&quot;, &quot;Medium roast&quot;)</code></pre>
+<h3>Problems with raw tuples</h3>
+<ul>
+  <li>Callers must remember column order</li>
+  <li>Type conversion gets repeated</li>
+  <li>Storage details leak upward</li>
+  <li>Small schema changes become fragile</li>
+</ul>
+<h3>Better goal</h3>
+<p>Return domain objects from the repository.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour3_Advanced.md — Opening Script: Why Raw Rows Are Not Enough --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Use `sqlite3.Row` + a Mapping Helper</h1>
+            <pre data-lang="python"><code>connection.row_factory = sqlite3.Row
+
+def from_row(row: sqlite3.Row) -&gt; Expense:
+    return Expense(
+        expense_id=row[&quot;expense_id&quot;],
+        title=row[&quot;title&quot;],
+        amount=row[&quot;amount&quot;],
+        category=row[&quot;category&quot;],
+        spent_on=date.fromisoformat(row[&quot;spent_on&quot;]),
+        notes=row[&quot;notes&quot;],
+    )</code></pre>
+<h3>Rule</h3>
+<p>Keep mapping logic in one place.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour3_Advanced.md — Mapping Options: Tuple Order versus Named Columns; Centralize the mapping helper --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Complete CRUD with Mapped Objects</h1>
+            <h3>Demo flow</h3>
+<ul>
+  <li>Set <code>row_factory</code></li>
+  <li>Implement <code>list_all()</code> and <code>get_by_id()</code></li>
+  <li>Implement <code>update()</code> with a <code>WHERE</code> clause</li>
+  <li>Implement <code>delete()</code></li>
+  <li>Re-read or check affected row count after update</li>
+  <li>Raise <code>NotFoundError</code> at the service layer when needed</li>
+</ul>
+<h3>Watch for</h3>
+<ul>
+  <li>Mismatched column names/order</li>
+  <li>Missing <code>WHERE</code> in <code>UPDATE</code></li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: repo.get_by_id returns a model object; Show NotFoundError when no row; Advanced/lessons/lecture/Day7_Hour3_Advanced.md — Live Demo Part 1 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Finish Repo CRUD</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Implement <code>get_by_id</code></li>
+  <li>Implement <code>update</code></li>
+  <li>Implement <code>delete</code></li>
+  <li>Ensure service code handles missing records clearly</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> CRUD repository methods are complete</p>
+<p><span class="check">✓</span> Row mapping is centralized</p>
+<p><span class="check">✓</span> Service layer handles missing IDs</p>
+<p><span class="check">✓</span> Update/delete target the correct row</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Implement get/update/delete; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 3: Hour 27 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 27)</h1>
+            <p><strong>⚠️</strong> Leaking raw tuples to the rest of the app</p>
+<p><strong>⚠️</strong> Mismatched column ordering/names</p>
+<p><strong>⚠️</strong> <code>UPDATE</code> without <code>WHERE</code></p>
+<p><strong>⚠️</strong> Forgetting to verify that the intended row changed</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What is the fastest safe way to confirm your <code>UPDATE</code> query worked?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 27 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 28: Transactions, Integrity, and `init_db()`</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain transactions in practical terms</li>
+  <li>Use context-manager commits/rollbacks</li>
+  <li>Write an idempotent <code>init_db()</code></li>
+  <li>Add a small set of meaningful constraints</li>
+  <li>Remember the SQLite foreign key reminder</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 28: Transactions + integrity + initialization patterns; Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Learning Outcomes --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Reliability Means More Than “It Worked Once”</h1>
+            <h3>A trustworthy DB layer has:</h3>
+<ol>
+  <li>Predictable startup</li>
+  <li>Structural guardrails against bad data</li>
+  <li>Multi-step writes that succeed together or fail together</li>
+</ol>
+<h3>Plain-language transaction rule</h3>
+<p>Either <strong>all</strong> related writes happen, or <strong>none</strong> of them do.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Opening Script: From Working to Reliable; Transactions in Plain English --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Safe Initialization Pattern</h1>
+            <pre data-lang="python"><code>def init_db(db_path: Path) -&gt; None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with connect(db_path) as connection:
+        connection.execute(create_table_sql)</code></pre>
+<h3>Why `init_db()` matters</h3>
+<ul>
+  <li>Startup becomes predictable</li>
+  <li>Schema creation is safe to repeat</li>
+  <li>New environments require less manual setup</li>
+</ul>
+<h3>Integrity examples</h3>
+<ul>
+  <li><code>NOT NULL</code></li>
+  <li><code>CHECK(amount &gt;= 0)</code></li>
+  <li>Stable primary key</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: init_db() function and calling it once at startup; Add basic constraints (NOT NULL for required fields); Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Live Demo Part 1 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Hardening the DB Layer</h1>
+            <h3>Demo flow</h3>
+<ul>
+  <li>Create <code>connect()</code> helper</li>
+  <li>Enable <code>PRAGMA foreign_keys = ON</code></li>
+  <li>Run <code>init_db()</code> on startup</li>
+  <li>Show one grouped transaction</li>
+  <li>Demonstrate rollback on failure</li>
+</ul>
+<p><strong>Quiz/homework cue</strong>: <code>Hour 28 | init script: schema ready</code></p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Mention foreign keys lightly and accurately; Live Demo Part 1; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 28 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Hardening Sprint</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Write <code>init_db(db_path)</code></li>
+  <li>Ensure it is safe to run more than once</li>
+  <li>Add basic constraints</li>
+  <li>Test one failure path in a grouped write</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> DB initializes reliably</p>
+<p><span class="check">✓</span> Constraints protect storage</p>
+<p><span class="check">✓</span> Grouped writes behave predictably</p>
+<p><span class="check">✓</span> Startup is calmer and more repeatable</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Hardening DB layer; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 4: Hour 28 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 28)</h1>
+            <p><strong>⚠️</strong> Partially applied writes</p>
+<p><strong>⚠️</strong> Schema drift after code changes</p>
+<p><strong>⚠️</strong> Assuming foreign keys are on automatically</p>
+<p><strong>⚠️</strong> Manual setup steps hidden outside startup</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why should <code>init_db()</code> be safe to run multiple times?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 28 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 7 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Added</h1>
+            <ul>
+  <li>Table-first thinking</li>
+  <li>Safe <code>sqlite3</code> CRUD</li>
+  <li>Clean row mapping</li>
+  <li>More dependable startup and writes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails</h1>
+            <p><span class="check">✓</span> Standard-library SQLite</p>
+<p><span class="check">✓</span> Parameterized SQL</p>
+<p><span class="check">✓</span> Repository boundary</p>
+<p><span class="check">✓</span> Practical constraints and transactions</p>
+<p><span class="cross">✗</span> Not today: ORM migration frameworks</p>
+<p><span class="cross">✗</span> Not required: multi-table deep design</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Instructor note; Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Instructor note --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Session 8 next:</p>
+<ul>
+  <li>Deeper SQL or tiny ORM exposure</li>
+  <li>Plug SQLite into the app</li>
+  <li>Search, pagination, and the data-driven checkpoint</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 8 overview (Hours 29–32) --&gt;</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/Advanced/lessons/slides/day-07/day-07-session-7.md
+++ b/Advanced/lessons/slides/day-07/day-07-session-7.md
@@ -1,0 +1,496 @@
+# Advanced Day 7 — Session 7 (Hours 25–28)
+Python Programming (Advanced) • From Objects to Tables with SQLite
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 7 overview (Hours 25–28); Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Instructor Notes -->
+
+---
+
+# Session 7 Overview
+
+## Topics Covered Today
+- Hour 25: Schema thinking + repository boundary
+- Hour 26: `sqlite3` CRUD with parameterized queries
+- Hour 27: Row mapping back into domain objects
+- Hour 28: Transactions, integrity, and `init_db()`
+
+## Today's milestone
+- Move from JSON-ready architecture to database-ready architecture
+- Keep the service layer clean while the repository absorbs SQL details
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 7 overview (Hours 25–28); Advanced/lessons/lecture/Day7_Hour2_Advanced.md — Opening Script -->
+
+---
+
+## Homework + Quiz Emphasis
+
+- Design the table from the domain model before coding
+- Use parameter placeholders for every query with values
+- Centralize row-to-object mapping
+- Make startup safe with `init_db()` and meaningful constraints
+
+### Canonical quiz/contracts to recognize
+- `Hour 25 | table name: tasks`
+- `Hour 26 | insert result: task-101 saved`
+- `Hour 27 | row type: sqlite3.Row`
+- `Hour 28 | init script: schema ready`
+
+<!-- Sources: Advanced/assignments/Advanced_Day7_homework.ipynb — Part 1 through Part 4; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 25 through Hour 28 canonical contract questions -->
+
+---
+
+# Hour 25: Schema Thinking + Repository Idea
+
+## Learning Outcomes
+- Map object attributes to table columns
+- Choose a stable primary key
+- Decide what is required vs optional
+- Name the CRUD operations before writing SQL
+- Define a repository interface for the core record type
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 25: From objects to tables: schema thinking + repository idea; Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Learning Outcomes -->
+
+---
+
+## From Object Shape to Table Shape
+
+### Python view
+```python
+@dataclass(slots=True)
+class Expense:
+    expense_id: int
+    title: str
+    amount: float
+    category: str
+    spent_on: date
+    notes: str | None = None
+```
+
+### Database view
+- One object ≈ one row
+- Attributes ≈ columns
+- Collection ≈ table
+- Stable ID ≈ primary key
+
+<!-- Sources: Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Schema Thinking: From One Object to One Row -->
+
+---
+
+## Draft the Schema Before the CRUD Code
+
+```sql
+CREATE TABLE expenses (
+    expense_id INTEGER PRIMARY KEY,
+    title TEXT NOT NULL,
+    amount REAL NOT NULL,
+    category TEXT NOT NULL,
+    spent_on TEXT NOT NULL,
+    notes TEXT
+);
+```
+
+### Design questions to answer first
+- Which fields are required?
+- Which fields are optional?
+- Which field is true identity?
+- Which values are derived vs stored?
+
+<!-- Sources: Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Table Design: Columns, Primary Keys, and Constraints -->
+
+---
+
+## Why a Repository Boundary Helps
+
+- Service code should ask for behaviors, not write SQL directly
+- Repository isolates DB details
+- Later storage changes are less disruptive
+- Tests can target repository or service behavior more cleanly
+
+### Repository sketch
+```python
+class ExpenseRepository(Protocol):
+    def add(self, item: NewExpense) -> Expense: ...
+    def list_all(self) -> list[Expense]: ...
+    def get_by_id(self, expense_id: int) -> Expense | None: ...
+```
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Repository isolates DB details; Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Repository idea -->
+
+---
+
+## Lab: Design Schema + Interface
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Draft a schema for your tracker's main record
+- Choose a stable ID type
+- List the CRUD methods the app will need
+- Write a repository interface or stub class
+
+### Completion Criteria
+✓ Schema draft exists  
+✓ Repository methods are defined  
+✓ Required vs optional fields are explicit  
+✓ Update/delete are planned around IDs
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Design schema; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 1: Hour 25 -->
+
+---
+
+## DB Quality Gate (Starts Now)
+
+* All SQL uses `?` placeholders — no string concatenation  
+* DB writes are committed via context manager or explicit `commit()`  
+* Every table has a stable primary key  
+* Update/delete always target IDs  
+* Log or print the target ID during early debugging
+
+## Quick Check
+**Question**: Why is a repository useful even for a small project?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — DB Quality Gate; Quick check / exit ticket; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 25 explanation -->
+
+---
+
+# Hour 26: `sqlite3` CRUD with Parameterized Queries
+
+## Learning Outcomes
+- Create/connect to a database file
+- Use `CREATE TABLE IF NOT EXISTS`
+- Insert and list records safely
+- Understand why `?` placeholders matter
+- Debug missing commits and DB-path mistakes
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 26: sqlite3 CRUD with parameterized queries; Advanced/lessons/lecture/Day7_Hour2_Advanced.md — Learning Outcomes -->
+
+---
+
+## `sqlite3` Fundamentals
+
+```python
+from pathlib import Path
+import sqlite3
+
+db_path = Path("data") / "expenses.db"
+db_path.parent.mkdir(exist_ok=True)
+
+with sqlite3.connect(db_path) as connection:
+    print("Connected.")
+```
+
+### Key ideas
+- SQLite is just a file on disk
+- Use `pathlib` for paths
+- Use a context manager for safer commit/rollback behavior
+
+<!-- Sources: Advanced/lessons/lecture/Day7_Hour2_Advanced.md — sqlite3 Fundamentals -->
+
+---
+
+## Safe SQL: Use Parameters, Not String Building
+
+### Avoid
+```python
+unsafe_sql = f"SELECT * FROM expenses WHERE title = '{user_title}'"
+```
+
+### Prefer
+```python
+safe_sql = "SELECT * FROM expenses WHERE title = ?"
+rows = connection.execute(safe_sql, ("Lunch",)).fetchall()
+```
+
+### Why
+- Safer quoting/escaping
+- Lower injection risk
+- More predictable query structure
+
+<!-- Sources: Advanced/lessons/lecture/Day7_Hour2_Advanced.md — Parameterized Queries: The Safety Rule of the Hour -->
+
+---
+
+## Demo: First SQLite Repository Methods
+
+### Demo flow
+1. Create the DB file
+2. Create the table with `IF NOT EXISTS`
+3. Implement `add()`
+4. Implement `list_all()`
+5. Print the DB path and inserted result
+
+**Quiz/homework cue**: `Hour 26 | insert result: task-101 saved`
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: create db file; create table; insert one row; select rows; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 2: Hour 26; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 26 canonical contract -->
+
+---
+
+## Lab: First SQLite Integration
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Create a DB file in `data/`
+- Create the table
+- Implement `repo.add()`
+- Implement `repo.list_all()`
+- Print results to confirm real persistence
+
+### Completion Criteria
+✓ DB file created  
+✓ Insert and list work  
+✓ Queries use parameters  
+✓ Writes are committed
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: First SQLite integration; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 2: Hour 26 -->
+
+---
+
+## Common Pitfalls (Hour 26)
+
+⚠️ Forgetting `commit()` / assuming the write stuck  
+⚠️ String-formatting SQL  
+⚠️ Writing to one DB file and reading from another  
+⚠️ Skipping the DB path print during debugging
+
+## Quick Check
+**Question**: What does the `?` placeholder do in `sqlite3`?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 26 explanation -->
+
+---
+
+# Hour 27: Row Mapping Back into Objects
+
+## Learning Outcomes
+- Convert rows into dataclass/domain objects
+- Use `sqlite3.Row` for readable mapping
+- Implement `get_by_id`, `update`, and `delete`
+- Convert stored text back into richer Python types
+- Surface missing-record errors clearly
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 27: Row mapping: converting rows to objects; Advanced/lessons/lecture/Day7_Hour3_Advanced.md — Learning Outcomes -->
+
+---
+
+## Why Raw Rows Are Not Enough
+
+```python
+(1, "Coffee beans", 18.5, "Groceries", "2026-01-13", "Medium roast")
+```
+
+### Problems with raw tuples
+- Callers must remember column order
+- Type conversion gets repeated
+- Storage details leak upward
+- Small schema changes become fragile
+
+### Better goal
+Return domain objects from the repository.
+
+<!-- Sources: Advanced/lessons/lecture/Day7_Hour3_Advanced.md — Opening Script: Why Raw Rows Are Not Enough -->
+
+---
+
+## Use `sqlite3.Row` + a Mapping Helper
+
+```python
+connection.row_factory = sqlite3.Row
+
+def from_row(row: sqlite3.Row) -> Expense:
+    return Expense(
+        expense_id=row["expense_id"],
+        title=row["title"],
+        amount=row["amount"],
+        category=row["category"],
+        spent_on=date.fromisoformat(row["spent_on"]),
+        notes=row["notes"],
+    )
+```
+
+### Rule
+Keep mapping logic in one place.
+
+<!-- Sources: Advanced/lessons/lecture/Day7_Hour3_Advanced.md — Mapping Options: Tuple Order versus Named Columns; Centralize the mapping helper -->
+
+---
+
+## Demo: Complete CRUD with Mapped Objects
+
+### Demo flow
+- Set `row_factory`
+- Implement `list_all()` and `get_by_id()`
+- Implement `update()` with a `WHERE` clause
+- Implement `delete()`
+- Re-read or check affected row count after update
+- Raise `NotFoundError` at the service layer when needed
+
+### Watch for
+- Mismatched column names/order
+- Missing `WHERE` in `UPDATE`
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: repo.get_by_id returns a model object; Show NotFoundError when no row; Advanced/lessons/lecture/Day7_Hour3_Advanced.md — Live Demo Part 1 -->
+
+---
+
+## Lab: Finish Repo CRUD
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Implement `get_by_id`
+- Implement `update`
+- Implement `delete`
+- Ensure service code handles missing records clearly
+
+### Completion Criteria
+✓ CRUD repository methods are complete  
+✓ Row mapping is centralized  
+✓ Service layer handles missing IDs  
+✓ Update/delete target the correct row
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Implement get/update/delete; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 3: Hour 27 -->
+
+---
+
+## Common Pitfalls (Hour 27)
+
+⚠️ Leaking raw tuples to the rest of the app  
+⚠️ Mismatched column ordering/names  
+⚠️ `UPDATE` without `WHERE`  
+⚠️ Forgetting to verify that the intended row changed
+
+## Quick Check
+**Question**: What is the fastest safe way to confirm your `UPDATE` query worked?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 27 explanation -->
+
+---
+
+# Hour 28: Transactions, Integrity, and `init_db()`
+
+## Learning Outcomes
+- Explain transactions in practical terms
+- Use context-manager commits/rollbacks
+- Write an idempotent `init_db()`
+- Add a small set of meaningful constraints
+- Remember the SQLite foreign key reminder
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 28: Transactions + integrity + initialization patterns; Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Learning Outcomes -->
+
+---
+
+## Reliability Means More Than “It Worked Once”
+
+### A trustworthy DB layer has:
+1. Predictable startup
+2. Structural guardrails against bad data
+3. Multi-step writes that succeed together or fail together
+
+### Plain-language transaction rule
+Either **all** related writes happen, or **none** of them do.
+
+<!-- Sources: Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Opening Script: From Working to Reliable; Transactions in Plain English -->
+
+---
+
+## Safe Initialization Pattern
+
+```python
+def init_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with connect(db_path) as connection:
+        connection.execute(create_table_sql)
+```
+
+### Why `init_db()` matters
+- Startup becomes predictable
+- Schema creation is safe to repeat
+- New environments require less manual setup
+
+### Integrity examples
+- `NOT NULL`
+- `CHECK(amount >= 0)`
+- Stable primary key
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: init_db() function and calling it once at startup; Add basic constraints (NOT NULL for required fields); Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Live Demo Part 1 -->
+
+---
+
+## Demo: Hardening the DB Layer
+
+### Demo flow
+- Create `connect()` helper
+- Enable `PRAGMA foreign_keys = ON`
+- Run `init_db()` on startup
+- Show one grouped transaction
+- Demonstrate rollback on failure
+
+**Quiz/homework cue**: `Hour 28 | init script: schema ready`
+
+<!-- Sources: Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Mention foreign keys lightly and accurately; Live Demo Part 1; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 28 canonical contract -->
+
+---
+
+## Lab: Hardening Sprint
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Write `init_db(db_path)`
+- Ensure it is safe to run more than once
+- Add basic constraints
+- Test one failure path in a grouped write
+
+### Completion Criteria
+✓ DB initializes reliably  
+✓ Constraints protect storage  
+✓ Grouped writes behave predictably  
+✓ Startup is calmer and more repeatable
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Hardening DB layer; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 4: Hour 28 -->
+
+---
+
+## Common Pitfalls (Hour 28)
+
+⚠️ Partially applied writes  
+⚠️ Schema drift after code changes  
+⚠️ Assuming foreign keys are on automatically  
+⚠️ Manual setup steps hidden outside startup
+
+## Quick Check
+**Question**: Why should `init_db()` be safe to run multiple times?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 28 explanation -->
+
+---
+
+# Session 7 Wrap-Up
+
+## What We Added
+- Table-first thinking
+- Safe `sqlite3` CRUD
+- Clean row mapping
+- More dependable startup and writes
+
+## Scope Guardrails
+✓ Standard-library SQLite  
+✓ Parameterized SQL  
+✓ Repository boundary  
+✓ Practical constraints and transactions
+
+✗ Not today: ORM migration frameworks  
+✗ Not required: multi-table deep design
+
+<!-- Sources: Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Instructor note; Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Instructor note -->
+
+---
+
+# Thank You!
+
+Session 8 next:
+- Deeper SQL or tiny ORM exposure
+- Plug SQLite into the app
+- Search, pagination, and the data-driven checkpoint
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 8 overview (Hours 29–32) -->

--- a/Advanced/lessons/slides/day-07/day-07-session-7.md
+++ b/Advanced/lessons/slides/day-07/day-07-session-7.md
@@ -294,6 +294,7 @@ Return domain objects from the repository.
 ## Use `sqlite3.Row` + a Mapping Helper
 
 ```python
+# from datetime import date  # required for date.fromisoformat()
 connection.row_factory = sqlite3.Row
 
 def from_row(row: sqlite3.Row) -> Expense:

--- a/Advanced/lessons/slides/day-08/day-08-session-8.html
+++ b/Advanced/lessons/slides/day-08/day-08-session-8.html
@@ -1,0 +1,1016 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 8 — Session 8 (Hours 29–32)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 8 — Session 8 (Hours 29–32)</h1>
+            <div class="subtitle">Python Programming (Advanced) • Data-Driven App Integration and Checkpoint 4</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 8 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 29: Deeper SQL practice, with ORM exposure as an optional extension</li>
+  <li>Hour 30: Plug the SQLite repository into the app</li>
+  <li>Hour 31: Search/filter + pagination patterns</li>
+  <li>Hour 32: Checkpoint 4 data-driven app milestone</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day goal</h1>
+            <ul>
+  <li>Make SQLite the actual source of truth</li>
+  <li>Add practical search</li>
+  <li>Prove persistence end to end</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 8 overview (Hours 29–32); Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Opening Script --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis</h1>
+            <ul>
+  <li>Default to deeper SQL practice for the required build path</li>
+  <li>Treat ORM as optional exposure, not mandatory scope</li>
+  <li>Keep the service contract stable during the storage swap</li>
+  <li>Apply stable ordering before slicing pages</li>
+  <li>Prove persistence-backed behavior at the checkpoint</li>
+</ul>
+<h3>Canonical quiz/contracts to recognize</h3>
+<ul>
+  <li><code>Hour 29 | chosen path: deeper SQL practice</code></li>
+  <li><code>Hour 30 | repository plugged in: yes</code></li>
+  <li><code>Hour 31 | search term: report</code></li>
+  <li><code>Hour 32 | db path: data/tracker.db</code></li>
+</ul>
+<p>&lt;!-- Sources: Advanced/assignments/Advanced_Day8_homework.ipynb — Part 1 through Part 4; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 29 through Hour 32 canonical contract questions --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 29: Deeper SQL Practice First, ORM Optional</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain what an ORM does in plain language</li>
+  <li>Compare ORM convenience vs SQL transparency</li>
+  <li>Implement one practical extension safely</li>
+  <li>Stay within the course scope</li>
+</ul>
+<h3>Default class path</h3>
+<ul>
+  <li><strong>Required</strong>: deeper SQL practice</li>
+  <li><strong>Optional extension</strong>: tiny SQLAlchemy slice if the environment supports it</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 29: Optional ORM slice (SQLAlchemy) OR deeper SQL practice; Advanced/assignments/Advanced_Day8_homework.ipynb — Part 1: Hour 29 - Deeper SQL practice (required) with ORM as an optional extension; Advanced/lessons/lecture/Day8_Hour1_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>The Real Tradeoff</h1>
+            <h3>ORM advantages</h3>
+<ul>
+  <li>Less repetitive mapping code</li>
+  <li>Object-style query API</li>
+  <li>Useful abstraction for common patterns</li>
+</ul>
+<h3>ORM disadvantages</h3>
+<ul>
+  <li>Extra dependency</li>
+  <li>More abstraction to debug</li>
+  <li>Hidden SQL can slow learning if the basics are still shaky</li>
+</ul>
+<h3>SQL advantages</h3>
+<ul>
+  <li>Transparent</li>
+  <li>Portable</li>
+  <li>Great for small apps and practical summaries</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour1_Advanced.md — What an ORM Does; What Raw SQL Gives You; The Real Comparison --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Path A vs Path B</h1>
+            <h3>Path A — tiny ORM exposure</h3>
+<ul>
+  <li>One model class</li>
+  <li>One session</li>
+  <li>One query</li>
+</ul>
+<h3>Path B — deeper SQL practice</h3>
+<ul>
+  <li><code>GROUP BY</code></li>
+  <li><code>COUNT(*)</code></li>
+  <li>Summary queries that answer real app questions</li>
+</ul>
+<p><strong>Recommendation</strong>: finish one path well; do not split your hour in half and complete neither.</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab (choose one); Advanced/lessons/lecture/Day8_Hour1_Advanced.md — Message to Learners; Live Demo --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: SQL Summary Query</h1>
+            <pre data-lang="python"><code>def summarize_by_status(db_path: str) -&gt; list[tuple[str, int]]:
+    query = &quot;&quot;&quot;
+        SELECT status, COUNT(*) AS total
+        FROM records
+        GROUP BY status
+        ORDER BY total DESC, status ASC
+    &quot;&quot;&quot;</code></pre>
+<h3>Why this path fits today</h3>
+<ul>
+  <li>No extra package install</li>
+  <li>Learners still see real SQL</li>
+  <li>The database answers the question directly</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour1_Advanced.md — Demo Track B: Deeper SQL Practice --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Choose One Depth Path</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Required baseline</h3>
+<ul>
+  <li>Complete the deeper SQL path first</li>
+  <li>Add one safe summary or reporting query</li>
+  <li>Explain one ORM tradeoff even if you stay with SQL</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> One path completed cleanly</p>
+<p><span class="check">✓</span> Tradeoffs explained at a high level</p>
+<p><span class="check">✓</span> Query or ORM slice remains small and readable</p>
+<p><span class="check">✓</span> App stability is preserved</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Completion criteria (Hour 29); Advanced/assignments/Advanced_Day8_homework.ipynb — Part 1: Hour 29 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 29)</h1>
+            <p><strong>⚠️</strong> Adding ORM complexity before understanding the query shape</p>
+<p><strong>⚠️</strong> Switching approaches midstream</p>
+<p><strong>⚠️</strong> Treating “more abstraction” as “automatically better”</p>
+<p><strong>⚠️</strong> Letting this hour derail the milestone path</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What is one advantage and one disadvantage of an ORM?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 29 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 30: Integrate the DB into the App</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Swap storage without rewriting the whole app</li>
+  <li>Keep the service contract stable</li>
+  <li>Use beginner-friendly dependency injection</li>
+  <li>Avoid two conflicting sources of truth</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 30: Integrate DB into the app; Advanced/lessons/lecture/Day8_Hour2_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Same Service Contract, New Storage Engine</h1>
+            <h3>Stable pieces</h3>
+<ul>
+  <li>Model classes</li>
+  <li>Validation logic</li>
+  <li>Service method names</li>
+  <li>UI callbacks / routes</li>
+</ul>
+<h3>Pieces that change</h3>
+<ul>
+  <li>Repository implementation</li>
+  <li>SQL statements</li>
+  <li>Row mapping</li>
+  <li><code>init_db()</code> and connection setup</li>
+</ul>
+<blockquote>The service should depend on what the repo can do, not how it stores data.</blockquote>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour2_Advanced.md — The One Big Idea; What Should Stay Stable --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Beginner-Friendly Dependency Injection</h1>
+            <pre data-lang="python"><code>repo = SQLiteTrackerRepository(&quot;data/tracker.db&quot;)
+service = TrackerService(repo=repo)</code></pre>
+<h3>Avoid</h3>
+<pre data-lang="python"><code>class TrackerService:
+    def __init__(self):
+        self.repo = SQLiteTrackerRepository(&quot;data/tracker.db&quot;)</code></pre>
+<h3>Why</h3>
+<ul>
+  <li>Easier to test</li>
+  <li>Easier to swap storage</li>
+  <li>Cleaner architecture</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour2_Advanced.md — Dependency Injection Without the Jargon Overload --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>One Source of Truth</h1>
+            <h3>Once SQLite is live</h3>
+<ul>
+  <li>SQLite is the live persistence layer</li>
+  <li>JSON can become export/import, not parallel truth</li>
+</ul>
+<h3>Danger pattern</h3>
+<ul>
+  <li>GUI writes to JSON</li>
+  <li>Search reads from SQLite</li>
+  <li>Nobody knows which state is current</li>
+</ul>
+<p><strong>Quiz/homework cue</strong>: <code>Hour 30 | repository plugged in: yes</code></p>
+<p>&lt;!-- Sources: Advanced/assignments/Advanced_Day8_homework.ipynb — Part 2: Hour 30; Advanced/lessons/lecture/Day8_Hour2_Advanced.md — The Risk of Two Sources of Truth; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 30 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Storage Swap With Minimal Drama</h1>
+            <h3>Demo flow</h3>
+<ol>
+  <li>Build the repo</li>
+  <li>Call <code>repo.init_db()</code></li>
+  <li>Construct the service with that repo</li>
+  <li>Launch the app</li>
+  <li>Show that add/list/update/delete still work</li>
+  <li>Restart and verify persistence</li>
+</ol>
+<h3>Success condition</h3>
+<ul>
+  <li>UI changes very little</li>
+  <li>Storage changes a lot</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: service = TrackerService(repo=SQLiteRepo(...)); Show UI still works after swap; Advanced/lessons/lecture/Day8_Hour2_Advanced.md — Live Demo of the Storage Swap --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Wire the Repository Under the Service</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Replace JSON/in-memory persistence with SQLite</li>
+  <li>Keep the service layer interface stable</li>
+  <li>Confirm CRUD works after the swap</li>
+  <li>Remove confusion about live storage</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> App persists via SQLite</p>
+<p><span class="check">✓</span> UI/API still functions</p>
+<p><span class="check">✓</span> One source of truth is clear</p>
+<p><span class="check">✓</span> Restart behavior is verified</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Wire it up; Advanced/assignments/Advanced_Day8_homework.ipynb — Part 2: Hour 30 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 30)</h1>
+            <p><strong>⚠️</strong> UI calling <code>sqlite3</code> directly</p>
+<p><strong>⚠️</strong> JSON and SQLite both acting “live”</p>
+<p><strong>⚠️</strong> Forgetting to refresh after DB writes</p>
+<p><strong>⚠️</strong> Rebuilding more layers than necessary</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What interface stayed the same when you swapped storage?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 30 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 31: Search, Filter, and Pagination</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Add a practical search feature</li>
+  <li>Use parameterized <code>LIKE</code> safely</li>
+  <li>Understand <code>LIMIT</code> and <code>OFFSET</code></li>
+  <li>Keep paging logic in the repository layer</li>
+  <li>Preserve stable ordering across pages</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 31: Search/filter + pagination patterns; Advanced/lessons/lecture/Day8_Hour3_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Search vs Filter</h1>
+            <h3>Search</h3>
+<ul>
+  <li>Partial text match</li>
+  <li>e.g. title contains <code>&quot;invoice&quot;</code></li>
+</ul>
+<h3>Filter</h3>
+<ul>
+  <li>Narrow by exact or controlled value</li>
+  <li>e.g. status equals <code>&quot;open&quot;</code></li>
+</ul>
+<h3>Practical method shape</h3>
+<pre data-lang="python"><code>def search(term: str = &quot;&quot;, status: str | None = None,
+           limit: int = 20, offset: int = 0) -&gt; list[Record]:
+    ...</code></pre>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour3_Advanced.md — Filtering vs Searching --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Safe `LIKE` + Stable Pagination</h1>
+            <pre data-lang="python"><code>wildcard = f&quot;%{term.strip().lower()}%&quot;
+query = &quot;&quot;&quot;
+    SELECT id, title, category, status
+    FROM records
+    WHERE lower(title) LIKE ?
+    ORDER BY id ASC
+    LIMIT ? OFFSET ?
+&quot;&quot;&quot;</code></pre>
+<h3>Rules to keep</h3>
+<ul>
+  <li>Add <code>%</code> to the <strong>parameter value</strong></li>
+  <li>Normalize case for a friendlier search</li>
+  <li>Sort before paginating</li>
+</ul>
+<p><strong>Quiz/homework cue</strong>: <code>Hour 31 | search term: report</code></p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour3_Advanced.md — Safe Search with <code>LIKE</code>; Why Pagination Exists; Advanced/assignments/Advanced_Day8_homework.ipynb — Part 3: Hour 31; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 31 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Search Repository + Optional UI Hook</h1>
+            <h3>Demo flow</h3>
+<ul>
+  <li>Add <code>search_records(term, status, limit, offset)</code></li>
+  <li>Reset page to zero on a new search</li>
+  <li>Add optional Next/Prev buttons</li>
+  <li>Repopulate the visible table from fresh results</li>
+</ul>
+<h3>Usability guardrails</h3>
+<ul>
+  <li>Empty result sets are valid</li>
+  <li>Clear stale rows before repopulating</li>
+  <li>Do not hand-build SQL with user values</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: repo.search(q, limit, offset); Demo: next/prev buttons in UI (optional); Advanced/lessons/lecture/Day8_Hour3_Advanced.md — Live Demo --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Practical Search Feature</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add a search box or script input</li>
+  <li>Implement a repository search method</li>
+  <li>Optional: add paging with limit 20 and Next/Prev</li>
+  <li>Keep results predictable with stable ordering</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> Search returns correct results</p>
+<p><span class="check">✓</span> No SQL injection risk</p>
+<p><span class="check">✓</span> Paging does not reorder records unpredictably</p>
+<p><span class="check">✓</span> Empty search results behave cleanly</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Search feature; Advanced/assignments/Advanced_Day8_homework.ipynb — Part 3: Hour 31 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 31)</h1>
+            <p><strong>⚠️</strong> Building SQL with string concatenation</p>
+<p><strong>⚠️</strong> Forgetting wildcards in <code>LIKE</code></p>
+<p><strong>⚠️</strong> Paginating unsorted results</p>
+<p><strong>⚠️</strong> Leaving stale UI rows after search</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Where should wildcard <code>%</code> be added: in the SQL string or the parameter value?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 31 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 32: Checkpoint 4 — Data-Driven App Milestone</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Required deliverables</h1>
+            <ul>
+  <li>SQLite repo with CRUD</li>
+  <li><code>init_db()</code> on startup</li>
+  <li>Database as source of truth</li>
+  <li>Basic search feature</li>
+  <li>Demo proving persistence across restarts</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 32: Checkpoint 4: Data-driven app milestone; Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Clarify the Deliverables --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Fast-Grade Demo Workflow</h1>
+            <ol>
+  <li>Launch the app</li>
+  <li>Create a record</li>
+  <li>Search for it</li>
+  <li>Close the app</li>
+  <li>Reopen the app</li>
+  <li>Confirm the record still exists</li>
+  <li>Update it</li>
+  <li>Delete it</li>
+</ol>
+<h3>Why this works</h3>
+<ul>
+  <li>It reveals path issues fast</li>
+  <li>It reveals stale in-memory state fast</li>
+  <li>It proves SQLite is really live</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Show the Fast-Grade Workflow --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Validation Checklist</h1>
+            <pre data-lang="text"><code>[ ] Database file exists in the expected path
+[ ] init_db runs safely on startup
+[ ] Add creates a new row in SQLite
+[ ] List reads from SQLite, not stale in-memory data
+[ ] Search returns expected results
+[ ] Update targets the correct record ID
+[ ] Delete removes the intended record
+[ ] Restart proves persistence
+[ ] Common errors do not crash the app</code></pre>
+<p><strong>Quiz/homework cue</strong>: <code>Hour 32 | db path: data/tracker.db</code></p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Validation Checklist for Learners; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 32 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Failure Modes to Triage</h1>
+            <h3>Data disappears after restart</h3>
+<ul>
+  <li>Check commit behavior</li>
+  <li>Check DB path</li>
+  <li>Check whether the UI still reads cached objects</li>
+</ul>
+<h3>Wrong record changes</h3>
+<ul>
+  <li>Print the target ID</li>
+  <li>Verify the <code>WHERE</code> clause</li>
+  <li>Check stale selected state</li>
+</ul>
+<h3>Search returns odd results</h3>
+<ul>
+  <li>Test the repo method by itself first</li>
+  <li>Check wildcard placement</li>
+  <li>Check row clearing in the UI</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Coaching Notes for Common Failure Modes --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 8 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What Success Looks Like</h1>
+            <ul>
+  <li>SQLite is now the real source of truth</li>
+  <li>Storage swaps did not break the service contract</li>
+  <li>Search is practical and safe</li>
+  <li>The checkpoint demo is honest and repeatable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails</h1>
+            <p><span class="check">✓</span> Stable milestone first</p>
+<p><span class="check">✓</span> Practical search and persistence</p>
+<p><span class="check">✓</span> Small optional ORM exposure only if environment allows</p>
+<p><span class="check">✓</span> Clear repo/service/UI boundaries</p>
+<p><span class="cross">✗</span> Not required: fancy joins, migrations, or advanced ORM topics</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour1_Advanced.md — Scope Guardrails; Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Stability is the priority --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Next milestone after Day 8:</p>
+<ul>
+  <li>refine architecture</li>
+  <li>expand data features carefully</li>
+  <li>keep reliability ahead of novelty</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Opening Script; Reflection and exit ticket framing --&gt;</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/Advanced/lessons/slides/day-08/day-08-session-8.md
+++ b/Advanced/lessons/slides/day-08/day-08-session-8.md
@@ -1,0 +1,486 @@
+# Advanced Day 8 — Session 8 (Hours 29–32)
+Python Programming (Advanced) • Data-Driven App Integration and Checkpoint 4
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 8 overview (Hours 29–32); Advanced/lessons/lecture/Day8_Hour1_Advanced.md — Instructor Prep Notes -->
+
+---
+
+# Session 8 Overview
+
+## Topics Covered Today
+- Hour 29: Deeper SQL practice, with ORM exposure as an optional extension
+- Hour 30: Plug the SQLite repository into the app
+- Hour 31: Search/filter + pagination patterns
+- Hour 32: Checkpoint 4 data-driven app milestone
+
+## Day goal
+- Make SQLite the actual source of truth
+- Add practical search
+- Prove persistence end to end
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 8 overview (Hours 29–32); Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Opening Script -->
+
+---
+
+## Homework + Quiz Emphasis
+
+- Default to deeper SQL practice for the required build path
+- Treat ORM as optional exposure, not mandatory scope
+- Keep the service contract stable during the storage swap
+- Apply stable ordering before slicing pages
+- Prove persistence-backed behavior at the checkpoint
+
+### Canonical quiz/contracts to recognize
+- `Hour 29 | chosen path: deeper SQL practice`
+- `Hour 30 | repository plugged in: yes`
+- `Hour 31 | search term: report`
+- `Hour 32 | db path: data/tracker.db`
+
+<!-- Sources: Advanced/assignments/Advanced_Day8_homework.ipynb — Part 1 through Part 4; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 29 through Hour 32 canonical contract questions -->
+
+---
+
+# Hour 29: Deeper SQL Practice First, ORM Optional
+
+## Learning Outcomes
+- Explain what an ORM does in plain language
+- Compare ORM convenience vs SQL transparency
+- Implement one practical extension safely
+- Stay within the course scope
+
+### Default class path
+- **Required**: deeper SQL practice
+- **Optional extension**: tiny SQLAlchemy slice if the environment supports it
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 29: Optional ORM slice (SQLAlchemy) OR deeper SQL practice; Advanced/assignments/Advanced_Day8_homework.ipynb — Part 1: Hour 29 - Deeper SQL practice (required) with ORM as an optional extension; Advanced/lessons/lecture/Day8_Hour1_Advanced.md — Learning Outcomes for This Hour -->
+
+---
+
+## The Real Tradeoff
+
+### ORM advantages
+- Less repetitive mapping code
+- Object-style query API
+- Useful abstraction for common patterns
+
+### ORM disadvantages
+- Extra dependency
+- More abstraction to debug
+- Hidden SQL can slow learning if the basics are still shaky
+
+### SQL advantages
+- Transparent
+- Portable
+- Great for small apps and practical summaries
+
+<!-- Sources: Advanced/lessons/lecture/Day8_Hour1_Advanced.md — What an ORM Does; What Raw SQL Gives You; The Real Comparison -->
+
+---
+
+## Demo Path A vs Path B
+
+### Path A — tiny ORM exposure
+- One model class
+- One session
+- One query
+
+### Path B — deeper SQL practice
+- `GROUP BY`
+- `COUNT(*)`
+- Summary queries that answer real app questions
+
+**Recommendation**: finish one path well; do not split your hour in half and complete neither.
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab (choose one); Advanced/lessons/lecture/Day8_Hour1_Advanced.md — Message to Learners; Live Demo -->
+
+---
+
+## Demo: SQL Summary Query
+
+```python
+def summarize_by_status(db_path: str) -> list[tuple[str, int]]:
+    query = """
+        SELECT status, COUNT(*) AS total
+        FROM records
+        GROUP BY status
+        ORDER BY total DESC, status ASC
+    """
+```
+
+### Why this path fits today
+- No extra package install
+- Learners still see real SQL
+- The database answers the question directly
+
+<!-- Sources: Advanced/lessons/lecture/Day8_Hour1_Advanced.md — Demo Track B: Deeper SQL Practice -->
+
+---
+
+## Lab: Choose One Depth Path
+
+**Time: 25–35 minutes**
+
+### Required baseline
+- Complete the deeper SQL path first
+- Add one safe summary or reporting query
+- Explain one ORM tradeoff even if you stay with SQL
+
+### Completion Criteria
+✓ One path completed cleanly  
+✓ Tradeoffs explained at a high level  
+✓ Query or ORM slice remains small and readable  
+✓ App stability is preserved
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Completion criteria (Hour 29); Advanced/assignments/Advanced_Day8_homework.ipynb — Part 1: Hour 29 -->
+
+---
+
+## Common Pitfalls (Hour 29)
+
+⚠️ Adding ORM complexity before understanding the query shape  
+⚠️ Switching approaches midstream  
+⚠️ Treating “more abstraction” as “automatically better”  
+⚠️ Letting this hour derail the milestone path
+
+## Quick Check
+**Question**: What is one advantage and one disadvantage of an ORM?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 29 explanation -->
+
+---
+
+# Hour 30: Integrate the DB into the App
+
+## Learning Outcomes
+- Swap storage without rewriting the whole app
+- Keep the service contract stable
+- Use beginner-friendly dependency injection
+- Avoid two conflicting sources of truth
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 30: Integrate DB into the app; Advanced/lessons/lecture/Day8_Hour2_Advanced.md — Learning Outcomes for This Hour -->
+
+---
+
+## Same Service Contract, New Storage Engine
+
+### Stable pieces
+- Model classes
+- Validation logic
+- Service method names
+- UI callbacks / routes
+
+### Pieces that change
+- Repository implementation
+- SQL statements
+- Row mapping
+- `init_db()` and connection setup
+
+> The service should depend on what the repo can do, not how it stores data.
+
+<!-- Sources: Advanced/lessons/lecture/Day8_Hour2_Advanced.md — The One Big Idea; What Should Stay Stable -->
+
+---
+
+## Beginner-Friendly Dependency Injection
+
+```python
+repo = SQLiteTrackerRepository("data/tracker.db")
+service = TrackerService(repo=repo)
+```
+
+### Avoid
+```python
+class TrackerService:
+    def __init__(self):
+        self.repo = SQLiteTrackerRepository("data/tracker.db")
+```
+
+### Why
+- Easier to test
+- Easier to swap storage
+- Cleaner architecture
+
+<!-- Sources: Advanced/lessons/lecture/Day8_Hour2_Advanced.md — Dependency Injection Without the Jargon Overload -->
+
+---
+
+## One Source of Truth
+
+### Once SQLite is live
+- SQLite is the live persistence layer
+- JSON can become export/import, not parallel truth
+
+### Danger pattern
+- GUI writes to JSON
+- Search reads from SQLite
+- Nobody knows which state is current
+
+**Quiz/homework cue**: `Hour 30 | repository plugged in: yes`
+
+<!-- Sources: Advanced/assignments/Advanced_Day8_homework.ipynb — Part 2: Hour 30; Advanced/lessons/lecture/Day8_Hour2_Advanced.md — The Risk of Two Sources of Truth; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 30 canonical contract -->
+
+---
+
+## Demo: Storage Swap With Minimal Drama
+
+### Demo flow
+1. Build the repo
+2. Call `repo.init_db()`
+3. Construct the service with that repo
+4. Launch the app
+5. Show that add/list/update/delete still work
+6. Restart and verify persistence
+
+### Success condition
+- UI changes very little
+- Storage changes a lot
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: service = TrackerService(repo=SQLiteRepo(...)); Show UI still works after swap; Advanced/lessons/lecture/Day8_Hour2_Advanced.md — Live Demo of the Storage Swap -->
+
+---
+
+## Lab: Wire the Repository Under the Service
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Replace JSON/in-memory persistence with SQLite
+- Keep the service layer interface stable
+- Confirm CRUD works after the swap
+- Remove confusion about live storage
+
+### Completion Criteria
+✓ App persists via SQLite  
+✓ UI/API still functions  
+✓ One source of truth is clear  
+✓ Restart behavior is verified
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Wire it up; Advanced/assignments/Advanced_Day8_homework.ipynb — Part 2: Hour 30 -->
+
+---
+
+## Common Pitfalls (Hour 30)
+
+⚠️ UI calling `sqlite3` directly  
+⚠️ JSON and SQLite both acting “live”  
+⚠️ Forgetting to refresh after DB writes  
+⚠️ Rebuilding more layers than necessary
+
+## Quick Check
+**Question**: What interface stayed the same when you swapped storage?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 30 explanation -->
+
+---
+
+# Hour 31: Search, Filter, and Pagination
+
+## Learning Outcomes
+- Add a practical search feature
+- Use parameterized `LIKE` safely
+- Understand `LIMIT` and `OFFSET`
+- Keep paging logic in the repository layer
+- Preserve stable ordering across pages
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 31: Search/filter + pagination patterns; Advanced/lessons/lecture/Day8_Hour3_Advanced.md — Learning Outcomes for This Hour -->
+
+---
+
+## Search vs Filter
+
+### Search
+- Partial text match
+- e.g. title contains `"invoice"`
+
+### Filter
+- Narrow by exact or controlled value
+- e.g. status equals `"open"`
+
+### Practical method shape
+```python
+def search(term: str = "", status: str | None = None,
+           limit: int = 20, offset: int = 0) -> list[Record]:
+    ...
+```
+
+<!-- Sources: Advanced/lessons/lecture/Day8_Hour3_Advanced.md — Filtering vs Searching -->
+
+---
+
+## Safe `LIKE` + Stable Pagination
+
+```python
+wildcard = f"%{term.strip().lower()}%"
+query = """
+    SELECT id, title, category, status
+    FROM records
+    WHERE lower(title) LIKE ?
+    ORDER BY id ASC
+    LIMIT ? OFFSET ?
+"""
+```
+
+### Rules to keep
+- Add `%` to the **parameter value**
+- Normalize case for a friendlier search
+- Sort before paginating
+
+**Quiz/homework cue**: `Hour 31 | search term: report`
+
+<!-- Sources: Advanced/lessons/lecture/Day8_Hour3_Advanced.md — Safe Search with `LIKE`; Why Pagination Exists; Advanced/assignments/Advanced_Day8_homework.ipynb — Part 3: Hour 31; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 31 canonical contract -->
+
+---
+
+## Demo: Search Repository + Optional UI Hook
+
+### Demo flow
+- Add `search_records(term, status, limit, offset)`
+- Reset page to zero on a new search
+- Add optional Next/Prev buttons
+- Repopulate the visible table from fresh results
+
+### Usability guardrails
+- Empty result sets are valid
+- Clear stale rows before repopulating
+- Do not hand-build SQL with user values
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: repo.search(q, limit, offset); Demo: next/prev buttons in UI (optional); Advanced/lessons/lecture/Day8_Hour3_Advanced.md — Live Demo -->
+
+---
+
+## Lab: Practical Search Feature
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Add a search box or script input
+- Implement a repository search method
+- Optional: add paging with limit 20 and Next/Prev
+- Keep results predictable with stable ordering
+
+### Completion Criteria
+✓ Search returns correct results  
+✓ No SQL injection risk  
+✓ Paging does not reorder records unpredictably  
+✓ Empty search results behave cleanly
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Search feature; Advanced/assignments/Advanced_Day8_homework.ipynb — Part 3: Hour 31 -->
+
+---
+
+## Common Pitfalls (Hour 31)
+
+⚠️ Building SQL with string concatenation  
+⚠️ Forgetting wildcards in `LIKE`  
+⚠️ Paginating unsorted results  
+⚠️ Leaving stale UI rows after search
+
+## Quick Check
+**Question**: Where should wildcard `%` be added: in the SQL string or the parameter value?
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 31 explanation -->
+
+---
+
+# Hour 32: Checkpoint 4 — Data-Driven App Milestone
+
+## Required deliverables
+- SQLite repo with CRUD
+- `init_db()` on startup
+- Database as source of truth
+- Basic search feature
+- Demo proving persistence across restarts
+
+<!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 32: Checkpoint 4: Data-driven app milestone; Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Clarify the Deliverables -->
+
+---
+
+## Fast-Grade Demo Workflow
+
+1. Launch the app
+2. Create a record
+3. Search for it
+4. Close the app
+5. Reopen the app
+6. Confirm the record still exists
+7. Update it
+8. Delete it
+
+### Why this works
+- It reveals path issues fast
+- It reveals stale in-memory state fast
+- It proves SQLite is really live
+
+<!-- Sources: Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Show the Fast-Grade Workflow -->
+
+---
+
+## Validation Checklist
+
+```text
+[ ] Database file exists in the expected path
+[ ] init_db runs safely on startup
+[ ] Add creates a new row in SQLite
+[ ] List reads from SQLite, not stale in-memory data
+[ ] Search returns expected results
+[ ] Update targets the correct record ID
+[ ] Delete removes the intended record
+[ ] Restart proves persistence
+[ ] Common errors do not crash the app
+```
+
+**Quiz/homework cue**: `Hour 32 | db path: data/tracker.db`
+
+<!-- Sources: Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Validation Checklist for Learners; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 32 canonical contract -->
+
+---
+
+## Common Failure Modes to Triage
+
+### Data disappears after restart
+- Check commit behavior
+- Check DB path
+- Check whether the UI still reads cached objects
+
+### Wrong record changes
+- Print the target ID
+- Verify the `WHERE` clause
+- Check stale selected state
+
+### Search returns odd results
+- Test the repo method by itself first
+- Check wildcard placement
+- Check row clearing in the UI
+
+<!-- Sources: Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Coaching Notes for Common Failure Modes -->
+
+---
+
+# Session 8 Wrap-Up
+
+## What Success Looks Like
+- SQLite is now the real source of truth
+- Storage swaps did not break the service contract
+- Search is practical and safe
+- The checkpoint demo is honest and repeatable
+
+## Scope Guardrails
+✓ Stable milestone first  
+✓ Practical search and persistence  
+✓ Small optional ORM exposure only if environment allows  
+✓ Clear repo/service/UI boundaries
+
+✗ Not required: fancy joins, migrations, or advanced ORM topics
+
+<!-- Sources: Advanced/lessons/lecture/Day8_Hour1_Advanced.md — Scope Guardrails; Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Stability is the priority -->
+
+---
+
+# Thank You!
+
+Next milestone after Day 8:
+- refine architecture
+- expand data features carefully
+- keep reliability ahead of novelty
+
+<!-- Sources: Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Opening Script; Reflection and exit ticket framing -->

--- a/Advanced/lessons/slides/day-09/day-09-session-9.html
+++ b/Advanced/lessons/slides/day-09/day-09-session-9.html
@@ -1,0 +1,1176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 9 — Session 9 (Hours 33–36)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 9 — Session 9 (Hours 33–36)</h1>
+            <div class="subtitle">Python Programming (Advanced) • REST APIs and Flask Foundations</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 9 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 33: REST fundamentals + Flask app setup</li>
+  <li>Hour 34: CRUD endpoints for the main resource</li>
+  <li>Hour 35: Serialization + validation</li>
+  <li>Hour 36: App structure + dependency wiring</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Capstone Through-Line</h1>
+            <ul>
+  <li>Expose the existing tracker logic through a Flask API</li>
+  <li>Keep the service layer as the center of truth</li>
+  <li>Build for maintainability, not framework novelty</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Alignment Sources</h1>
+            <ul>
+  <li>Runbook: <code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → Session 9 overview; Hours 33–36</li>
+  <li>Lecture: <code>Advanced/lessons/lecture/Day9_Hour1_Advanced.md</code> through <code>Day9_Hour4_Advanced.md</code></li>
+  <li>Homework: <code>Advanced/assignments/Advanced_Day9_homework.ipynb</code></li>
+  <li>Quiz: <code>Advanced/quizzes/Advanced_Day9_Quiz.html</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Today’s Output Target</h1>
+            <ul>
+  <li>A working Flask surface over the tracker project</li>
+  <li>Predictable JSON responses</li>
+  <li>A structure that can keep growing tomorrow</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Success Criteria</h1>
+            <ul>
+  <li><code>/health</code> responds with JSON</li>
+  <li>Main resource supports CRUD behavior</li>
+  <li>Error responses use one consistent JSON shape</li>
+  <li>Write-ready app structure uses explicit dependency wiring</li>
+  <li>Homework and quiz checkpoints are visible in the day’s build flow</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            <ul>
+  <li>Stay in course scope: Flask + clean contracts + practical structure</li>
+  <li>Do <strong>not</strong> drift into deployment, OAuth, JWT, or API versioning</li>
+  <li>Reuse service and repository logic instead of rebuilding business rules in routes</li>
+  <li>Choose one resource name and keep it consistent in your own project</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 33: REST Fundamentals + Flask App Setup</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain REST-style resources in plain language</li>
+  <li>Distinguish <code>GET</code> from <code>POST</code></li>
+  <li>Create a minimal Flask app</li>
+  <li>Return JSON instead of default HTML errors</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why an API Matters Now</h1>
+            <ul>
+  <li>The capstone already has logic and persistence</li>
+  <li>Flask becomes a <strong>new interface</strong>, not a new project</li>
+  <li>An API lets other tools call the same application behavior</li>
+  <li>Strong layering now makes later integration easier</li>
+</ul>
+<pre data-lang="text"><code>Client -&gt; Flask route -&gt; service -&gt; repository -&gt; SQLite</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>REST in Plain English</h1>
+            <ul>
+  <li><strong>Resource</strong>: the thing the API exposes</li>
+  <li><strong>Route</strong>: URL pattern connected to code</li>
+  <li><strong>Method</strong>: <code>GET</code>, <code>POST</code>, <code>PUT</code>, <code>DELETE</code></li>
+  <li><strong>Status code</strong>: fast signal of what happened</li>
+  <li><strong>JSON contract</strong>: predictable request/response shape</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Useful Day 9 status codes</h1>
+            <ul>
+  <li><code>200</code> success</li>
+  <li><code>201</code> created</li>
+  <li><code>400</code> bad input</li>
+  <li><code>404</code> missing resource</li>
+  <li><code>500</code> unexpected failure</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Minimal Flask Starter</h1>
+            <pre data-lang="python"><code>from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.get(&quot;/health&quot;)
+def health():
+    return jsonify({&quot;status&quot;: &quot;ok&quot;})</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Teaching point</h1>
+            <ul>
+  <li>Start with one honest route before adding CRUD</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Consistent Error Contract</h1>
+            <pre data-lang="json"><code>{
+  &quot;error&quot;: {
+    &quot;code&quot;: &quot;not_found&quot;,
+    &quot;message&quot;: &quot;Record 12 was not found.&quot;,
+    &quot;request_id&quot;: &quot;a1b2c3d4&quot;
+  }
+}</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Why it matters</h1>
+            <ul>
+  <li>Clients can depend on one structure</li>
+  <li>Logs and user-facing errors connect more cleanly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Flow: Hour 33</h1>
+            <ol>
+  <li>Create <code>app = Flask(__name__)</code></li>
+  <li>Add <code>/health</code></li>
+  <li>Run the server locally</li>
+  <li>Test with browser, <code>curl</code>, or a small Python call</li>
+  <li>Trigger one intentional failure and show JSON output</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Flask Starter + Smoke Test</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create a small Flask app</li>
+  <li>Add <code>/health</code></li>
+  <li>Return JSON on success</li>
+  <li>Add one reusable error helper</li>
+  <li>Verify the app from outside the Flask file</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>App starts reliably</li>
+  <li><code>/health</code> returns JSON</li>
+  <li>Learner can explain what a route does</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 33)</h1>
+            <p><strong>⚠️</strong> Mixing setup, routing, and service logic in one giant file</p>
+<p><strong>⚠️</strong> Returning HTML errors while success paths return JSON</p>
+<p><strong>⚠️</strong> Treating the API as a separate project instead of a new interface</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 33)</h1>
+            <ul>
+  <li>Homework goal: build a Flask app with a health route and clear REST basics</li>
+  <li>Best practice: start with one small health endpoint before layering CRUD</li>
+  <li>Quiz-ready anchor: <code>Hour 33 | framework: Flask</code></li>
+  <li>Deliverable check: can you show a health route and explain why it matters?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is a health endpoint a smart first step before building CRUD routes?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 34: CRUD Endpoints for the Main Resource</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Implement <code>GET</code>, <code>POST</code>, <code>PUT</code>, and <code>DELETE</code></li>
+  <li>Keep routes thin</li>
+  <li>Connect handlers to the service layer</li>
+  <li>Return the right status codes for the outcome</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Canonical Route Set</h1>
+            <ul>
+  <li><code>GET /records</code></li>
+  <li><code>POST /records</code></li>
+  <li><code>GET /records/&lt;id&gt;</code></li>
+  <li><code>PUT /records/&lt;id&gt;</code></li>
+  <li><code>DELETE /records/&lt;id&gt;</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Naming note</h1>
+            <ul>
+  <li>Lecture examples use <code>records</code></li>
+  <li>Homework/quiz output anchors may use <code>tasks</code></li>
+  <li>Your project should pick <strong>one</strong> resource name and stay consistent</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Thin Route Handler Mindset</h1>
+            <h3>Route responsibilities</h3>
+<ul>
+  <li>Read request input</li>
+  <li>Call the service</li>
+  <li>Catch known exceptions</li>
+  <li>Return JSON + status code</li>
+</ul>
+<h3>Avoid in the route</h3>
+<ul>
+  <li>Direct SQL</li>
+  <li>Deep business logic</li>
+  <li>Hidden global state</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Safe JSON Parsing Pattern</h1>
+            <pre data-lang="python"><code>payload = request.get_json(silent=True)
+if payload is None:
+    return error_response(
+        &quot;invalid_json&quot;,
+        &quot;Request body must be valid JSON.&quot;,
+        400,
+    )</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Key distinction</h1>
+            <ul>
+  <li>Bad input → <code>400</code></li>
+  <li>Missing resource → <code>404</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>CRUD Example</h1>
+            <pre data-lang="python"><code>@app.post(&quot;/records&quot;)
+def create_record():
+    payload = request.get_json(silent=True)
+    if payload is None:
+        return error_response(&quot;invalid_json&quot;, &quot;Request body must be valid JSON.&quot;, 400)
+
+    record = service.add_record(
+        title=payload.get(&quot;title&quot;, &quot;&quot;),
+        category=payload.get(&quot;category&quot;, &quot;&quot;),
+        status=payload.get(&quot;status&quot;, &quot;open&quot;),
+    )
+    return jsonify(record.to_dict()), 201</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Flow: Hour 34</h1>
+            <ol>
+  <li>Add list + create routes</li>
+  <li>Add get-by-id</li>
+  <li>Add update + delete</li>
+  <li>Show one success case</li>
+  <li>Show one validation or not-found case</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Smoke test habit</h1>
+            <ul>
+  <li>Verify behavior from outside the Flask app</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Build the CRUD Surface</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add the full CRUD route set</li>
+  <li>Route everything through the service layer</li>
+  <li>Return consistent JSON</li>
+  <li>Test at least one success and one failure for each major path</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>CRUD endpoints respond predictably</li>
+  <li>Status codes match the actual outcome</li>
+  <li>Learner can explain <code>400</code> vs <code>404</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 34)</h1>
+            <p><strong>⚠️</strong> Returning <code>200</code> for everything</p>
+<p><strong>⚠️</strong> Writing business rules in Flask handlers</p>
+<p><strong>⚠️</strong> Forgetting to test malformed requests</p>
+<p><strong>⚠️</strong> Letting route names drift between files</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 34)</h1>
+            <ul>
+  <li>Homework goal: a small set of CRUD endpoints for the tracker resource</li>
+  <li>Best practice: use HTTP verbs and status codes consistently</li>
+  <li>Pitfall to avoid: wrong status codes make clients harder to trust</li>
+  <li>Quiz-ready anchor: <code>Hour 34 | endpoint: POST /tasks</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: When should a route return <code>400</code> instead of <code>404</code>?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 35: Serialization + Validation</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Centralize request parsing</li>
+  <li>Centralize response serialization</li>
+  <li>Keep validation rules coherent</li>
+  <li>Use intentional negative cases to test the contract</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>API Contracts Are Promises</h1>
+            <ul>
+  <li>Requests should arrive in a predictable shape</li>
+  <li>Responses should leave in a predictable shape</li>
+  <li>Failure paths should look consistent too</li>
+  <li>“It works” is not enough if every endpoint behaves differently</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Serializer Helper</h1>
+            <pre data-lang="python"><code>def serialize_record(record) -&gt; dict:
+    return {
+        &quot;id&quot;: record.id,
+        &quot;title&quot;: record.title,
+        &quot;category&quot;: record.category,
+        &quot;status&quot;: record.status,
+        &quot;priority&quot;: record.priority,
+    }</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Benefit</h1>
+            <ul>
+  <li>One change point instead of copy/paste edits across routes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Parser + Validation Helper</h1>
+            <pre data-lang="python"><code>def parse_record_payload(payload: dict) -&gt; dict:
+    title = str(payload.get(&quot;title&quot;, &quot;&quot;)).strip()
+    category = str(payload.get(&quot;category&quot;, &quot;&quot;)).strip()
+    status = str(payload.get(&quot;status&quot;, &quot;open&quot;)).strip().lower()
+
+    if not title:
+        raise ValidationError(&quot;Title is required.&quot;)
+    if not category:
+        raise ValidationError(&quot;Category is required.&quot;)
+    if status not in {&quot;open&quot;, &quot;in_progress&quot;, &quot;done&quot;}:
+        raise ValidationError(&quot;Status is invalid.&quot;)
+
+    return {&quot;title&quot;: title, &quot;category&quot;: category, &quot;status&quot;: status}</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Where Validation Should Live</h1>
+            <ul>
+  <li>Parser helpers normalize and reject malformed payloads</li>
+  <li>Service layer enforces domain invariants</li>
+  <li>Routes should <strong>not</strong> duplicate the same rules repeatedly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Negative test ideas</h1>
+            <ul>
+  <li>invalid JSON</li>
+  <li>missing title</li>
+  <li>missing category</li>
+  <li>invalid status value</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Cleaner Route Pattern</h1>
+            <pre data-lang="python"><code>@app.post(&quot;/records&quot;)
+def create_record():
+    payload = request.get_json(silent=True)
+    if payload is None:
+        return error_response(&quot;invalid_json&quot;, &quot;Request body must be valid JSON.&quot;, 400)
+
+    try:
+        parsed = parse_record_payload(payload)
+        record = service.add_record(**parsed)
+    except ValidationError as exc:
+        return error_response(&quot;validation_error&quot;, str(exc), 400)
+
+    return jsonify(serialize_record(record)), 201</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Make the API Coherent</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add one serializer helper</li>
+  <li>Add one parser/validator helper</li>
+  <li>Replace ad hoc route logic with helpers</li>
+  <li>Run a few negative cases intentionally</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Output shape is consistent across routes</li>
+  <li>Validation rules live in one obvious place</li>
+  <li>Learner can explain at least one negative test result</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 35)</h1>
+            <p><strong>⚠️</strong> Different key sets across endpoints</p>
+<p><strong>⚠️</strong> Validation logic duplicated in multiple routes</p>
+<p><strong>⚠️</strong> Plain-text errors in one handler and JSON in another</p>
+<p><strong>⚠️</strong> Negative cases never tested until demo time</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 35)</h1>
+            <ul>
+  <li>Homework goal: manual serializers and validators for tracker payloads</li>
+  <li>Best practice: one consistent request/response contract</li>
+  <li>Pitfall to avoid: different key sets confuse clients</li>
+  <li>Quiz-ready anchor: <code>Hour 35 | request fields checked: title, priority</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is centralizing parsing and serialization safer than rebuilding dictionaries inside each route?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 36: App Structure + Dependency Wiring</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain why growing apps need structure</li>
+  <li>Refactor toward a <code>create_app()</code> pattern</li>
+  <li>Wire dependencies explicitly</li>
+  <li>Avoid circular imports and hidden globals</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>When Structure Starts to Matter</h1>
+            <ul>
+  <li>Single-file apps are great for learning</li>
+  <li>Growth creates import noise and setup confusion</li>
+  <li>Testing gets harder when construction happens at import time</li>
+  <li>Clear startup makes the app easier to reason about</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Simple Application Factory</h1>
+            <pre data-lang="python"><code>def create_app():
+    app = Flask(__name__)
+    repo = SQLiteTrackerRepository(&quot;data/tracker.db&quot;)
+    repo.init_db()
+    service = TrackerService(repo=repo)
+    register_routes(app, service)
+    return app</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Why it helps</h1>
+            <ul>
+  <li>One visible startup path</li>
+  <li>Explicit dependencies</li>
+  <li>Easier testing later</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Structure Options for This Course</h1>
+            <h3>Minimum good structure</h3>
+<ul>
+  <li><code>api/app.py</code> for startup</li>
+  <li><code>api/routes.py</code> for route registration</li>
+  <li>service + repository modules stay separate</li>
+</ul>
+<h3>Optional structure</h3>
+<ul>
+  <li>Flask blueprints if the learner is ready</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Guardrail</h1>
+            <ul>
+  <li>Do not overframework the capstone</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Architecture Risks</h1>
+            <ul>
+  <li>Global service creation at import time</li>
+  <li><code>routes.py</code> importing <code>app.py</code> and vice versa</li>
+  <li>Repository construction hidden in random modules</li>
+  <li>Learners changing file layout without updating imports deliberately</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Refactor Sprint</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Move routes into a dedicated module or grouping</li>
+  <li>Add <code>create_app()</code></li>
+  <li>Construct repository + service in one clear place</li>
+  <li>Re-test <code>/health</code> and main resource routes</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Startup is predictable</li>
+  <li>Route wiring is readable</li>
+  <li>API still behaves the same after refactor</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 36)</h1>
+            <p><strong>⚠️</strong> Circular imports</p>
+<p><strong>⚠️</strong> Hidden global singletons</p>
+<p><strong>⚠️</strong> Refactoring too much at once</p>
+<p><strong>⚠️</strong> Losing a working route while reorganizing</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 36)</h1>
+            <ul>
+  <li>Homework goal: an app structure that can grow beyond one file</li>
+  <li>Best practice: use an app factory and optional blueprints to organize startup</li>
+  <li>Pitfall to avoid: global singletons hide dependencies and hurt testing</li>
+  <li>Quiz-ready anchor: <code>Hour 36 | app factory: create_app</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What problem does <code>create_app()</code> solve that a global <code>service = ...</code> pattern does not?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 9 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What Learners Should Leave With</h1>
+            <ul>
+  <li>A Flask entry point</li>
+  <li>CRUD routes around one main resource</li>
+  <li>Manual parser + serializer helpers</li>
+  <li>A maintainable startup path for tomorrow’s security and client work</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Homework Focus</h1>
+            <ul>
+  <li>Build deterministic outputs in <code>Advanced_Day9_homework.ipynb</code></li>
+  <li>Keep the contract stable enough for autograder-style labels</li>
+  <li>Rehearse the hour anchors:</li>
+  <li style="margin-left: 30px;"><code>framework: Flask</code></li>
+  <li style="margin-left: 30px;"><code>endpoint: POST /tasks</code></li>
+  <li style="margin-left: 30px;"><code>request fields checked: title, priority</code></li>
+  <li style="margin-left: 30px;"><code>app factory: create_app</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Exit Ticket</h1>
+            <ol>
+  <li>Which route feels strongest right now?</li>
+  <li>Which failure case still needs testing?</li>
+  <li>What part of your API structure will make tomorrow easier?</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Looking Ahead</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Next Session</h1>
+            <ul>
+  <li>Protect write routes with an API key</li>
+  <li>Build a Python client</li>
+  <li>Choose an integration path</li>
+  <li>Demo the API milestone confidently</li>
+</ul>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/Advanced/lessons/slides/day-09/day-09-session-9.md
+++ b/Advanced/lessons/slides/day-09/day-09-session-9.md
@@ -238,6 +238,11 @@ if payload is None:
 ## CRUD Example
 
 ```python
+# from flask import Flask, request, jsonify
+# from .services import service          # TrackerService instance
+# from .errors import error_response     # helper returning JSON error + status code
+# app = Flask(__name__)
+
 @app.post("/records")
 def create_record():
     payload = request.get_json(silent=True)

--- a/Advanced/lessons/slides/day-09/day-09-session-9.md
+++ b/Advanced/lessons/slides/day-09/day-09-session-9.md
@@ -1,0 +1,582 @@
+# Advanced Day 9 — Session 9 (Hours 33–36)
+Python Programming (Advanced) • REST APIs and Flask Foundations
+
+---
+
+# Session 9 Overview
+
+## Topics Covered Today
+- Hour 33: REST fundamentals + Flask app setup
+- Hour 34: CRUD endpoints for the main resource
+- Hour 35: Serialization + validation
+- Hour 36: App structure + dependency wiring
+
+## Capstone Through-Line
+- Expose the existing tracker logic through a Flask API
+- Keep the service layer as the center of truth
+- Build for maintainability, not framework novelty
+
+---
+
+# Alignment Sources
+
+- Runbook: `Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md` → Session 9 overview; Hours 33–36
+- Lecture: `Advanced/lessons/lecture/Day9_Hour1_Advanced.md` through `Day9_Hour4_Advanced.md`
+- Homework: `Advanced/assignments/Advanced_Day9_homework.ipynb`
+- Quiz: `Advanced/quizzes/Advanced_Day9_Quiz.html`
+
+## Today’s Output Target
+- A working Flask surface over the tracker project
+- Predictable JSON responses
+- A structure that can keep growing tomorrow
+
+---
+
+# Session Success Criteria
+
+- `/health` responds with JSON
+- Main resource supports CRUD behavior
+- Error responses use one consistent JSON shape
+- Write-ready app structure uses explicit dependency wiring
+- Homework and quiz checkpoints are visible in the day’s build flow
+
+---
+
+# Scope Guardrails for Today
+
+- Stay in course scope: Flask + clean contracts + practical structure
+- Do **not** drift into deployment, OAuth, JWT, or API versioning
+- Reuse service and repository logic instead of rebuilding business rules in routes
+- Choose one resource name and keep it consistent in your own project
+
+---
+
+# Hour 33: REST Fundamentals + Flask App Setup
+
+## Learning Outcomes
+- Explain REST-style resources in plain language
+- Distinguish `GET` from `POST`
+- Create a minimal Flask app
+- Return JSON instead of default HTML errors
+
+---
+
+## Why an API Matters Now
+
+- The capstone already has logic and persistence
+- Flask becomes a **new interface**, not a new project
+- An API lets other tools call the same application behavior
+- Strong layering now makes later integration easier
+
+```text
+Client -> Flask route -> service -> repository -> SQLite
+```
+
+---
+
+## REST in Plain English
+
+- **Resource**: the thing the API exposes
+- **Route**: URL pattern connected to code
+- **Method**: `GET`, `POST`, `PUT`, `DELETE`
+- **Status code**: fast signal of what happened
+- **JSON contract**: predictable request/response shape
+
+## Useful Day 9 status codes
+- `200` success
+- `201` created
+- `400` bad input
+- `404` missing resource
+- `500` unexpected failure
+
+---
+
+## Minimal Flask Starter
+
+```python
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.get("/health")
+def health():
+    return jsonify({"status": "ok"})
+```
+
+## Teaching point
+- Start with one honest route before adding CRUD
+
+---
+
+## Consistent Error Contract
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Record 12 was not found.",
+    "request_id": "a1b2c3d4"
+  }
+}
+```
+
+## Why it matters
+- Clients can depend on one structure
+- Logs and user-facing errors connect more cleanly
+
+---
+
+## Demo Flow: Hour 33
+
+1. Create `app = Flask(__name__)`
+2. Add `/health`
+3. Run the server locally
+4. Test with browser, `curl`, or a small Python call
+5. Trigger one intentional failure and show JSON output
+
+---
+
+## Lab: Flask Starter + Smoke Test
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Create a small Flask app
+- Add `/health`
+- Return JSON on success
+- Add one reusable error helper
+- Verify the app from outside the Flask file
+
+### Completion Criteria
+- App starts reliably
+- `/health` returns JSON
+- Learner can explain what a route does
+
+---
+
+## Common Pitfalls (Hour 33)
+
+⚠️ Mixing setup, routing, and service logic in one giant file  
+⚠️ Returning HTML errors while success paths return JSON  
+⚠️ Treating the API as a separate project instead of a new interface
+
+---
+
+## Homework + Quiz Emphasis (Hour 33)
+
+- Homework goal: build a Flask app with a health route and clear REST basics
+- Best practice: start with one small health endpoint before layering CRUD
+- Quiz-ready anchor: `Hour 33 | framework: Flask`
+- Deliverable check: can you show a health route and explain why it matters?
+
+---
+
+## Quick Check
+
+**Question**: Why is a health endpoint a smart first step before building CRUD routes?
+
+---
+
+# Hour 34: CRUD Endpoints for the Main Resource
+
+## Learning Outcomes
+- Implement `GET`, `POST`, `PUT`, and `DELETE`
+- Keep routes thin
+- Connect handlers to the service layer
+- Return the right status codes for the outcome
+
+---
+
+## Canonical Route Set
+
+- `GET /records`
+- `POST /records`
+- `GET /records/<id>`
+- `PUT /records/<id>`
+- `DELETE /records/<id>`
+
+## Naming note
+- Lecture examples use `records`
+- Homework/quiz output anchors may use `tasks`
+- Your project should pick **one** resource name and stay consistent
+
+---
+
+## Thin Route Handler Mindset
+
+### Route responsibilities
+- Read request input
+- Call the service
+- Catch known exceptions
+- Return JSON + status code
+
+### Avoid in the route
+- Direct SQL
+- Deep business logic
+- Hidden global state
+
+---
+
+## Safe JSON Parsing Pattern
+
+```python
+payload = request.get_json(silent=True)
+if payload is None:
+    return error_response(
+        "invalid_json",
+        "Request body must be valid JSON.",
+        400,
+    )
+```
+
+## Key distinction
+- Bad input → `400`
+- Missing resource → `404`
+
+---
+
+## CRUD Example
+
+```python
+@app.post("/records")
+def create_record():
+    payload = request.get_json(silent=True)
+    if payload is None:
+        return error_response("invalid_json", "Request body must be valid JSON.", 400)
+
+    record = service.add_record(
+        title=payload.get("title", ""),
+        category=payload.get("category", ""),
+        status=payload.get("status", "open"),
+    )
+    return jsonify(record.to_dict()), 201
+```
+
+---
+
+## Demo Flow: Hour 34
+
+1. Add list + create routes
+2. Add get-by-id
+3. Add update + delete
+4. Show one success case
+5. Show one validation or not-found case
+
+## Smoke test habit
+- Verify behavior from outside the Flask app
+
+---
+
+## Lab: Build the CRUD Surface
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Add the full CRUD route set
+- Route everything through the service layer
+- Return consistent JSON
+- Test at least one success and one failure for each major path
+
+### Completion Criteria
+- CRUD endpoints respond predictably
+- Status codes match the actual outcome
+- Learner can explain `400` vs `404`
+
+---
+
+## Common Pitfalls (Hour 34)
+
+⚠️ Returning `200` for everything  
+⚠️ Writing business rules in Flask handlers  
+⚠️ Forgetting to test malformed requests  
+⚠️ Letting route names drift between files
+
+---
+
+## Homework + Quiz Emphasis (Hour 34)
+
+- Homework goal: a small set of CRUD endpoints for the tracker resource
+- Best practice: use HTTP verbs and status codes consistently
+- Pitfall to avoid: wrong status codes make clients harder to trust
+- Quiz-ready anchor: `Hour 34 | endpoint: POST /tasks`
+
+---
+
+## Quick Check
+
+**Question**: When should a route return `400` instead of `404`?
+
+---
+
+# Hour 35: Serialization + Validation
+
+## Learning Outcomes
+- Centralize request parsing
+- Centralize response serialization
+- Keep validation rules coherent
+- Use intentional negative cases to test the contract
+
+---
+
+## API Contracts Are Promises
+
+- Requests should arrive in a predictable shape
+- Responses should leave in a predictable shape
+- Failure paths should look consistent too
+- “It works” is not enough if every endpoint behaves differently
+
+---
+
+## Serializer Helper
+
+```python
+def serialize_record(record) -> dict:
+    return {
+        "id": record.id,
+        "title": record.title,
+        "category": record.category,
+        "status": record.status,
+        "priority": record.priority,
+    }
+```
+
+## Benefit
+- One change point instead of copy/paste edits across routes
+
+---
+
+## Parser + Validation Helper
+
+```python
+def parse_record_payload(payload: dict) -> dict:
+    title = str(payload.get("title", "")).strip()
+    category = str(payload.get("category", "")).strip()
+    status = str(payload.get("status", "open")).strip().lower()
+
+    if not title:
+        raise ValidationError("Title is required.")
+    if not category:
+        raise ValidationError("Category is required.")
+    if status not in {"open", "in_progress", "done"}:
+        raise ValidationError("Status is invalid.")
+
+    return {"title": title, "category": category, "status": status}
+```
+
+---
+
+## Where Validation Should Live
+
+- Parser helpers normalize and reject malformed payloads
+- Service layer enforces domain invariants
+- Routes should **not** duplicate the same rules repeatedly
+
+## Negative test ideas
+- invalid JSON
+- missing title
+- missing category
+- invalid status value
+
+---
+
+## Cleaner Route Pattern
+
+```python
+@app.post("/records")
+def create_record():
+    payload = request.get_json(silent=True)
+    if payload is None:
+        return error_response("invalid_json", "Request body must be valid JSON.", 400)
+
+    try:
+        parsed = parse_record_payload(payload)
+        record = service.add_record(**parsed)
+    except ValidationError as exc:
+        return error_response("validation_error", str(exc), 400)
+
+    return jsonify(serialize_record(record)), 201
+```
+
+---
+
+## Lab: Make the API Coherent
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Add one serializer helper
+- Add one parser/validator helper
+- Replace ad hoc route logic with helpers
+- Run a few negative cases intentionally
+
+### Completion Criteria
+- Output shape is consistent across routes
+- Validation rules live in one obvious place
+- Learner can explain at least one negative test result
+
+---
+
+## Common Pitfalls (Hour 35)
+
+⚠️ Different key sets across endpoints  
+⚠️ Validation logic duplicated in multiple routes  
+⚠️ Plain-text errors in one handler and JSON in another  
+⚠️ Negative cases never tested until demo time
+
+---
+
+## Homework + Quiz Emphasis (Hour 35)
+
+- Homework goal: manual serializers and validators for tracker payloads
+- Best practice: one consistent request/response contract
+- Pitfall to avoid: different key sets confuse clients
+- Quiz-ready anchor: `Hour 35 | request fields checked: title, priority`
+
+---
+
+## Quick Check
+
+**Question**: Why is centralizing parsing and serialization safer than rebuilding dictionaries inside each route?
+
+---
+
+# Hour 36: App Structure + Dependency Wiring
+
+## Learning Outcomes
+- Explain why growing apps need structure
+- Refactor toward a `create_app()` pattern
+- Wire dependencies explicitly
+- Avoid circular imports and hidden globals
+
+---
+
+## When Structure Starts to Matter
+
+- Single-file apps are great for learning
+- Growth creates import noise and setup confusion
+- Testing gets harder when construction happens at import time
+- Clear startup makes the app easier to reason about
+
+---
+
+## Simple Application Factory
+
+```python
+def create_app():
+    app = Flask(__name__)
+    repo = SQLiteTrackerRepository("data/tracker.db")
+    repo.init_db()
+    service = TrackerService(repo=repo)
+    register_routes(app, service)
+    return app
+```
+
+## Why it helps
+- One visible startup path
+- Explicit dependencies
+- Easier testing later
+
+---
+
+## Structure Options for This Course
+
+### Minimum good structure
+- `api/app.py` for startup
+- `api/routes.py` for route registration
+- service + repository modules stay separate
+
+### Optional structure
+- Flask blueprints if the learner is ready
+
+## Guardrail
+- Do not overframework the capstone
+
+---
+
+## Common Architecture Risks
+
+- Global service creation at import time
+- `routes.py` importing `app.py` and vice versa
+- Repository construction hidden in random modules
+- Learners changing file layout without updating imports deliberately
+
+---
+
+## Refactor Sprint
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Move routes into a dedicated module or grouping
+- Add `create_app()`
+- Construct repository + service in one clear place
+- Re-test `/health` and main resource routes
+
+### Completion Criteria
+- Startup is predictable
+- Route wiring is readable
+- API still behaves the same after refactor
+
+---
+
+## Common Pitfalls (Hour 36)
+
+⚠️ Circular imports  
+⚠️ Hidden global singletons  
+⚠️ Refactoring too much at once  
+⚠️ Losing a working route while reorganizing
+
+---
+
+## Homework + Quiz Emphasis (Hour 36)
+
+- Homework goal: an app structure that can grow beyond one file
+- Best practice: use an app factory and optional blueprints to organize startup
+- Pitfall to avoid: global singletons hide dependencies and hurt testing
+- Quiz-ready anchor: `Hour 36 | app factory: create_app`
+
+---
+
+## Quick Check
+
+**Question**: What problem does `create_app()` solve that a global `service = ...` pattern does not?
+
+---
+
+# Day 9 Wrap-Up
+
+## What Learners Should Leave With
+- A Flask entry point
+- CRUD routes around one main resource
+- Manual parser + serializer helpers
+- A maintainable startup path for tomorrow’s security and client work
+
+---
+
+## Homework Focus
+
+- Build deterministic outputs in `Advanced_Day9_homework.ipynb`
+- Keep the contract stable enough for autograder-style labels
+- Rehearse the hour anchors:
+  - `framework: Flask`
+  - `endpoint: POST /tasks`
+  - `request fields checked: title, priority`
+  - `app factory: create_app`
+
+---
+
+## Exit Ticket
+
+1. Which route feels strongest right now?
+2. Which failure case still needs testing?
+3. What part of your API structure will make tomorrow easier?
+
+---
+
+# Looking Ahead
+
+## Next Session
+- Protect write routes with an API key
+- Build a Python client
+- Choose an integration path
+- Demo the API milestone confidently

--- a/Advanced/lessons/slides/day-10/day-10-session-10.html
+++ b/Advanced/lessons/slides/day-10/day-10-session-10.html
@@ -1,0 +1,1151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 10 — Session 10 (Hours 37–40)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 10 — Session 10 (Hours 37–40)</h1>
+            <div class="subtitle">Python Programming (Advanced) • API Security, Clients, and Milestone Demo</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 10 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 37: API security basics with an API key gate</li>
+  <li>Hour 38: Consuming your own API with Python client functions</li>
+  <li>Hour 39: Integration choice — GUI to API or parallel UI/API</li>
+  <li>Hour 40: Checkpoint 5 API milestone demo</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day Goal</h1>
+            <ul>
+  <li>Move from “API exists” to “API is controlled, usable, and demo-ready”</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Alignment Sources</h1>
+            <ul>
+  <li>Runbook: <code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → Session 10 overview; Hours 37–40</li>
+  <li>Lecture: <code>Advanced/lessons/lecture/Day10_Hour1_Advanced.md</code> through <code>Day10_Hour4_Advanced.md</code></li>
+  <li>Homework: <code>Advanced/assignments/Advanced_Day10_homework.ipynb</code></li>
+  <li>Quiz: <code>Advanced/quizzes/Advanced_Day10_Quiz.html</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Theme</h1>
+            <ul>
+  <li>Protect the write surface</li>
+  <li>Use the API from the outside</li>
+  <li>Choose an integration path intentionally</li>
+  <li>Stabilize for checkpoint evidence</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Success Criteria</h1>
+            <ul>
+  <li>Write routes require an API key</li>
+  <li>Client calls use timeouts and predictable error handling</li>
+  <li>The project has a clear integration story</li>
+  <li>Checkpoint 5 shows health, CRUD, protection, and architecture explanation</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            <ul>
+  <li>This is <strong>not</strong> full authentication or identity management</li>
+  <li>API keys live in configuration, not source control</li>
+  <li>Choose the architecture that best protects the milestone</li>
+  <li>Stabilize before adding extra features</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 37: API Security Basics</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain why writes need stronger protection than reads</li>
+  <li>Load a key from configuration</li>
+  <li>Require <code>X-API-Key</code> on <code>POST</code>, <code>PUT</code>, and <code>DELETE</code></li>
+  <li>Return clear <code>401</code> and <code>403</code> responses</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Security Framing Without Panic</h1>
+            <ul>
+  <li>We are adding a <strong>course-level gate</strong></li>
+  <li>We are <strong>not</strong> building OAuth, JWT, or full auth systems</li>
+  <li>The lesson is about:</li>
+  <li style="margin-left: 30px;">safer configuration</li>
+  <li style="margin-left: 30px;">boundary checks</li>
+  <li style="margin-left: 30px;">consistent failure responses</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Rule of thumb</h1>
+            <ul>
+  <li>Reads may be open</li>
+  <li>Writes deserve protection</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>What an API Key Is — and Is Not</h1>
+            <ul>
+  <li>A shared secret checked at the HTTP boundary</li>
+  <li>Good enough for course-level protection of write operations</li>
+  <li><strong>Not</strong> a user identity system</li>
+  <li><strong>Not</strong> a replacement for a production auth stack</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Keep the Secret Out of Source</h1>
+            <pre data-lang="python"><code>import os
+
+API_KEY = os.getenv(&quot;TRACKER_API_KEY&quot;, &quot;&quot;)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Safe handling habits</h1>
+            <ul>
+  <li>Do not hard-code the key</li>
+  <li>Do not commit real values</li>
+  <li><code>.env.example</code> may hold placeholders only</li>
+  <li>Do not log the actual secret</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Header + Status Code Pattern</h1>
+            <h3>Client sends</h3>
+<pre data-lang="text"><code>X-API-Key: &lt;value&gt;</code></pre>
+<h3>Server responds</h3>
+<ul>
+  <li><code>401</code> when the key is missing</li>
+  <li><code>403</code> when the key is present but wrong</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Key habit</h1>
+            <ul>
+  <li>Pick a rule and apply it consistently</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Guard Helper Example</h1>
+            <pre data-lang="python"><code>def require_api_key():
+    provided = request.headers.get(&quot;X-API-Key&quot;, &quot;&quot;)
+
+    if not provided:
+        return error_response(&quot;missing_api_key&quot;, &quot;API key is required.&quot;, 401)
+
+    if not API_KEY or not hmac.compare_digest(provided, API_KEY):
+        return error_response(&quot;invalid_api_key&quot;, &quot;API key is invalid.&quot;, 403)
+
+    return None</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Flow: Hour 37</h1>
+            <ol>
+  <li>Read the key from config</li>
+  <li>Add the helper</li>
+  <li>Protect write routes</li>
+  <li>Test three cases:</li>
+</ol>
+<ul>
+  <li style="margin-left: 30px;">no key</li>
+  <li style="margin-left: 30px;">wrong key</li>
+  <li style="margin-left: 30px;">correct key</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Teaching point</h1>
+            <ul>
+  <li>Security work is incomplete until the failure cases are tested</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Protect the Write Surface</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Load the key from configuration</li>
+  <li>Protect <code>POST</code>, <code>PUT</code>, and <code>DELETE</code></li>
+  <li>Return structured auth failures</li>
+  <li>Add placeholder documentation for secret setup</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Every write route is protected</li>
+  <li>Auth failures still use JSON</li>
+  <li>Learner can explain why the service layer stays header-free</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 37)</h1>
+            <p><strong>⚠️</strong> Hard-coding the key</p>
+<p><strong>⚠️</strong> Protecting some write routes but forgetting one</p>
+<p><strong>⚠️</strong> Logging the real secret</p>
+<p><strong>⚠️</strong> Treating missing and wrong keys as the same case without intention</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 37)</h1>
+            <ul>
+  <li>Homework goal: a simple API key check around write operations</li>
+  <li>Best practice: environment-based key in course scope</li>
+  <li>Pitfall to avoid: hard-coded credentials in source or logs</li>
+  <li>Quiz-ready anchor: <code>Hour 37 | protected route: POST /tasks</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why should the API key check live in the route layer instead of inside the service layer?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 38: Consuming Your Own API</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Write small client functions</li>
+  <li>Set request timeouts</li>
+  <li>Pass auth headers for protected operations</li>
+  <li>Turn server-side failures into readable client feedback</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Become Your Own Client?</h1>
+            <ul>
+  <li>An API can feel fine from the inside but awkward from the outside</li>
+  <li>Client code reveals:</li>
+  <li style="margin-left: 30px;">confusing contracts</li>
+  <li style="margin-left: 30px;">inconsistent errors</li>
+  <li style="margin-left: 30px;">missing timeouts</li>
+  <li style="margin-left: 30px;">unreliable route behavior</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Healthy mindset</h1>
+            <ul>
+  <li>Let the API prove itself from the consumer’s side</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Shape of a Simple Client Module</h1>
+            <ul>
+  <li>Keep it flat and readable</li>
+  <li>Each function should:</li>
+  <li style="margin-left: 30px;">build the URL</li>
+  <li style="margin-left: 30px;">send the request</li>
+  <li style="margin-left: 30px;">set a timeout</li>
+  <li style="margin-left: 30px;">handle errors predictably</li>
+  <li style="margin-left: 30px;">return parsed JSON or a small mapped result</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Timeout + Header Pattern</h1>
+            <pre data-lang="python"><code>import requests
+
+def create_record(payload: dict, api_key: str) -&gt; dict:
+    response = requests.post(
+        f&quot;{BASE_URL}/records&quot;,
+        json=payload,
+        headers={&quot;X-API-Key&quot;: api_key},
+        timeout=5,
+    )
+    response.raise_for_status()
+    return response.json()</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Habit to keep</h1>
+            <ul>
+  <li>Never let requests hang indefinitely</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Friendly Error Handling</h1>
+            <pre data-lang="python"><code>def safe_create_record(payload: dict, api_key: str):
+    try:
+        return create_record(payload, api_key)
+    except requests.Timeout:
+        print(&quot;The API request timed out.&quot;)
+    except requests.HTTPError as exc:
+        print(f&quot;Request failed: {exc}&quot;)
+    return None</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Teaching point</h1>
+            <ul>
+  <li>The client should help the user understand what failed</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Build the Client Module</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Required functions</h3>
+<ul>
+  <li><code>list_records</code></li>
+  <li><code>create_record</code></li>
+  <li><code>update_record</code></li>
+  <li><code>delete_record</code></li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Timeout is visible in each request path</li>
+  <li>Write operations pass the header</li>
+  <li>Learner can explain the difference between timeout and validation failure</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 38)</h1>
+            <p><strong>⚠️</strong> No timeout</p>
+<p><strong>⚠️</strong> Forgetting headers on <code>PUT</code> or <code>DELETE</code></p>
+<p><strong>⚠️</strong> Copy-pasting base URLs everywhere</p>
+<p><strong>⚠️</strong> Swallowing errors with no visible message</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 38)</h1>
+            <ul>
+  <li>Homework goal: a reusable Python client for the tracker API</li>
+  <li>Best practice: wrap requests in small client functions</li>
+  <li>Pitfall to avoid: raw requests calls scattered everywhere</li>
+  <li>Quiz-ready anchor: <code>Hour 38 | client base url: http://localhost:5000</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What problem does <code>timeout=5</code> solve that a successful happy-path demo might hide?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 39: Integration Choice</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Describe two valid integration patterns</li>
+  <li>Choose the safer path for the current project state</li>
+  <li>Prove the system stays coherent</li>
+  <li>Explain tradeoffs clearly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Two Valid Paths</h1>
+            <h3>Option A: GUI talks to API</h3>
+<pre data-lang="text"><code>GUI -&gt; client functions -&gt; API -&gt; service -&gt; repository -&gt; database</code></pre>
+<h3>Option B: Parallel GUI and API</h3>
+<pre data-lang="text"><code>GUI -&gt; service -&gt; repository -&gt; database
+API -&gt; service -&gt; repository -&gt; database</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Important</h1>
+            <ul>
+  <li>Both are valid in this course</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Option A: GUI to API</h1>
+            <h3>Benefits</h3>
+<ul>
+  <li>One outward-facing contract</li>
+  <li>GUI exercises the same HTTP behavior as other clients</li>
+  <li>Good practice for decoupled systems</li>
+</ul>
+<h3>Tradeoffs</h3>
+<ul>
+  <li>More moving parts</li>
+  <li>More failure points</li>
+  <li>GUI must handle network-style issues</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Option B: Parallel GUI and API</h1>
+            <h3>Benefits</h3>
+<ul>
+  <li>Faster to stabilize</li>
+  <li>Lower integration friction</li>
+  <li>Still demonstrates architecture reuse</li>
+</ul>
+<h3>Tradeoffs</h3>
+<ul>
+  <li>GUI does not exercise the HTTP contract directly</li>
+  <li>Fields and behavior can drift if discipline slips</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>How to Choose Well</h1>
+            <ul>
+  <li>If the API and client are stable, Option A is reasonable</li>
+  <li>If the project still feels shaky, Option B often protects the milestone better</li>
+  <li>Choosing the safer path is a <strong>professional decision</strong>, not a weaker one</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Integration Sprint</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Choose Option A or B intentionally</li>
+  <li>Document the choice briefly</li>
+  <li>Prove both surfaces touch the same underlying data</li>
+  <li>Fix at least one mismatch if it appears</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>The architecture choice is explicit</li>
+  <li>The system still looks like <strong>one</strong> application</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 39)</h1>
+            <p><strong>⚠️</strong> GUI and API using different field names</p>
+<p><strong>⚠️</strong> Stale GUI data after writes</p>
+<p><strong>⚠️</strong> Accidentally creating two database files</p>
+<p><strong>⚠️</strong> Drifting into a hybrid design nobody can explain</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 39)</h1>
+            <ul>
+  <li>Homework goal: an integration story that connects the interface to the API cleanly</li>
+  <li>Best practice: pick one path and document the communication flow</li>
+  <li>Pitfall to avoid: parallel flows without a clear source of truth</li>
+  <li>Quiz-ready anchor: <code>Hour 39 | chosen path: gui talks to api</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: When would Option B be the smarter choice even if Option A feels more impressive?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 40: Checkpoint 5 — API Milestone Demo</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Demonstrate a working API backed by SQLite</li>
+  <li>Show security and error handling in action</li>
+  <li>Explain the layer connections</li>
+  <li>Identify the weakest part of the milestone honestly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>What Counts as Success</h1>
+            <ul>
+  <li>Flask API with CRUD routes</li>
+  <li>SQLite-backed persistence</li>
+  <li>Consistent JSON errors</li>
+  <li>API key protection on write operations</li>
+  <li>Optional Python client if available</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Reminder</h1>
+            <ul>
+  <li>Today rewards stability more than feature count</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Fast-Grade Demo Sequence</h1>
+            <ol>
+  <li><code>GET /health</code></li>
+  <li><code>GET /records</code></li>
+  <li><code>POST /records</code> with valid key</li>
+  <li><code>PUT /records/&lt;id&gt;</code> with valid key</li>
+  <li><code>DELETE /records/&lt;id&gt;</code> with valid key</li>
+  <li>one missing or invalid key failure</li>
+  <li>one invalid input or not-found failure</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Stabilization Checklist</h1>
+            <pre data-lang="text"><code>[ ] API starts reliably
+[ ] /health returns JSON
+[ ] Create returns 201
+[ ] Update returns 200
+[ ] Delete returns 200
+[ ] Invalid input returns 400 JSON
+[ ] Missing/wrong key returns 401/403 JSON
+[ ] Data persists in SQLite</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Rehearsal Mindset</h1>
+            <ul>
+  <li>Confirm payloads before demo time</li>
+  <li>Confirm headers before demo time</li>
+  <li>Confirm database path before demo time</li>
+  <li>Reproduce failures intentionally</li>
+  <li>Fix the weakest route first</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope guardrail</h1>
+            <ul>
+  <li>Stabilize before adding any “nice-to-have” endpoint</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Failure Modes</h1>
+            <p><strong>⚠️</strong> HTML error page instead of JSON</p>
+<p><strong>⚠️</strong> One write route forgot the API key check</p>
+<p><strong>⚠️</strong> Service exceptions leaking uncaught</p>
+<p><strong>⚠️</strong> Payload shape not matching parser rules</p>
+<p><strong>⚠️</strong> Different database paths in different environments</p>
+        </section>
+
+        <section class="slide">
+            <h1>Showcase Prompt</h1>
+            <ul>
+  <li>Show one healthy path</li>
+  <li>Show one protected failure</li>
+  <li>Explain the architecture in one minute</li>
+  <li>Name the most fragile part honestly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Good demo standard</h1>
+            <ul>
+  <li>believable</li>
+  <li>repeatable</li>
+  <li>explainable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 40)</h1>
+            <ul>
+  <li>Homework goal: a checkpoint demo showing the secured API and client path</li>
+  <li>Best practice: checkpoint the full request flow from caller to response</li>
+  <li>Pitfall to avoid: proving only one endpoint and calling it a milestone</li>
+  <li>Quiz-ready anchor: <code>Hour 40 | api demo health: ok</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What makes an API milestone feel maintainable, not just functional?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 10 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>End-of-Day Evidence</h1>
+            <ul>
+  <li>Key-based protection is working</li>
+  <li>Client code can consume the API safely</li>
+  <li>Integration choice is deliberate</li>
+  <li>Checkpoint 5 can be demoed without guesswork</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Homework Focus</h1>
+            <ul>
+  <li>Keep output deterministic in <code>Advanced_Day10_homework.ipynb</code></li>
+  <li>Rehearse the anchor lines:</li>
+  <li style="margin-left: 30px;"><code>protected route: POST /tasks</code></li>
+  <li style="margin-left: 30px;"><code>client base url: http://localhost:5000</code></li>
+  <li style="margin-left: 30px;"><code>chosen path: gui talks to api</code></li>
+  <li style="margin-left: 30px;"><code>api demo health: ok</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Exit Ticket</h1>
+            <ol>
+  <li>Which endpoint is strongest in your demo flow?</li>
+  <li>What did the client reveal about your API?</li>
+  <li>Which architecture choice did you make — and why?</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Looking Ahead</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Next Session</h1>
+            <ul>
+  <li>Turn stored data into summaries</li>
+  <li>Build report-ready charts</li>
+  <li>Try a limited regression workflow or fallback analysis</li>
+  <li>Add analytics as a real capstone feature</li>
+</ul>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/Advanced/lessons/slides/day-10/day-10-session-10.md
+++ b/Advanced/lessons/slides/day-10/day-10-session-10.md
@@ -1,0 +1,547 @@
+# Advanced Day 10 — Session 10 (Hours 37–40)
+Python Programming (Advanced) • API Security, Clients, and Milestone Demo
+
+---
+
+# Session 10 Overview
+
+## Topics Covered Today
+- Hour 37: API security basics with an API key gate
+- Hour 38: Consuming your own API with Python client functions
+- Hour 39: Integration choice — GUI to API or parallel UI/API
+- Hour 40: Checkpoint 5 API milestone demo
+
+## Day Goal
+- Move from “API exists” to “API is controlled, usable, and demo-ready”
+
+---
+
+# Alignment Sources
+
+- Runbook: `Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md` → Session 10 overview; Hours 37–40
+- Lecture: `Advanced/lessons/lecture/Day10_Hour1_Advanced.md` through `Day10_Hour4_Advanced.md`
+- Homework: `Advanced/assignments/Advanced_Day10_homework.ipynb`
+- Quiz: `Advanced/quizzes/Advanced_Day10_Quiz.html`
+
+## Session Theme
+- Protect the write surface
+- Use the API from the outside
+- Choose an integration path intentionally
+- Stabilize for checkpoint evidence
+
+---
+
+# Session Success Criteria
+
+- Write routes require an API key
+- Client calls use timeouts and predictable error handling
+- The project has a clear integration story
+- Checkpoint 5 shows health, CRUD, protection, and architecture explanation
+
+---
+
+# Scope Guardrails for Today
+
+- This is **not** full authentication or identity management
+- API keys live in configuration, not source control
+- Choose the architecture that best protects the milestone
+- Stabilize before adding extra features
+
+---
+
+# Hour 37: API Security Basics
+
+## Learning Outcomes
+- Explain why writes need stronger protection than reads
+- Load a key from configuration
+- Require `X-API-Key` on `POST`, `PUT`, and `DELETE`
+- Return clear `401` and `403` responses
+
+---
+
+## Security Framing Without Panic
+
+- We are adding a **course-level gate**
+- We are **not** building OAuth, JWT, or full auth systems
+- The lesson is about:
+  - safer configuration
+  - boundary checks
+  - consistent failure responses
+
+## Rule of thumb
+- Reads may be open
+- Writes deserve protection
+
+---
+
+## What an API Key Is — and Is Not
+
+- A shared secret checked at the HTTP boundary
+- Good enough for course-level protection of write operations
+- **Not** a user identity system
+- **Not** a replacement for a production auth stack
+
+---
+
+## Keep the Secret Out of Source
+
+```python
+import os
+
+API_KEY = os.getenv("TRACKER_API_KEY", "")
+```
+
+## Safe handling habits
+- Do not hard-code the key
+- Do not commit real values
+- `.env.example` may hold placeholders only
+- Do not log the actual secret
+
+---
+
+## Header + Status Code Pattern
+
+### Client sends
+```text
+X-API-Key: <value>
+```
+
+### Server responds
+- `401` when the key is missing
+- `403` when the key is present but wrong
+
+## Key habit
+- Pick a rule and apply it consistently
+
+---
+
+## Guard Helper Example
+
+```python
+def require_api_key():
+    provided = request.headers.get("X-API-Key", "")
+
+    if not provided:
+        return error_response("missing_api_key", "API key is required.", 401)
+
+    if not API_KEY or not hmac.compare_digest(provided, API_KEY):
+        return error_response("invalid_api_key", "API key is invalid.", 403)
+
+    return None
+```
+
+---
+
+## Demo Flow: Hour 37
+
+1. Read the key from config
+2. Add the helper
+3. Protect write routes
+4. Test three cases:
+   - no key
+   - wrong key
+   - correct key
+
+## Teaching point
+- Security work is incomplete until the failure cases are tested
+
+---
+
+## Lab: Protect the Write Surface
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Load the key from configuration
+- Protect `POST`, `PUT`, and `DELETE`
+- Return structured auth failures
+- Add placeholder documentation for secret setup
+
+### Completion Criteria
+- Every write route is protected
+- Auth failures still use JSON
+- Learner can explain why the service layer stays header-free
+
+---
+
+## Common Pitfalls (Hour 37)
+
+⚠️ Hard-coding the key  
+⚠️ Protecting some write routes but forgetting one  
+⚠️ Logging the real secret  
+⚠️ Treating missing and wrong keys as the same case without intention
+
+---
+
+## Homework + Quiz Emphasis (Hour 37)
+
+- Homework goal: a simple API key check around write operations
+- Best practice: environment-based key in course scope
+- Pitfall to avoid: hard-coded credentials in source or logs
+- Quiz-ready anchor: `Hour 37 | protected route: POST /tasks`
+
+---
+
+## Quick Check
+
+**Question**: Why should the API key check live in the route layer instead of inside the service layer?
+
+---
+
+# Hour 38: Consuming Your Own API
+
+## Learning Outcomes
+- Write small client functions
+- Set request timeouts
+- Pass auth headers for protected operations
+- Turn server-side failures into readable client feedback
+
+---
+
+## Why Become Your Own Client?
+
+- An API can feel fine from the inside but awkward from the outside
+- Client code reveals:
+  - confusing contracts
+  - inconsistent errors
+  - missing timeouts
+  - unreliable route behavior
+
+## Healthy mindset
+- Let the API prove itself from the consumer’s side
+
+---
+
+## Shape of a Simple Client Module
+
+- Keep it flat and readable
+- Each function should:
+  - build the URL
+  - send the request
+  - set a timeout
+  - handle errors predictably
+  - return parsed JSON or a small mapped result
+
+---
+
+## Timeout + Header Pattern
+
+```python
+import requests
+
+def create_record(payload: dict, api_key: str) -> dict:
+    response = requests.post(
+        f"{BASE_URL}/records",
+        json=payload,
+        headers={"X-API-Key": api_key},
+        timeout=5,
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+## Habit to keep
+- Never let requests hang indefinitely
+
+---
+
+## Friendly Error Handling
+
+```python
+def safe_create_record(payload: dict, api_key: str):
+    try:
+        return create_record(payload, api_key)
+    except requests.Timeout:
+        print("The API request timed out.")
+    except requests.HTTPError as exc:
+        print(f"Request failed: {exc}")
+    return None
+```
+
+## Teaching point
+- The client should help the user understand what failed
+
+---
+
+## Lab: Build the Client Module
+
+**Time: 25–35 minutes**
+
+### Required functions
+- `list_records`
+- `create_record`
+- `update_record`
+- `delete_record`
+
+### Completion Criteria
+- Timeout is visible in each request path
+- Write operations pass the header
+- Learner can explain the difference between timeout and validation failure
+
+---
+
+## Common Pitfalls (Hour 38)
+
+⚠️ No timeout  
+⚠️ Forgetting headers on `PUT` or `DELETE`  
+⚠️ Copy-pasting base URLs everywhere  
+⚠️ Swallowing errors with no visible message
+
+---
+
+## Homework + Quiz Emphasis (Hour 38)
+
+- Homework goal: a reusable Python client for the tracker API
+- Best practice: wrap requests in small client functions
+- Pitfall to avoid: raw requests calls scattered everywhere
+- Quiz-ready anchor: `Hour 38 | client base url: http://localhost:5000`
+
+---
+
+## Quick Check
+
+**Question**: What problem does `timeout=5` solve that a successful happy-path demo might hide?
+
+---
+
+# Hour 39: Integration Choice
+
+## Learning Outcomes
+- Describe two valid integration patterns
+- Choose the safer path for the current project state
+- Prove the system stays coherent
+- Explain tradeoffs clearly
+
+---
+
+## Two Valid Paths
+
+### Option A: GUI talks to API
+```text
+GUI -> client functions -> API -> service -> repository -> database
+```
+
+### Option B: Parallel GUI and API
+```text
+GUI -> service -> repository -> database
+API -> service -> repository -> database
+```
+
+## Important
+- Both are valid in this course
+
+---
+
+## Option A: GUI to API
+
+### Benefits
+- One outward-facing contract
+- GUI exercises the same HTTP behavior as other clients
+- Good practice for decoupled systems
+
+### Tradeoffs
+- More moving parts
+- More failure points
+- GUI must handle network-style issues
+
+---
+
+## Option B: Parallel GUI and API
+
+### Benefits
+- Faster to stabilize
+- Lower integration friction
+- Still demonstrates architecture reuse
+
+### Tradeoffs
+- GUI does not exercise the HTTP contract directly
+- Fields and behavior can drift if discipline slips
+
+---
+
+## How to Choose Well
+
+- If the API and client are stable, Option A is reasonable
+- If the project still feels shaky, Option B often protects the milestone better
+- Choosing the safer path is a **professional decision**, not a weaker one
+
+---
+
+## Integration Sprint
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Choose Option A or B intentionally
+- Document the choice briefly
+- Prove both surfaces touch the same underlying data
+- Fix at least one mismatch if it appears
+
+### Completion Criteria
+- The architecture choice is explicit
+- The system still looks like **one** application
+
+---
+
+## Common Pitfalls (Hour 39)
+
+⚠️ GUI and API using different field names  
+⚠️ Stale GUI data after writes  
+⚠️ Accidentally creating two database files  
+⚠️ Drifting into a hybrid design nobody can explain
+
+---
+
+## Homework + Quiz Emphasis (Hour 39)
+
+- Homework goal: an integration story that connects the interface to the API cleanly
+- Best practice: pick one path and document the communication flow
+- Pitfall to avoid: parallel flows without a clear source of truth
+- Quiz-ready anchor: `Hour 39 | chosen path: gui talks to api`
+
+---
+
+## Quick Check
+
+**Question**: When would Option B be the smarter choice even if Option A feels more impressive?
+
+---
+
+# Hour 40: Checkpoint 5 — API Milestone Demo
+
+## Learning Outcomes
+- Demonstrate a working API backed by SQLite
+- Show security and error handling in action
+- Explain the layer connections
+- Identify the weakest part of the milestone honestly
+
+---
+
+## What Counts as Success
+
+- Flask API with CRUD routes
+- SQLite-backed persistence
+- Consistent JSON errors
+- API key protection on write operations
+- Optional Python client if available
+
+## Reminder
+- Today rewards stability more than feature count
+
+---
+
+## Fast-Grade Demo Sequence
+
+1. `GET /health`
+2. `GET /records`
+3. `POST /records` with valid key
+4. `PUT /records/<id>` with valid key
+5. `DELETE /records/<id>` with valid key
+6. one missing or invalid key failure
+7. one invalid input or not-found failure
+
+---
+
+## Stabilization Checklist
+
+```text
+[ ] API starts reliably
+[ ] /health returns JSON
+[ ] Create returns 201
+[ ] Update returns 200
+[ ] Delete returns 200
+[ ] Invalid input returns 400 JSON
+[ ] Missing/wrong key returns 401/403 JSON
+[ ] Data persists in SQLite
+```
+
+---
+
+## Rehearsal Mindset
+
+- Confirm payloads before demo time
+- Confirm headers before demo time
+- Confirm database path before demo time
+- Reproduce failures intentionally
+- Fix the weakest route first
+
+## Scope guardrail
+- Stabilize before adding any “nice-to-have” endpoint
+
+---
+
+## Common Failure Modes
+
+⚠️ HTML error page instead of JSON  
+⚠️ One write route forgot the API key check  
+⚠️ Service exceptions leaking uncaught  
+⚠️ Payload shape not matching parser rules  
+⚠️ Different database paths in different environments
+
+---
+
+## Showcase Prompt
+
+- Show one healthy path
+- Show one protected failure
+- Explain the architecture in one minute
+- Name the most fragile part honestly
+
+## Good demo standard
+- believable
+- repeatable
+- explainable
+
+---
+
+## Homework + Quiz Emphasis (Hour 40)
+
+- Homework goal: a checkpoint demo showing the secured API and client path
+- Best practice: checkpoint the full request flow from caller to response
+- Pitfall to avoid: proving only one endpoint and calling it a milestone
+- Quiz-ready anchor: `Hour 40 | api demo health: ok`
+
+---
+
+## Quick Check
+
+**Question**: What makes an API milestone feel maintainable, not just functional?
+
+---
+
+# Day 10 Wrap-Up
+
+## End-of-Day Evidence
+- Key-based protection is working
+- Client code can consume the API safely
+- Integration choice is deliberate
+- Checkpoint 5 can be demoed without guesswork
+
+---
+
+## Homework Focus
+
+- Keep output deterministic in `Advanced_Day10_homework.ipynb`
+- Rehearse the anchor lines:
+  - `protected route: POST /tasks`
+  - `client base url: http://localhost:5000`
+  - `chosen path: gui talks to api`
+  - `api demo health: ok`
+
+---
+
+## Exit Ticket
+
+1. Which endpoint is strongest in your demo flow?
+2. What did the client reveal about your API?
+3. Which architecture choice did you make — and why?
+
+---
+
+# Looking Ahead
+
+## Next Session
+- Turn stored data into summaries
+- Build report-ready charts
+- Try a limited regression workflow or fallback analysis
+- Add analytics as a real capstone feature

--- a/Advanced/lessons/slides/day-11/day-11-session-11.html
+++ b/Advanced/lessons/slides/day-11/day-11-session-11.html
@@ -1,0 +1,1125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 11 — Session 11 (Hours 41–44)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 11 — Session 11 (Hours 41–44)</h1>
+            <div class="subtitle">Python Programming (Advanced) • Analytics, Visualization, and Reporting</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 11 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 41: pandas essentials — loading, cleaning, summarizing</li>
+  <li>Hour 42: visualization with matplotlib</li>
+  <li>Hour 43: regression demo or equivalent analysis</li>
+  <li>Hour 44: integrate analytics into the capstone</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day Goal</h1>
+            <ul>
+  <li>Turn capstone data into a repeatable reporting pipeline</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Alignment Sources</h1>
+            <ul>
+  <li>Runbook: <code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → Session 11 overview; Hours 41–44</li>
+  <li>Lecture: <code>Advanced/lessons/lecture/Day11_Hour1_Advanced.md</code> through <code>Day11_Hour4_Advanced.md</code></li>
+  <li>Homework: <code>Advanced/assignments/Advanced_Day11_homework.ipynb</code></li>
+  <li>Quiz: <code>Advanced/quizzes/Advanced_Day11_Quiz.html</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Theme</h1>
+            <ul>
+  <li>Use the <strong>same dataset</strong> all day</li>
+  <li>Clean before trusting</li>
+  <li>Visualize with intention</li>
+  <li>Package analytics as a feature, not a notebook fragment</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Success Criteria</h1>
+            <ul>
+  <li>Exported data loads into pandas cleanly</li>
+  <li>At least one summary artifact is saved</li>
+  <li>At least one readable chart lands in <code>reports/</code></li>
+  <li>Analysis stays within course scope</li>
+  <li>Report generation becomes repeatable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            <ul>
+  <li>Start from the capstone dataset when possible</li>
+  <li>Do not force machine learning if the data does not fit</li>
+  <li>A clear summary + one strong chart beats a flashy but shallow notebook</li>
+  <li>Repeatability matters more than manual heroics</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 41: pandas Essentials</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Load capstone data into a DataFrame</li>
+  <li>Inspect shape, columns, and types</li>
+  <li>Clean common data issues</li>
+  <li>Compute useful summaries and grouped counts</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>The Analytics Mindset</h1>
+            <ul>
+  <li>We are not leaving the capstone behind</li>
+  <li>We are adding a reporting lens to the same project</li>
+  <li>Strong analysis starts with:</li>
+  <li style="margin-left: 30px;">inspection</li>
+  <li style="margin-left: 30px;">cleaning</li>
+  <li style="margin-left: 30px;">simple, honest summaries</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day 11 reminder</h1>
+            <ul>
+  <li>Use the same dataset from Hour 41 through Hour 44</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>First Inspection Steps</h1>
+            <pre data-lang="python"><code>import pandas as pd
+
+df = pd.read_csv(&quot;reports/records_export.csv&quot;)
+print(df.head())
+print(df.shape)
+print(df.dtypes)
+print(df.isna().sum())</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Habit</h1>
+            <ul>
+  <li>Inspect before you interpret</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Cleaning Moves</h1>
+            <pre data-lang="python"><code>df[&quot;category&quot;] = df[&quot;category&quot;].str.strip().str.lower()
+df[&quot;priority&quot;] = pd.to_numeric(df[&quot;priority&quot;], errors=&quot;coerce&quot;)
+df[&quot;status&quot;] = df[&quot;status&quot;].fillna(&quot;unknown&quot;)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Typical issues</h1>
+            <ul>
+  <li>whitespace</li>
+  <li>missing values</li>
+  <li>numeric strings</li>
+  <li>inconsistent casing</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Summary Patterns Worth Starting With</h1>
+            <ul>
+  <li>total row count</li>
+  <li>counts by category</li>
+  <li>counts by status</li>
+  <li>mean or sum of a numeric field</li>
+</ul>
+<pre data-lang="python"><code>summary = df.groupby(&quot;status&quot;).size().reset_index(name=&quot;count&quot;)
+print(summary)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Flow: Load, Clean, Summarize</h1>
+            <ol>
+  <li>Load exported data</li>
+  <li>Inspect <code>head()</code>, <code>shape</code>, and <code>dtypes</code></li>
+  <li>Make one explainable cleaning choice</li>
+  <li>Group and summarize</li>
+  <li>Save a reusable summary artifact</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Build the First Analytics Pass</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Locate or export one CSV</li>
+  <li>Load it into pandas</li>
+  <li>Inspect the structure</li>
+  <li>Make at least one cleaning decision</li>
+  <li>Compute at least three metrics</li>
+  <li>Save a summary CSV into <code>reports/</code></li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Learner can explain one cleaning choice</li>
+  <li>Summary artifact is saved and reusable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 41)</h1>
+            <p><strong>⚠️</strong> Analyzing before inspecting</p>
+<p><strong>⚠️</strong> Cleaning data in ways you cannot explain</p>
+<p><strong>⚠️</strong> Ignoring missing values</p>
+<p><strong>⚠️</strong> Forgetting to save the summary artifact</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 41)</h1>
+            <ul>
+  <li>Homework goal: a small cleaned DataFrame with labeled summary outputs</li>
+  <li>Best practice: normalize and clean before trusting counts</li>
+  <li>Pitfall to avoid: summarizing dirty data hides real problems</li>
+  <li>Quiz-ready anchor: <code>Hour 41 | dataframe rows: 5</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What can <code>df.dtypes</code> reveal before you compute a single summary?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 42: Visualization with Matplotlib</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Create at least one readable chart</li>
+  <li>Label title and axes clearly</li>
+  <li>Save plots into <code>reports/</code></li>
+  <li>Avoid common figure-management mistakes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Chart Design Matters</h1>
+            <ul>
+  <li>A chart is a compressed explanation</li>
+  <li>If the labels are weak, the chart stops helping</li>
+  <li>Good plots should stand on their own without narration</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Minimum readability checklist</h1>
+            <ul>
+  <li>title</li>
+  <li>x-axis label</li>
+  <li>y-axis label</li>
+  <li>readable categories</li>
+  <li>saved artifact path</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Start from Aggregated Data</h1>
+            <ul>
+  <li>Counts by category are often a strong first chart</li>
+  <li>Counts by status are usually easy to explain</li>
+  <li>Time-based summaries can support line charts later</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Practical rule</h1>
+            <ul>
+  <li>Plot the <strong>summary</strong>, not the raw noise</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Bar Chart Pattern</h1>
+            <pre data-lang="python"><code>import matplotlib.pyplot as plt
+
+plt.figure(figsize=(8, 4))
+plt.bar(summary[&quot;category&quot;], summary[&quot;count&quot;])
+plt.title(&quot;Records by Category&quot;)
+plt.xlabel(&quot;Category&quot;)
+plt.ylabel(&quot;Count&quot;)
+plt.xticks(rotation=45, ha=&quot;right&quot;)
+plt.tight_layout()
+plt.savefig(&quot;reports/category_counts.png&quot;)
+plt.close()</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Chart Choice Is Communication</h1>
+            <ul>
+  <li>Bar chart → category comparisons</li>
+  <li>Line chart → trend over time</li>
+  <li>Choose the chart that matches the question</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Teaching point</h1>
+            <ul>
+  <li>Plotting is not just syntax; it is storytelling</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Save a Report-Ready Plot</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Reuse a cleaned dataset or summary</li>
+  <li>Create at least one chart</li>
+  <li>Label title + axes</li>
+  <li>Save the artifact into <code>reports/</code></li>
+  <li>Open the file and confirm readability</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Another learner can understand the plot quickly</li>
+  <li>The saved file works as a reusable artifact</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 42)</h1>
+            <p><strong>⚠️</strong> Unlabeled axes</p>
+<p><strong>⚠️</strong> Overlapping category labels</p>
+<p><strong>⚠️</strong> Plotting raw data when a summary would be clearer</p>
+<p><strong>⚠️</strong> Forgetting <code>tight_layout()</code> or <code>plt.close()</code></p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 42)</h1>
+            <ul>
+  <li>Homework goal: a saved matplotlib chart that supports the tracker report</li>
+  <li>Best practice: clear labels, titles, and saved artifact path</li>
+  <li>Pitfall to avoid: an unlabeled chart communicates very little</li>
+  <li>Quiz-ready anchor: <code>Hour 42 | chart type: bar</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is saving the plot to <code>reports/</code> better than leaving it only inside a notebook session?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 43: Regression Demo or Equivalent Analysis</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain when regression makes sense</li>
+  <li>Describe why train/test split matters</li>
+  <li>Run one small predictive workflow if appropriate</li>
+  <li>Use a fallback analysis if the data does not support regression</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrail</h1>
+            <ul>
+  <li>We are <strong>not</strong> becoming ML engineers in one hour</li>
+  <li>This is a limited workflow demo</li>
+  <li>The runbook explicitly allows a fallback analysis</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Smart decision</h1>
+            <ul>
+  <li>If the dataset does not fit, do more honest analysis instead</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>When Regression Makes Sense</h1>
+            <ul>
+  <li>Target must be numeric</li>
+  <li>Features should be numeric and clean enough</li>
+  <li>The question should genuinely involve prediction</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Keep evaluation simple</h1>
+            <ul>
+  <li>One metric is enough for today</li>
+  <li>Explain the result in plain language</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Tiny Workflow Example</h1>
+            <pre data-lang="python"><code>from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_absolute_error
+from sklearn.model_selection import train_test_split
+
+X = df[[&quot;priority&quot;]]
+y = df[&quot;hours_to_complete&quot;]
+
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, random_state=42
+)
+
+model = LinearRegression()
+model.fit(X_train, y_train)
+predictions = model.predict(X_test)
+mae = mean_absolute_error(y_test, predictions)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>What This Demo Is Really Teaching</h1>
+            <ul>
+  <li>Prepare features + target</li>
+  <li>Hold back test data</li>
+  <li>Fit a model</li>
+  <li>Predict on unseen data</li>
+  <li>Report one metric honestly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>If regression is a bad fit</h1>
+            <ul>
+  <li>Add another summary</li>
+  <li>Add another chart</li>
+  <li>Explain why the fallback is better</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Predictive Slice or Honest Fallback</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Decide whether the data supports regression</li>
+  <li>Run the workflow or choose fallback analysis</li>
+  <li>Report one metric or observation</li>
+  <li>Write one sentence explaining the result</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Learner can justify the method choice</li>
+  <li>The outcome is explained in plain language</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 43)</h1>
+            <p><strong>⚠️</strong> Forcing regression onto non-numeric data</p>
+<p><strong>⚠️</strong> Treating the demo as production-ready analytics</p>
+<p><strong>⚠️</strong> Skipping cleaning and blaming the tool</p>
+<p><strong>⚠️</strong> Reporting a metric without explaining it</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 43)</h1>
+            <ul>
+  <li>Homework goal: a simple regression example with one labeled prediction</li>
+  <li>Best practice: keep the forecast practical and limited</li>
+  <li>Pitfall to avoid: overstating a quick demo as production-ready analytics</li>
+  <li>Quiz-ready anchor: <code>Hour 43 | model: linear regression</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is “regression is not the right fit here” sometimes the most advanced answer?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 44: Integrate Analytics into the Capstone</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Add a report-generation path to the capstone</li>
+  <li>Produce export, summary, and chart artifacts repeatably</li>
+  <li>Document how the report runs</li>
+  <li>Treat analytics as part of the product</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Analytics as a Feature</h1>
+            <ul>
+  <li>The capstone should not only store data</li>
+  <li>It should also summarize and communicate data intentionally</li>
+  <li>A report feature turns analysis into something reusable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Product mindset</h1>
+            <ul>
+  <li>one command</li>
+  <li>or one button</li>
+  <li>same cleaned pipeline every time</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Repeatable Report Pipeline</h1>
+            <ol>
+  <li>export data</li>
+  <li>load + clean data</li>
+  <li>compute summaries</li>
+  <li>generate charts</li>
+  <li>save artifacts to <code>reports/</code></li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Anti-pattern</h1>
+            <ul>
+  <li>hidden manual steps between those stages</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Example Entry Point</h1>
+            <pre data-lang="python"><code>from reports.export_data import export_records_csv
+from reports.analyze import build_summary
+from reports.plotting import create_plots
+
+def main():
+    csv_path = export_records_csv()
+    summary_path = build_summary(csv_path)
+    create_plots(summary_path)
+    print(&quot;Report artifacts generated in reports/&quot;)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Add the Report Feature</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create or refine an export step</li>
+  <li>Generate a summary table</li>
+  <li>Save at least one chart</li>
+  <li>Put outputs in <code>reports/</code></li>
+  <li>Document how to run the feature</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Another learner could trigger the report tomorrow</li>
+  <li>Artifacts appear in predictable places</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 44)</h1>
+            <p><strong>⚠️</strong> Hard-coded paths that work on only one machine</p>
+<p><strong>⚠️</strong> Report logic scattered across scripts and notebooks</p>
+<p><strong>⚠️</strong> Missing README guidance</p>
+<p><strong>⚠️</strong> Hand-edited intermediate files</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 44)</h1>
+            <ul>
+  <li>Homework goal: a report feature that connects data outputs to the tracker project</li>
+  <li>Best practice: combine summaries, charts, and predictions into one readable feature</li>
+  <li>Pitfall to avoid: disconnected notebook snippets weaken the capstone</li>
+  <li>Quiz-ready anchor: <code>Hour 44 | report file: reports/weekly_summary.txt</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What makes a report feature repeatable instead of “works when I remember the steps”?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 11 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>End-of-Day Evidence</h1>
+            <ul>
+  <li>Data is loaded and cleaned intentionally</li>
+  <li>Summaries answer real questions</li>
+  <li>Charts are readable and saved</li>
+  <li>The capstone now has a report-generation path</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Homework Focus</h1>
+            <ul>
+  <li>Keep outputs deterministic in <code>Advanced_Day11_homework.ipynb</code></li>
+  <li>Rehearse the anchor lines:</li>
+  <li style="margin-left: 30px;"><code>dataframe rows: 5</code></li>
+  <li style="margin-left: 30px;"><code>chart type: bar</code></li>
+  <li style="margin-left: 30px;"><code>model: linear regression</code></li>
+  <li style="margin-left: 30px;"><code>report file: reports/weekly_summary.txt</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Exit Ticket</h1>
+            <ol>
+  <li>Which cleaning decision changed your analysis most?</li>
+  <li>What question does your chart answer?</li>
+  <li>Is regression the right fit for your data — why or why not?</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Looking Ahead</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Next Session</h1>
+            <ul>
+  <li>Lock in quality with pytest</li>
+  <li>Use coverage strategically</li>
+  <li>Package the project for handoff</li>
+  <li>Finish with a final capstone demo and reflection</li>
+</ul>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/Advanced/lessons/slides/day-11/day-11-session-11.md
+++ b/Advanced/lessons/slides/day-11/day-11-session-11.md
@@ -1,0 +1,520 @@
+# Advanced Day 11 — Session 11 (Hours 41–44)
+Python Programming (Advanced) • Analytics, Visualization, and Reporting
+
+---
+
+# Session 11 Overview
+
+## Topics Covered Today
+- Hour 41: pandas essentials — loading, cleaning, summarizing
+- Hour 42: visualization with matplotlib
+- Hour 43: regression demo or equivalent analysis
+- Hour 44: integrate analytics into the capstone
+
+## Day Goal
+- Turn capstone data into a repeatable reporting pipeline
+
+---
+
+# Alignment Sources
+
+- Runbook: `Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md` → Session 11 overview; Hours 41–44
+- Lecture: `Advanced/lessons/lecture/Day11_Hour1_Advanced.md` through `Day11_Hour4_Advanced.md`
+- Homework: `Advanced/assignments/Advanced_Day11_homework.ipynb`
+- Quiz: `Advanced/quizzes/Advanced_Day11_Quiz.html`
+
+## Session Theme
+- Use the **same dataset** all day
+- Clean before trusting
+- Visualize with intention
+- Package analytics as a feature, not a notebook fragment
+
+---
+
+# Session Success Criteria
+
+- Exported data loads into pandas cleanly
+- At least one summary artifact is saved
+- At least one readable chart lands in `reports/`
+- Analysis stays within course scope
+- Report generation becomes repeatable
+
+---
+
+# Scope Guardrails for Today
+
+- Start from the capstone dataset when possible
+- Do not force machine learning if the data does not fit
+- A clear summary + one strong chart beats a flashy but shallow notebook
+- Repeatability matters more than manual heroics
+
+---
+
+# Hour 41: pandas Essentials
+
+## Learning Outcomes
+- Load capstone data into a DataFrame
+- Inspect shape, columns, and types
+- Clean common data issues
+- Compute useful summaries and grouped counts
+
+---
+
+## The Analytics Mindset
+
+- We are not leaving the capstone behind
+- We are adding a reporting lens to the same project
+- Strong analysis starts with:
+  - inspection
+  - cleaning
+  - simple, honest summaries
+
+## Day 11 reminder
+- Use the same dataset from Hour 41 through Hour 44
+
+---
+
+## First Inspection Steps
+
+```python
+import pandas as pd
+
+df = pd.read_csv("reports/records_export.csv")
+print(df.head())
+print(df.shape)
+print(df.dtypes)
+print(df.isna().sum())
+```
+
+## Habit
+- Inspect before you interpret
+
+---
+
+## Common Cleaning Moves
+
+```python
+df["category"] = df["category"].str.strip().str.lower()
+df["priority"] = pd.to_numeric(df["priority"], errors="coerce")
+df["status"] = df["status"].fillna("unknown")
+```
+
+## Typical issues
+- whitespace
+- missing values
+- numeric strings
+- inconsistent casing
+
+---
+
+## Summary Patterns Worth Starting With
+
+- total row count
+- counts by category
+- counts by status
+- mean or sum of a numeric field
+
+```python
+summary = df.groupby("status").size().reset_index(name="count")
+print(summary)
+```
+
+---
+
+## Demo Flow: Load, Clean, Summarize
+
+1. Load exported data
+2. Inspect `head()`, `shape`, and `dtypes`
+3. Make one explainable cleaning choice
+4. Group and summarize
+5. Save a reusable summary artifact
+
+---
+
+## Lab: Build the First Analytics Pass
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Locate or export one CSV
+- Load it into pandas
+- Inspect the structure
+- Make at least one cleaning decision
+- Compute at least three metrics
+- Save a summary CSV into `reports/`
+
+### Completion Criteria
+- Learner can explain one cleaning choice
+- Summary artifact is saved and reusable
+
+---
+
+## Common Pitfalls (Hour 41)
+
+⚠️ Analyzing before inspecting  
+⚠️ Cleaning data in ways you cannot explain  
+⚠️ Ignoring missing values  
+⚠️ Forgetting to save the summary artifact
+
+---
+
+## Homework + Quiz Emphasis (Hour 41)
+
+- Homework goal: a small cleaned DataFrame with labeled summary outputs
+- Best practice: normalize and clean before trusting counts
+- Pitfall to avoid: summarizing dirty data hides real problems
+- Quiz-ready anchor: `Hour 41 | dataframe rows: 5`
+
+---
+
+## Quick Check
+
+**Question**: What can `df.dtypes` reveal before you compute a single summary?
+
+---
+
+# Hour 42: Visualization with Matplotlib
+
+## Learning Outcomes
+- Create at least one readable chart
+- Label title and axes clearly
+- Save plots into `reports/`
+- Avoid common figure-management mistakes
+
+---
+
+## Why Chart Design Matters
+
+- A chart is a compressed explanation
+- If the labels are weak, the chart stops helping
+- Good plots should stand on their own without narration
+
+## Minimum readability checklist
+- title
+- x-axis label
+- y-axis label
+- readable categories
+- saved artifact path
+
+---
+
+## Start from Aggregated Data
+
+- Counts by category are often a strong first chart
+- Counts by status are usually easy to explain
+- Time-based summaries can support line charts later
+
+## Practical rule
+- Plot the **summary**, not the raw noise
+
+---
+
+## Bar Chart Pattern
+
+```python
+import matplotlib.pyplot as plt
+
+plt.figure(figsize=(8, 4))
+plt.bar(summary["category"], summary["count"])
+plt.title("Records by Category")
+plt.xlabel("Category")
+plt.ylabel("Count")
+plt.xticks(rotation=45, ha="right")
+plt.tight_layout()
+plt.savefig("reports/category_counts.png")
+plt.close()
+```
+
+---
+
+## Chart Choice Is Communication
+
+- Bar chart → category comparisons
+- Line chart → trend over time
+- Choose the chart that matches the question
+
+## Teaching point
+- Plotting is not just syntax; it is storytelling
+
+---
+
+## Lab: Save a Report-Ready Plot
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Reuse a cleaned dataset or summary
+- Create at least one chart
+- Label title + axes
+- Save the artifact into `reports/`
+- Open the file and confirm readability
+
+### Completion Criteria
+- Another learner can understand the plot quickly
+- The saved file works as a reusable artifact
+
+---
+
+## Common Pitfalls (Hour 42)
+
+⚠️ Unlabeled axes  
+⚠️ Overlapping category labels  
+⚠️ Plotting raw data when a summary would be clearer  
+⚠️ Forgetting `tight_layout()` or `plt.close()`
+
+---
+
+## Homework + Quiz Emphasis (Hour 42)
+
+- Homework goal: a saved matplotlib chart that supports the tracker report
+- Best practice: clear labels, titles, and saved artifact path
+- Pitfall to avoid: an unlabeled chart communicates very little
+- Quiz-ready anchor: `Hour 42 | chart type: bar`
+
+---
+
+## Quick Check
+
+**Question**: Why is saving the plot to `reports/` better than leaving it only inside a notebook session?
+
+---
+
+# Hour 43: Regression Demo or Equivalent Analysis
+
+## Learning Outcomes
+- Explain when regression makes sense
+- Describe why train/test split matters
+- Run one small predictive workflow if appropriate
+- Use a fallback analysis if the data does not support regression
+
+---
+
+## Scope Guardrail
+
+- We are **not** becoming ML engineers in one hour
+- This is a limited workflow demo
+- The runbook explicitly allows a fallback analysis
+
+## Smart decision
+- If the dataset does not fit, do more honest analysis instead
+
+---
+
+## When Regression Makes Sense
+
+- Target must be numeric
+- Features should be numeric and clean enough
+- The question should genuinely involve prediction
+
+## Keep evaluation simple
+- One metric is enough for today
+- Explain the result in plain language
+
+---
+
+## Tiny Workflow Example
+
+```python
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_absolute_error
+from sklearn.model_selection import train_test_split
+
+X = df[["priority"]]
+y = df["hours_to_complete"]
+
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, random_state=42
+)
+
+model = LinearRegression()
+model.fit(X_train, y_train)
+predictions = model.predict(X_test)
+mae = mean_absolute_error(y_test, predictions)
+```
+
+---
+
+## What This Demo Is Really Teaching
+
+- Prepare features + target
+- Hold back test data
+- Fit a model
+- Predict on unseen data
+- Report one metric honestly
+
+## If regression is a bad fit
+- Add another summary
+- Add another chart
+- Explain why the fallback is better
+
+---
+
+## Lab: Predictive Slice or Honest Fallback
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Decide whether the data supports regression
+- Run the workflow or choose fallback analysis
+- Report one metric or observation
+- Write one sentence explaining the result
+
+### Completion Criteria
+- Learner can justify the method choice
+- The outcome is explained in plain language
+
+---
+
+## Common Pitfalls (Hour 43)
+
+⚠️ Forcing regression onto non-numeric data  
+⚠️ Treating the demo as production-ready analytics  
+⚠️ Skipping cleaning and blaming the tool  
+⚠️ Reporting a metric without explaining it
+
+---
+
+## Homework + Quiz Emphasis (Hour 43)
+
+- Homework goal: a simple regression example with one labeled prediction
+- Best practice: keep the forecast practical and limited
+- Pitfall to avoid: overstating a quick demo as production-ready analytics
+- Quiz-ready anchor: `Hour 43 | model: linear regression`
+
+---
+
+## Quick Check
+
+**Question**: Why is “regression is not the right fit here” sometimes the most advanced answer?
+
+---
+
+# Hour 44: Integrate Analytics into the Capstone
+
+## Learning Outcomes
+- Add a report-generation path to the capstone
+- Produce export, summary, and chart artifacts repeatably
+- Document how the report runs
+- Treat analytics as part of the product
+
+---
+
+## Analytics as a Feature
+
+- The capstone should not only store data
+- It should also summarize and communicate data intentionally
+- A report feature turns analysis into something reusable
+
+## Product mindset
+- one command
+- or one button
+- same cleaned pipeline every time
+
+---
+
+## Repeatable Report Pipeline
+
+1. export data
+2. load + clean data
+3. compute summaries
+4. generate charts
+5. save artifacts to `reports/`
+
+## Anti-pattern
+- hidden manual steps between those stages
+
+---
+
+## Example Entry Point
+
+```python
+from reports.export_data import export_records_csv
+from reports.analyze import build_summary
+from reports.plotting import create_plots
+
+def main():
+    csv_path = export_records_csv()
+    summary_path = build_summary(csv_path)
+    create_plots(summary_path)
+    print("Report artifacts generated in reports/")
+```
+
+---
+
+## Lab: Add the Report Feature
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Create or refine an export step
+- Generate a summary table
+- Save at least one chart
+- Put outputs in `reports/`
+- Document how to run the feature
+
+### Completion Criteria
+- Another learner could trigger the report tomorrow
+- Artifacts appear in predictable places
+
+---
+
+## Common Pitfalls (Hour 44)
+
+⚠️ Hard-coded paths that work on only one machine  
+⚠️ Report logic scattered across scripts and notebooks  
+⚠️ Missing README guidance  
+⚠️ Hand-edited intermediate files
+
+---
+
+## Homework + Quiz Emphasis (Hour 44)
+
+- Homework goal: a report feature that connects data outputs to the tracker project
+- Best practice: combine summaries, charts, and predictions into one readable feature
+- Pitfall to avoid: disconnected notebook snippets weaken the capstone
+- Quiz-ready anchor: `Hour 44 | report file: reports/weekly_summary.txt`
+
+---
+
+## Quick Check
+
+**Question**: What makes a report feature repeatable instead of “works when I remember the steps”?
+
+---
+
+# Day 11 Wrap-Up
+
+## End-of-Day Evidence
+- Data is loaded and cleaned intentionally
+- Summaries answer real questions
+- Charts are readable and saved
+- The capstone now has a report-generation path
+
+---
+
+## Homework Focus
+
+- Keep outputs deterministic in `Advanced_Day11_homework.ipynb`
+- Rehearse the anchor lines:
+  - `dataframe rows: 5`
+  - `chart type: bar`
+  - `model: linear regression`
+  - `report file: reports/weekly_summary.txt`
+
+---
+
+## Exit Ticket
+
+1. Which cleaning decision changed your analysis most?
+2. What question does your chart answer?
+3. Is regression the right fit for your data — why or why not?
+
+---
+
+# Looking Ahead
+
+## Next Session
+- Lock in quality with pytest
+- Use coverage strategically
+- Package the project for handoff
+- Finish with a final capstone demo and reflection

--- a/Advanced/lessons/slides/day-12/day-12-session-12.html
+++ b/Advanced/lessons/slides/day-12/day-12-session-12.html
@@ -1,0 +1,1080 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 12 — Session 12 (Hours 45–48)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 12 — Session 12 (Hours 45–48)</h1>
+            <div class="subtitle">Python Programming (Advanced) • Testing, Packaging, and Final Delivery</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 12 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 45: testing with pytest for the service layer</li>
+  <li>Hour 46: coverage, edge cases, and a lightweight integration test</li>
+  <li>Hour 47: packaging and delivery</li>
+  <li>Hour 48: final capstone demo, certification-style review, and retrospective</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day Goal</h1>
+            <ul>
+  <li>Finish the capstone with quality, delivery confidence, and explanation clarity</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Alignment Sources</h1>
+            <ul>
+  <li>Runbook: <code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → Session 12 overview; Hours 45–48</li>
+  <li>Lecture: <code>Advanced/lessons/lecture/Day12_Hour1_Advanced.md</code> through <code>Day12_Hour4_Advanced.md</code></li>
+  <li>Homework: <code>Advanced/assignments/Advanced_Day12_homework.ipynb</code></li>
+  <li>Quiz: <code>Advanced/quizzes/Advanced_Day12_Quiz.html</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Theme</h1>
+            <ul>
+  <li>Quality supports confidence</li>
+  <li>Packaging supports handoff</li>
+  <li>The final demo should show a system, not random features</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Success Criteria</h1>
+            <ul>
+  <li>Core service behavior is covered by pytest tests</li>
+  <li>Coverage is used as a guide, not a vanity metric</li>
+  <li>README + requirements support a fresh-run test</li>
+  <li>Final demos show architecture, persistence, analytics, and growth</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            <ul>
+  <li>Prioritize service-layer and repository-confidence tests over UI testing</li>
+  <li>Do not chase 100% coverage blindly</li>
+  <li>Package the runnable source release before optional executables</li>
+  <li>Final demos should be concise, stable, and explainable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 45: Testing with pytest</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Write focused service-layer unit tests</li>
+  <li>Use fixtures and plain <code>assert</code></li>
+  <li>Cover success and failure paths</li>
+  <li>Explain why UI testing is not the priority here</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Testing Fits Here</h1>
+            <ul>
+  <li>The capstone now has enough structure to test meaningfully</li>
+  <li>Service logic and exception patterns are stable enough to protect</li>
+  <li>Testing now reinforces quality instead of chasing a moving target</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Framing</h1>
+            <ul>
+  <li>Tests are fast feedback</li>
+  <li>Tests are not punishment</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>pytest Basics</h1>
+            <ul>
+  <li>Plain test functions stay readable</li>
+  <li>Arrange → Act → Assert is enough structure</li>
+  <li>Fixtures reduce repeated setup</li>
+  <li>Negative tests matter as much as happy paths</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Fixture + Test Pattern</h1>
+            <pre data-lang="python"><code>@pytest.fixture
+def service():
+    repo = InMemoryTrackerRepository()
+    return TrackerService(repo=repo)
+
+def test_add_and_get_record(service):
+    created = service.add_record(&quot;Write report&quot;, &quot;ops&quot;, &quot;open&quot;)
+    fetched = service.get_record(created.id)
+    assert fetched.title == &quot;Write report&quot;</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Negative Test Pattern</h1>
+            <pre data-lang="python"><code>def test_add_record_rejects_empty_title(service):
+    with pytest.raises(ValidationError):
+        service.add_record(&quot;&quot;, &quot;ops&quot;, &quot;open&quot;)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Teaching point</h1>
+            <ul>
+  <li>Good tests protect behaviors learners actually care about</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Write the First Real Test Suite</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create a test file such as <code>tests/test_service.py</code></li>
+  <li>Add at least five tests</li>
+  <li>Include at least two negative tests</li>
+  <li>Run pytest and confirm the suite passes</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Test names communicate the behavior clearly</li>
+  <li>The suite focuses on logic, not UI callbacks</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 45)</h1>
+            <p><strong>⚠️</strong> Testing UI callbacks directly</p>
+<p><strong>⚠️</strong> One test checking too many behaviors</p>
+<p><strong>⚠️</strong> Shared mutable state without reset</p>
+<p><strong>⚠️</strong> Happy-path-only thinking</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 45)</h1>
+            <ul>
+  <li>Homework goal: a small pytest suite for core service-layer rules</li>
+  <li>Best practice: focused unit tests around behavior and validation</li>
+  <li>Pitfall to avoid: testing private implementation details</li>
+  <li>Quiz-ready anchor: <code>Hour 45 | test runner: pytest</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What should a strong unit test avoid if you want refactors to stay safe?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 46: Coverage + Edge Cases + Integration</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Run a basic coverage report</li>
+  <li>Find high-value gaps</li>
+  <li>Add edge-case tests</li>
+  <li>Prove one meaningful boundary with an integration-style test</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Coverage with Perspective</h1>
+            <ul>
+  <li>Coverage shows which lines executed</li>
+  <li>Coverage does <strong>not</strong> prove the tests are meaningful</li>
+  <li>Use it as a flashlight, not a scorecard</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Smart question</h1>
+            <ul>
+  <li>Which uncovered branch is most likely to matter in a real bug?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Coverage Commands</h1>
+            <pre data-lang="bash"><code>coverage run -m pytest
+coverage report -m</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Great edge-case candidates</h1>
+            <ul>
+  <li>missing record</li>
+  <li>invalid input</li>
+  <li>empty search result</li>
+  <li>auth helper failure</li>
+  <li>duplicate ID assumptions</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lightweight Integration Test</h1>
+            <pre data-lang="python"><code>def test_service_and_sqlite_repo_work_together(tmp_path):
+    db_path = tmp_path / &quot;tracker.db&quot;
+    repo = SQLiteTrackerRepository(str(db_path))
+    repo.init_db()
+    service = TrackerService(repo=repo)
+
+    created = service.add_record(&quot;Ship deck&quot;, &quot;training&quot;, &quot;open&quot;)
+    fetched = service.get_record(created.id)
+
+    assert fetched.title == &quot;Ship deck&quot;</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Harden the Suite</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Run coverage</li>
+  <li>Identify at least two valuable missing branches</li>
+  <li>Add two tests for those branches</li>
+  <li>Add one integration-style test</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Coverage changes testing priorities intelligently</li>
+  <li>Integration proves a real boundary, not a giant workflow</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 46)</h1>
+            <p><strong>⚠️</strong> Chasing 100% blindly</p>
+<p><strong>⚠️</strong> Executing code without useful assertions</p>
+<p><strong>⚠️</strong> Turning one integration test into an end-to-end maze</p>
+<p><strong>⚠️</strong> Adding coverage numbers without discussing risk</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 46)</h1>
+            <ul>
+  <li>Homework goal: a tighter test suite with edge-case and integration confidence</li>
+  <li>Best practice: add edge cases and one lightweight integration test after unit tests pass</li>
+  <li>Pitfall to avoid: chasing a number instead of meaningful scenarios</li>
+  <li>Quiz-ready anchor: <code>Hour 46 | coverage target: service layer</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: How can high coverage still miss real bugs?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 47: Packaging and Delivery</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain the difference between “runs here” and “ships”</li>
+  <li>Refine <code>README.md</code>, <code>requirements.txt</code>, and <code>requirements-dev.txt</code></li>
+  <li>Perform a fresh-run smoke test</li>
+  <li>Identify hidden dependency or path assumptions</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>What Shipping Really Means</h1>
+            <ul>
+  <li>Repeatable install</li>
+  <li>Repeatable run</li>
+  <li>Honest documentation</li>
+  <li>Clear entry point</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Course minimum</h1>
+            <ul>
+  <li>A runnable source release</li>
+  <li>Optional packaging extras only if time permits</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Deliverable Recipe</h1>
+            <ul>
+  <li><code>README.md</code> with exact setup + run steps</li>
+  <li><code>requirements.txt</code> for runtime dependencies</li>
+  <li><code>requirements-dev.txt</code> for dev tooling</li>
+  <li><code>.gitignore</code> for environment and build outputs</li>
+  <li>one verified entry point</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Fresh-Run Sequence</h1>
+            <pre data-lang="bash"><code>python -m venv .venv
+.venv\Scripts\activate
+python -m pip install -r requirements.txt
+python -m pytest
+python api/app.py</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Teaching point</h1>
+            <ul>
+  <li>If the steps are not written clearly, the deliverable is weaker than it looks</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Make the Project Shareable</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Update <code>README.md</code></li>
+  <li>Verify runtime and dev dependencies</li>
+  <li>Check <code>.gitignore</code></li>
+  <li>Perform a fresh-run smoke test</li>
+  <li>Fix one missing setup step if discovered</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Another learner could follow the setup without guessing</li>
+  <li>Entry points and environment variables are documented</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 47)</h1>
+            <p><strong>⚠️</strong> Missing dependency in <code>requirements.txt</code></p>
+<p><strong>⚠️</strong> Undocumented environment variables</p>
+<p><strong>⚠️</strong> Entry-point confusion between GUI, API, and scripts</p>
+<p><strong>⚠️</strong> Relative paths that only work from one folder</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 47)</h1>
+            <ul>
+  <li>Homework goal: a documented runnable delivery package for the capstone</li>
+  <li>Best practice: package the runnable app before optional build tooling</li>
+  <li>Pitfall to avoid: spending all packaging time on an executable</li>
+  <li>Quiz-ready anchor: <code>Hour 47 | requirements file: ready</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What does a fresh-run test reveal that “it works on my machine” usually hides?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 48: Final Demo + Review + Retrospective</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Demonstrate the minimum capstone deliverables clearly</li>
+  <li>Explain architecture choices and tradeoffs</li>
+  <li>Practice certification-style code reading</li>
+  <li>Name one next step for continued growth</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Capstone Minimum Deliverables</h1>
+            <ul>
+  <li>model + service layer</li>
+  <li>SQLite persistence</li>
+  <li>one interface surface: GUI or API</li>
+  <li>analytics/reporting</li>
+  <li>tests</li>
+  <li>packaging readiness</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Final-hour mindset</h1>
+            <ul>
+  <li>coherence over perfection</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Strong Demo Flow</h1>
+            <ol>
+  <li>one-sentence problem statement</li>
+  <li>create or retrieve data</li>
+  <li>show persistence</li>
+  <li>show interface surface</li>
+  <li>show one analytics/report artifact</li>
+  <li>mention testing or packaging evidence</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Timebox</h1>
+            <ul>
+  <li>aim for 3–5 minutes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Questions Worth Answering During Demos</h1>
+            <ul>
+  <li>Why did you choose this architecture?</li>
+  <li>What part was hardest to stabilize?</li>
+  <li>What tradeoff did you make intentionally?</li>
+  <li>What would you improve next?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Coaching note</h1>
+            <ul>
+  <li>Bring the story back to user flow + architecture if details take over</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Certification-Style Review Prompt</h1>
+            <pre data-lang="python"><code>class Tracker:
+    def __init__(self):
+        self.items = []
+
+    def add(self, item):
+        self.items.append(item)
+
+t = Tracker()
+t.add(&quot;alpha&quot;)
+print(len(t.items))</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Ask</h1>
+            <ul>
+  <li>What prints?</li>
+  <li>Why?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Retrospective Prompts</h1>
+            <ul>
+  <li>What can you do now that you could not do before?</li>
+  <li>What still feels shaky but understandable?</li>
+  <li>What will you practice next while the material is fresh?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Ask learners to capture</h1>
+            <ol>
+  <li>one skill to apply immediately</li>
+  <li>one skill to keep practicing</li>
+  <li>one artifact they are proud of</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 48)</h1>
+            <ul>
+  <li>Homework goal: a final capstone walkthrough and certification-style review summary</li>
+  <li>Best practice: connect the whole course back to one coherent architecture</li>
+  <li>Pitfall to avoid: a demo without reflection</li>
+  <li>Quiz-ready anchor: <code>Hour 48 | final demo domain: tracker</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What makes a final demo convincing even if the project is not perfect?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 12 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>End-of-Day Evidence</h1>
+            <ul>
+  <li>Tests protect core behavior</li>
+  <li>Coverage informs smarter improvements</li>
+  <li>Packaging supports a clean handoff</li>
+  <li>The final demo proves understanding, not just feature count</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Homework Focus</h1>
+            <ul>
+  <li>Keep outputs deterministic in <code>Advanced_Day12_homework.ipynb</code></li>
+  <li>Rehearse the anchor lines:</li>
+  <li style="margin-left: 30px;"><code>test runner: pytest</code></li>
+  <li style="margin-left: 30px;"><code>coverage target: service layer</code></li>
+  <li style="margin-left: 30px;"><code>requirements file: ready</code></li>
+  <li style="margin-left: 30px;"><code>final demo domain: tracker</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Final Exit Ticket</h1>
+            <ol>
+  <li>Which test gives you the most confidence?</li>
+  <li>What did the fresh-run test teach you?</li>
+  <li>What part of your capstone best shows your growth?</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Course Close</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>You Can Now</h1>
+            <ul>
+  <li>design layered Python applications</li>
+  <li>persist and query data</li>
+  <li>expose and consume APIs</li>
+  <li>build analytics/reporting paths</li>
+  <li>test core logic</li>
+  <li>package a runnable deliverable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Next step</h1>
+            <ul>
+  <li>keep the capstone alive through one deliberate improvement</li>
+</ul>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/Advanced/lessons/slides/day-12/day-12-session-12.md
+++ b/Advanced/lessons/slides/day-12/day-12-session-12.md
@@ -1,0 +1,473 @@
+# Advanced Day 12 — Session 12 (Hours 45–48)
+Python Programming (Advanced) • Testing, Packaging, and Final Delivery
+
+---
+
+# Session 12 Overview
+
+## Topics Covered Today
+- Hour 45: testing with pytest for the service layer
+- Hour 46: coverage, edge cases, and a lightweight integration test
+- Hour 47: packaging and delivery
+- Hour 48: final capstone demo, certification-style review, and retrospective
+
+## Day Goal
+- Finish the capstone with quality, delivery confidence, and explanation clarity
+
+---
+
+# Alignment Sources
+
+- Runbook: `Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md` → Session 12 overview; Hours 45–48
+- Lecture: `Advanced/lessons/lecture/Day12_Hour1_Advanced.md` through `Day12_Hour4_Advanced.md`
+- Homework: `Advanced/assignments/Advanced_Day12_homework.ipynb`
+- Quiz: `Advanced/quizzes/Advanced_Day12_Quiz.html`
+
+## Session Theme
+- Quality supports confidence
+- Packaging supports handoff
+- The final demo should show a system, not random features
+
+---
+
+# Session Success Criteria
+
+- Core service behavior is covered by pytest tests
+- Coverage is used as a guide, not a vanity metric
+- README + requirements support a fresh-run test
+- Final demos show architecture, persistence, analytics, and growth
+
+---
+
+# Scope Guardrails for Today
+
+- Prioritize service-layer and repository-confidence tests over UI testing
+- Do not chase 100% coverage blindly
+- Package the runnable source release before optional executables
+- Final demos should be concise, stable, and explainable
+
+---
+
+# Hour 45: Testing with pytest
+
+## Learning Outcomes
+- Write focused service-layer unit tests
+- Use fixtures and plain `assert`
+- Cover success and failure paths
+- Explain why UI testing is not the priority here
+
+---
+
+## Why Testing Fits Here
+
+- The capstone now has enough structure to test meaningfully
+- Service logic and exception patterns are stable enough to protect
+- Testing now reinforces quality instead of chasing a moving target
+
+## Framing
+- Tests are fast feedback
+- Tests are not punishment
+
+---
+
+## pytest Basics
+
+- Plain test functions stay readable
+- Arrange → Act → Assert is enough structure
+- Fixtures reduce repeated setup
+- Negative tests matter as much as happy paths
+
+---
+
+## Fixture + Test Pattern
+
+```python
+@pytest.fixture
+def service():
+    repo = InMemoryTrackerRepository()
+    return TrackerService(repo=repo)
+
+def test_add_and_get_record(service):
+    created = service.add_record("Write report", "ops", "open")
+    fetched = service.get_record(created.id)
+    assert fetched.title == "Write report"
+```
+
+---
+
+## Negative Test Pattern
+
+```python
+def test_add_record_rejects_empty_title(service):
+    with pytest.raises(ValidationError):
+        service.add_record("", "ops", "open")
+```
+
+## Teaching point
+- Good tests protect behaviors learners actually care about
+
+---
+
+## Lab: Write the First Real Test Suite
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Create a test file such as `tests/test_service.py`
+- Add at least five tests
+- Include at least two negative tests
+- Run pytest and confirm the suite passes
+
+### Completion Criteria
+- Test names communicate the behavior clearly
+- The suite focuses on logic, not UI callbacks
+
+---
+
+## Common Pitfalls (Hour 45)
+
+⚠️ Testing UI callbacks directly  
+⚠️ One test checking too many behaviors  
+⚠️ Shared mutable state without reset  
+⚠️ Happy-path-only thinking
+
+---
+
+## Homework + Quiz Emphasis (Hour 45)
+
+- Homework goal: a small pytest suite for core service-layer rules
+- Best practice: focused unit tests around behavior and validation
+- Pitfall to avoid: testing private implementation details
+- Quiz-ready anchor: `Hour 45 | test runner: pytest`
+
+---
+
+## Quick Check
+
+**Question**: What should a strong unit test avoid if you want refactors to stay safe?
+
+---
+
+# Hour 46: Coverage + Edge Cases + Integration
+
+## Learning Outcomes
+- Run a basic coverage report
+- Find high-value gaps
+- Add edge-case tests
+- Prove one meaningful boundary with an integration-style test
+
+---
+
+## Coverage with Perspective
+
+- Coverage shows which lines executed
+- Coverage does **not** prove the tests are meaningful
+- Use it as a flashlight, not a scorecard
+
+## Smart question
+- Which uncovered branch is most likely to matter in a real bug?
+
+---
+
+## Coverage Commands
+
+```bash
+coverage run -m pytest
+coverage report -m
+```
+
+## Great edge-case candidates
+- missing record
+- invalid input
+- empty search result
+- auth helper failure
+- duplicate ID assumptions
+
+---
+
+## Lightweight Integration Test
+
+```python
+def test_service_and_sqlite_repo_work_together(tmp_path):
+    db_path = tmp_path / "tracker.db"
+    repo = SQLiteTrackerRepository(str(db_path))
+    repo.init_db()
+    service = TrackerService(repo=repo)
+
+    created = service.add_record("Ship deck", "training", "open")
+    fetched = service.get_record(created.id)
+
+    assert fetched.title == "Ship deck"
+```
+
+---
+
+## Lab: Harden the Suite
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Run coverage
+- Identify at least two valuable missing branches
+- Add two tests for those branches
+- Add one integration-style test
+
+### Completion Criteria
+- Coverage changes testing priorities intelligently
+- Integration proves a real boundary, not a giant workflow
+
+---
+
+## Common Pitfalls (Hour 46)
+
+⚠️ Chasing 100% blindly  
+⚠️ Executing code without useful assertions  
+⚠️ Turning one integration test into an end-to-end maze  
+⚠️ Adding coverage numbers without discussing risk
+
+---
+
+## Homework + Quiz Emphasis (Hour 46)
+
+- Homework goal: a tighter test suite with edge-case and integration confidence
+- Best practice: add edge cases and one lightweight integration test after unit tests pass
+- Pitfall to avoid: chasing a number instead of meaningful scenarios
+- Quiz-ready anchor: `Hour 46 | coverage target: service layer`
+
+---
+
+## Quick Check
+
+**Question**: How can high coverage still miss real bugs?
+
+---
+
+# Hour 47: Packaging and Delivery
+
+## Learning Outcomes
+- Explain the difference between “runs here” and “ships”
+- Refine `README.md`, `requirements.txt`, and `requirements-dev.txt`
+- Perform a fresh-run smoke test
+- Identify hidden dependency or path assumptions
+
+---
+
+## What Shipping Really Means
+
+- Repeatable install
+- Repeatable run
+- Honest documentation
+- Clear entry point
+
+## Course minimum
+- A runnable source release
+- Optional packaging extras only if time permits
+
+---
+
+## Deliverable Recipe
+
+- `README.md` with exact setup + run steps
+- `requirements.txt` for runtime dependencies
+- `requirements-dev.txt` for dev tooling
+- `.gitignore` for environment and build outputs
+- one verified entry point
+
+---
+
+## Fresh-Run Sequence
+
+```bash
+python -m venv .venv
+.venv\Scripts\activate
+python -m pip install -r requirements.txt
+python -m pytest
+python api/app.py
+```
+
+## Teaching point
+- If the steps are not written clearly, the deliverable is weaker than it looks
+
+---
+
+## Lab: Make the Project Shareable
+
+**Time: 25–35 minutes**
+
+### Tasks
+- Update `README.md`
+- Verify runtime and dev dependencies
+- Check `.gitignore`
+- Perform a fresh-run smoke test
+- Fix one missing setup step if discovered
+
+### Completion Criteria
+- Another learner could follow the setup without guessing
+- Entry points and environment variables are documented
+
+---
+
+## Common Pitfalls (Hour 47)
+
+⚠️ Missing dependency in `requirements.txt`  
+⚠️ Undocumented environment variables  
+⚠️ Entry-point confusion between GUI, API, and scripts  
+⚠️ Relative paths that only work from one folder
+
+---
+
+## Homework + Quiz Emphasis (Hour 47)
+
+- Homework goal: a documented runnable delivery package for the capstone
+- Best practice: package the runnable app before optional build tooling
+- Pitfall to avoid: spending all packaging time on an executable
+- Quiz-ready anchor: `Hour 47 | requirements file: ready`
+
+---
+
+## Quick Check
+
+**Question**: What does a fresh-run test reveal that “it works on my machine” usually hides?
+
+---
+
+# Hour 48: Final Demo + Review + Retrospective
+
+## Learning Outcomes
+- Demonstrate the minimum capstone deliverables clearly
+- Explain architecture choices and tradeoffs
+- Practice certification-style code reading
+- Name one next step for continued growth
+
+---
+
+## Capstone Minimum Deliverables
+
+- model + service layer
+- SQLite persistence
+- one interface surface: GUI or API
+- analytics/reporting
+- tests
+- packaging readiness
+
+## Final-hour mindset
+- coherence over perfection
+
+---
+
+## Strong Demo Flow
+
+1. one-sentence problem statement
+2. create or retrieve data
+3. show persistence
+4. show interface surface
+5. show one analytics/report artifact
+6. mention testing or packaging evidence
+
+## Timebox
+- aim for 3–5 minutes
+
+---
+
+## Questions Worth Answering During Demos
+
+- Why did you choose this architecture?
+- What part was hardest to stabilize?
+- What tradeoff did you make intentionally?
+- What would you improve next?
+
+## Coaching note
+- Bring the story back to user flow + architecture if details take over
+
+---
+
+## Certification-Style Review Prompt
+
+```python
+class Tracker:
+    def __init__(self):
+        self.items = []
+
+    def add(self, item):
+        self.items.append(item)
+
+t = Tracker()
+t.add("alpha")
+print(len(t.items))
+```
+
+## Ask
+- What prints?
+- Why?
+
+---
+
+## Retrospective Prompts
+
+- What can you do now that you could not do before?
+- What still feels shaky but understandable?
+- What will you practice next while the material is fresh?
+
+## Ask learners to capture
+1. one skill to apply immediately
+2. one skill to keep practicing
+3. one artifact they are proud of
+
+---
+
+## Homework + Quiz Emphasis (Hour 48)
+
+- Homework goal: a final capstone walkthrough and certification-style review summary
+- Best practice: connect the whole course back to one coherent architecture
+- Pitfall to avoid: a demo without reflection
+- Quiz-ready anchor: `Hour 48 | final demo domain: tracker`
+
+---
+
+## Quick Check
+
+**Question**: What makes a final demo convincing even if the project is not perfect?
+
+---
+
+# Day 12 Wrap-Up
+
+## End-of-Day Evidence
+- Tests protect core behavior
+- Coverage informs smarter improvements
+- Packaging supports a clean handoff
+- The final demo proves understanding, not just feature count
+
+---
+
+## Homework Focus
+
+- Keep outputs deterministic in `Advanced_Day12_homework.ipynb`
+- Rehearse the anchor lines:
+  - `test runner: pytest`
+  - `coverage target: service layer`
+  - `requirements file: ready`
+  - `final demo domain: tracker`
+
+---
+
+## Final Exit Ticket
+
+1. Which test gives you the most confidence?
+2. What did the fresh-run test teach you?
+3. What part of your capstone best shows your growth?
+
+---
+
+# Course Close
+
+## You Can Now
+- design layered Python applications
+- persist and query data
+- expose and consume APIs
+- build analytics/reporting paths
+- test core logic
+- package a runnable deliverable
+
+## Next step
+- keep the capstone alive through one deliberate improvement

--- a/Advanced/lessons/slides/day-12/day-12-session-12.md
+++ b/Advanced/lessons/slides/day-12/day-12-session-12.md
@@ -277,9 +277,19 @@ def test_service_and_sqlite_repo_work_together(tmp_path):
 
 ## Fresh-Run Sequence
 
-```bash
+**Windows (cmd / PowerShell)**
+```bat
 python -m venv .venv
 .venv\Scripts\activate
+python -m pip install -r requirements.txt
+python -m pytest
+python api/app.py
+```
+
+**macOS / Linux (bash / zsh)**
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
 python -m pip install -r requirements.txt
 python -m pytest
 python api/app.py

--- a/python_programming_courses.code-workspace
+++ b/python_programming_courses.code-workspace
@@ -1,0 +1,11 @@
+{
+    "folders": [
+        {
+            "path": "/mnt/c/Users/darf3/Documents/python_programming_courses"
+        }
+    ],
+    "settings": {
+        "terminal.integrated.cwd": "",
+        "git.ignoreLimitWarning": true,
+    }
+}

--- a/slides/advanced/day-01/day-01-session-1.html
+++ b/slides/advanced/day-01/day-01-session-1.html
@@ -1,0 +1,1163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 1 — Session 1 (Hours 1–4)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 1 — Session 1 (Hours 1–4)</h1>
+            <div class="subtitle">Python Programming (Advanced) • Kickoff, Class Design, Validation, and Composition</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 1 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 1: Advanced kickoff + baseline diagnostic + Git workflow</li>
+  <li>Hour 2: Designing classes from requirements</li>
+  <li>Hour 3: Properties, invariants, and custom exceptions</li>
+  <li>Hour 4: Composition vs inheritance + polymorphism</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → <code>## Session 1 overview</code></li>
+  <li><code>Advanced/lessons/lecture/Day1_Hour1_Advanced.md</code> → <code># Day 1, Hour 1: Advanced Kickoff, Baseline Diagnostic, and Git Workflow</code></li>
+  <li><code>Advanced/lessons/lecture/Day1_Hour2_Advanced.md</code> → <code># Day 1, Hour 2: Designing Classes from Requirements</code></li>
+  <li><code>Advanced/lessons/lecture/Day1_Hour3_Advanced.md</code> → <code># Day 1, Hour 3: Properties, Invariants, and Custom Exceptions</code></li>
+  <li><code>Advanced/lessons/lecture/Day1_Hour4_Advanced.md</code> → <code># Day 1, Hour 4: Composition vs Inheritance + Polymorphism</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session 1 Outcomes</h1>
+            <ul>
+  <li>Set up an advanced-course capstone workspace</li>
+  <li>Use Git for frequent, understandable progress commits</li>
+  <li>Translate requirements into domain models + service boundaries</li>
+  <li>Protect object state with validation and specific exceptions</li>
+  <li>Prefer composition when collaborator behavior may change</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>In Scope</h1>
+            <ul>
+  <li>Project scaffold and workflow habits</li>
+  <li>Responsibility-driven design</li>
+  <li>Properties, invariants, and custom exceptions</li>
+  <li>Lightweight polymorphism and composition</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Not Yet</h1>
+            <ul>
+  <li>Database persistence</li>
+  <li>GUI or HTTP layers</li>
+  <li>Production auth/security systems</li>
+  <li>Overengineered inheritance hierarchies</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 1: Advanced Kickoff + Baseline Diagnostic</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Confirm the lab environment is ready for advanced work</li>
+  <li>Create the standard capstone folder layout</li>
+  <li>Initialize Git and make a first meaningful commit</li>
+  <li>Prove baseline readiness with a tiny diagnostic script</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Day 1 Starts Here</h1>
+            <ul>
+  <li>Advanced Python is about <strong>structure</strong>, not just syntax</li>
+  <li>We will build a capstone across the course</li>
+  <li>Frequent saves and small commits reduce recovery pain</li>
+  <li>The goal is a repeatable workflow before bigger architecture work</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/lessons/lecture/Day1_Hour1_Advanced.md</code> → <code>## 1. Advanced Kickoff (10 minutes)</code></li>
+  <li><code>Advanced/assignments/Advanced_Day1_homework.ipynb</code> → <code>## Part 1: Setup, Diagnostic Thinking, and Git Workflow</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Standard Capstone Scaffold</h1>
+            <pre data-lang="text"><code>project_root/
+├── src/
+├── tests/
+├── data/
+└── reports/</code></pre>
+<ul>
+  <li>Keep course work inside one repo/workspace</li>
+  <li>Save files normally; use lab suspend for longer breaks</li>
+  <li>Build the habit now before the project gets bigger</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Workspace + Git Baseline</h1>
+            <pre data-lang="bash"><code>mkdir capstone_tracker
+cd capstone_tracker
+git init
+python --version
+git status</code></pre>
+<ul>
+  <li>Start in a clean project folder</li>
+  <li>Confirm interpreter selection early</li>
+  <li>Commit after a working checkpoint, not after a mystery pile of edits</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Readiness Script</h1>
+            <pre data-lang="python"><code>class Hello:
+    def __init__(self, name: str) -&gt; None:
+        self.name = name
+
+    def greet(self) -&gt; None:
+        print(f&quot;Hello, {self.name}!&quot;)
+
+
+data = {&quot;status&quot;: &quot;ready&quot;}</code></pre>
+<ul>
+  <li>Include a class</li>
+  <li>Touch a dictionary</li>
+  <li>Show exception handling</li>
+  <li>Demonstrate file-aware thinking</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Environment + Diagnostic Check</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create the project folders: <code>src</code>, <code>tests</code>, <code>data</code>, <code>reports</code></li>
+  <li>Initialize a Git repo</li>
+  <li>Write a short diagnostic script that:</li>
+  <li style="margin-left: 30px;">defines a class</li>
+  <li style="margin-left: 30px;">uses a dictionary</li>
+  <li style="margin-left: 30px;">catches a specific error</li>
+  <li style="margin-left: 30px;">ends with <code>Diagnostic status: ready</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 1)</h1>
+            <p><span class="check">✓</span> <code>python --version</code> succeeds</p>
+<p><span class="check">✓</span> <code>git init</code> completed in the project folder</p>
+<p><span class="check">✓</span> Diagnostic script runs cleanly</p>
+<p><span class="check">✓</span> Learner can explain <strong>commit vs push</strong></p>
+<p><span class="check">✓</span> Folder layout matches the course scaffold</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 1)</h1>
+            <ul>
+  <li>Homework asks for:</li>
+  <li style="margin-left: 30px;"><code>Student: ...</code></li>
+  <li style="margin-left: 30px;"><code>Goal: ...</code></li>
+  <li style="margin-left: 30px;"><code>Python Version: ...</code></li>
+  <li style="margin-left: 30px;"><code>Project folders: src, tests, data, reports</code></li>
+  <li style="margin-left: 30px;"><code>Git workflow: clone -&gt; pull -&gt; status -&gt; add -&gt; commit -&gt; push</code></li>
+  <li>Quiz focus:</li>
+  <li style="margin-left: 30px;">save vs suspend</li>
+  <li style="margin-left: 30px;"><code>git init</code></li>
+  <li style="margin-left: 30px;">commit vs push</li>
+  <li style="margin-left: 30px;">diagnostic skill mix</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day1_homework.ipynb</code> → <code>### Exercise 1.1</code>, <code>### Exercise 1.2</code>, <code>### Exercise 1.3</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day1_Quiz.html</code> → <code>QUIZ_DATA</code> questions 1–6</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 1)</h1>
+            <p><strong>⚠️</strong> Confusing file save with lab session save</p>
+<p><strong>⚠️</strong> Waiting too long between commits</p>
+<p><strong>⚠️</strong> Skipping the readiness script and discovering issues later</p>
+<p><strong>⚠️</strong> Treating Git as backup instead of workflow</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> What does a commit do that a push does not?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 2: Designing Classes from Requirements</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Turn a requirements list into candidate classes</li>
+  <li>Separate what an object <strong>knows</strong> from what it <strong>does</strong></li>
+  <li>Keep UI concerns out of domain models</li>
+  <li>Introduce a coordinating service layer</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Responsibility-Driven Design</h1>
+            <ul>
+  <li>Ask first:</li>
+  <li style="margin-left: 30px;">What does this object know?</li>
+  <li style="margin-left: 30px;">What does this object do?</li>
+  <li>Keep methods small and testable</li>
+  <li>Let the model protect its own state</li>
+  <li>Let the service layer coordinate workflows</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>From Requirements to Classes</h1>
+            <h3>Example Tracker Domain</h3>
+<ul>
+  <li><code>Task</code></li>
+  <li style="margin-left: 30px;">knows: title, description, priority, status</li>
+  <li style="margin-left: 30px;">does: complete(), update_priority()</li>
+  <li><code>TaskService</code> or <code>TaskManager</code></li>
+  <li style="margin-left: 30px;">knows: collection of tasks</li>
+  <li style="margin-left: 30px;">does: add_task(), get_pending_tasks(), search()</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Boundary Rule</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Keep These Separate</h1>
+            <ul>
+  <li><strong>Model</strong>: domain state + invariant-friendly behavior</li>
+  <li><strong>Service layer</strong>: orchestration + use cases</li>
+  <li><strong>UI layer</strong>: <code>print()</code>, <code>input()</code>, menus, prompts</li>
+</ul>
+<h3>Smell to Fix</h3>
+<ul>
+  <li>A <code>Task</code> class that asks for user input directly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Small but Clean Model</h1>
+            <pre data-lang="python"><code>class Task:
+    def __init__(self, title: str, description: str, priority: str = &quot;Medium&quot;) -&gt; None:
+        self.title = title
+        self.description = description
+        self.priority = priority
+        self.is_complete = False
+
+    def complete(self) -&gt; None:
+        self.is_complete = True</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Outside-the-Class Summary</h1>
+            <pre data-lang="python"><code>def display_task_summary(task: Task) -&gt; None:
+    status = &quot;Done&quot; if task.is_complete else &quot;Pending&quot;
+    print(f&quot;[{status}] {task.title} (Priority: {task.priority})&quot;)</code></pre>
+<ul>
+  <li>Logic stays in the model</li>
+  <li>Presentation stays outside the model</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Domain Modeling</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Pick one tracker domain:</li>
+  <li style="margin-left: 30px;">tasks</li>
+  <li style="margin-left: 30px;">contacts</li>
+  <li style="margin-left: 30px;">inventory</li>
+  <li style="margin-left: 30px;">notes</li>
+  <li style="margin-left: 30px;">expenses</li>
+  <li>Write 5–8 requirements</li>
+  <li>Design 3–5 classes</li>
+  <li>Implement at least:</li>
+  <li style="margin-left: 30px;">one domain class</li>
+  <li style="margin-left: 30px;">one coordinating class</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 2)</h1>
+            <p><span class="check">✓</span> Requirements map clearly to classes</p>
+<p><span class="check">✓</span> Attributes and methods are distinct</p>
+<p><span class="check">✓</span> No <code>input()</code> / <code>print()</code> inside domain logic</p>
+<p><span class="check">✓</span> Demo block creates an object and shows a summary externally</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 2)</h1>
+            <ul>
+  <li>Homework expects:</li>
+  <li style="margin-left: 30px;">requirement bullets</li>
+  <li style="margin-left: 30px;">3–5 classes</li>
+  <li style="margin-left: 30px;">one domain class + one coordinating class</li>
+  <li style="margin-left: 30px;">a clear boundary rule</li>
+  <li>Quiz focus:</li>
+  <li style="margin-left: 30px;">what an object knows vs does</li>
+  <li style="margin-left: 30px;">what belongs in a service layer</li>
+  <li style="margin-left: 30px;">where validation should live</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day1_homework.ipynb</code> → <code>## Part 2: Designing Classes from Requirements</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day1_Quiz.html</code> → <code>QUIZ_DATA</code> questions 7–12</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 2)</h1>
+            <p><strong>⚠️</strong> Putting UI prompts into model methods</p>
+<p><strong>⚠️</strong> Designing around globals instead of collaborators</p>
+<p><strong>⚠️</strong> Making classes vague helper buckets</p>
+<p><strong>⚠️</strong> Jumping to inheritance before clarifying responsibilities</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Where should business validation live: UI, service/model, or Git history?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 3: Properties, Invariants, and Custom Exceptions</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Define an invariant for a real domain object</li>
+  <li>Use <code>@property</code> to control attribute access</li>
+  <li>Raise specific exceptions for domain problems</li>
+  <li>Catch errors in the driver/UI layer instead of inside the model</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Core Idea: Valid Objects Stay Valid</h1>
+            <ul>
+  <li>An <strong>invariant</strong> is a rule that must remain true</li>
+  <li>Examples:</li>
+  <li style="margin-left: 30px;">title must not be blank</li>
+  <li style="margin-left: 30px;">amount must be positive</li>
+  <li style="margin-left: 30px;">priority must be an integer in range</li>
+  <li>A model that accepts invalid state becomes harder to trust later</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Custom Exception + Property</h1>
+            <pre data-lang="python"><code>class ValidationError(Exception):
+    pass
+
+
+class Task:
+    def __init__(self, title: str, priority: int = 1) -&gt; None:
+        self.title = title
+        self.priority = priority</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Validated Setter</h1>
+            <pre data-lang="python"><code>    @property
+    def priority(self) -&gt; int:
+        return self._priority
+
+    @priority.setter
+    def priority(self, value: int) -&gt; None:
+        if not isinstance(value, int) or value &lt; 1:
+            raise ValidationError(&quot;Priority must be an integer &gt;= 1&quot;)
+        self._priority = value</code></pre>
+<ul>
+  <li>Backing field uses <code>_priority</code></li>
+  <li>Setter guards the invariant</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Catching Specific Errors</h1>
+            <pre data-lang="python"><code>try:
+    task = Task(&quot;Clean Desk&quot;, priority=-1)
+except ValidationError as error:
+    print(f&quot;ValidationError: {error}&quot;)</code></pre>
+<ul>
+  <li>Specific beats broad</li>
+  <li>Avoid <code>except Exception:</code> for expected domain failures</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Validation + Exceptions</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Convert one important attribute to a validated property</li>
+  <li>Add at least two custom exceptions:</li>
+  <li style="margin-left: 30px;"><code>ValidationError</code></li>
+  <li style="margin-left: 30px;"><code>NotFoundError</code></li>
+  <li>Show:</li>
+  <li style="margin-left: 30px;">invalid data raises <code>ValidationError</code></li>
+  <li style="margin-left: 30px;">missing lookup raises <code>NotFoundError</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 3)</h1>
+            <p><span class="check">✓</span> A real invariant is enforced</p>
+<p><span class="check">✓</span> The setter uses a backing field</p>
+<p><span class="check">✓</span> Specific exceptions are raised intentionally</p>
+<p><span class="check">✓</span> Friendly handling happens in a driver/demo block</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 3)</h1>
+            <ul>
+  <li>Homework expects both <code>ValidationError</code> and <code>NotFoundError</code></li>
+  <li>Canonical outputs include:</li>
+  <li style="margin-left: 30px;"><code>Priority set to: 3</code></li>
+  <li style="margin-left: 30px;"><code>ValidationError: title cannot be empty</code></li>
+  <li style="margin-left: 30px;"><code>NotFoundError: task 404 was not found</code></li>
+  <li>Quiz focus:</li>
+  <li style="margin-left: 30px;">invariant meaning</li>
+  <li style="margin-left: 30px;">why <code>@property</code> helps</li>
+  <li style="margin-left: 30px;">why specific exceptions beat <code>except Exception:</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day1_homework.ipynb</code> → <code>## Part 3: Properties, Invariants, and Custom Exceptions</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day1_Quiz.html</code> → <code>QUIZ_DATA</code> questions 13–18</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 3)</h1>
+            <p><strong>⚠️</strong> Setter assigns to <code>self.priority</code> recursively</p>
+<p><strong>⚠️</strong> Returning <code>False</code> instead of surfacing a real error</p>
+<p><strong>⚠️</strong> Catching every exception and hiding unrelated bugs</p>
+<p><strong>⚠️</strong> Validating only in the UI and not in the model/service</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Why is <code>ValidationError</code> usually better than returning <code>False</code> from validation code?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 4: Composition vs Inheritance + Polymorphism</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Distinguish <strong>is-a</strong> from <strong>has-a</strong></li>
+  <li>Use composition when collaborator behavior may vary</li>
+  <li>Reduce branchy code with shared method names</li>
+  <li>Explain duck typing in practical terms</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Inheritance vs Composition</h1>
+            <h3>Use Inheritance for</h3>
+<ul>
+  <li>real <strong>is-a</strong> relationships</li>
+  <li>stable shared behavior</li>
+</ul>
+<h3>Use Composition for</h3>
+<ul>
+  <li><strong>has-a</strong> relationships</li>
+  <li>swappable collaborators</li>
+  <li>cleaner extension without deep class trees</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Branchy Export Smell</h1>
+            <pre data-lang="python"><code>def export_data(data, format_type):
+    if format_type == &quot;json&quot;:
+        ...
+    elif format_type == &quot;csv&quot;:
+        ...
+    else:
+        raise ValueError(&quot;Unknown format&quot;)</code></pre>
+<ul>
+  <li>Works at first</li>
+  <li>Scales badly as new behaviors appear</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Polymorphic Exporters</h1>
+            <pre data-lang="python"><code>class JSONExporter:
+    def export(self, data):
+        return {&quot;data&quot;: data}
+
+
+class CSVExporter:
+    def export(self, data):
+        return f&quot;data,{data}&quot;</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Composition in the Caller</h1>
+            <pre data-lang="python"><code>class ReportService:
+    def __init__(self, exporter) -&gt; None:
+        self.exporter = exporter
+
+    def generate(self, data):
+        return self.exporter.export(data)</code></pre>
+<ul>
+  <li>Caller depends on a compatible collaborator</li>
+  <li>New exporter types do not require new caller branches</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Refactor a Branchy Design</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Start with a branching scenario:</li>
+  <li style="margin-left: 30px;">exporting</li>
+  <li style="margin-left: 30px;">notifications</li>
+  <li style="margin-left: 30px;">payments</li>
+  <li>Create 2+ implementations with the same method name</li>
+  <li>Add a class that <strong>has a</strong> collaborator</li>
+  <li>Swap collaborators without changing caller structure</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 4)</h1>
+            <p><span class="check">✓</span> A large <code>if/elif</code> chain is reduced or removed</p>
+<p><span class="check">✓</span> Two or more implementations share one method name</p>
+<p><span class="check">✓</span> Composition is visible in the caller</p>
+<p><span class="check">✓</span> A third implementation could be added with minimal change</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 4)</h1>
+            <ul>
+  <li>Homework expects:</li>
+  <li style="margin-left: 30px;">a branchy design replaced</li>
+  <li style="margin-left: 30px;">composition shown clearly</li>
+  <li style="margin-left: 30px;">optional third implementation</li>
+  <li>Canonical output references:</li>
+  <li style="margin-left: 30px;"><code>Composed notifier sent: Task created</code></li>
+  <li style="margin-left: 30px;"><code>Export text: TASK-101 | Draft syllabus</code></li>
+  <li style="margin-left: 30px;"><code>Export dict: {&#x27;id&#x27;: &#x27;TASK-101&#x27;, &#x27;title&#x27;: &#x27;Draft syllabus&#x27;}</code></li>
+  <li>Quiz focus:</li>
+  <li style="margin-left: 30px;">is-a vs has-a</li>
+  <li style="margin-left: 30px;">duck typing</li>
+  <li style="margin-left: 30px;">caller stability when new implementations appear</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day1_homework.ipynb</code> → <code>## Part 4: Composition vs Inheritance + Polymorphism</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day1_Quiz.html</code> → <code>QUIZ_DATA</code> questions 19–24</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 4)</h1>
+            <p><strong>⚠️</strong> Moving the <code>if/elif</code> chain into a new class instead of removing it</p>
+<p><strong>⚠️</strong> Inheriting when the relationship is really has-a</p>
+<p><strong>⚠️</strong> Forgetting that duck typing cares about behavior, not ancestry</p>
+<p><strong>⚠️</strong> Hard-coding collaborator choice inside the caller</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> What is the practical benefit of giving the caller any object with a compatible <code>export()</code> method?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 1 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Built Today</h1>
+            <ul>
+  <li>A stable workspace + Git baseline</li>
+  <li>Cleaner domain boundaries</li>
+  <li>Validated models with specific exceptions</li>
+  <li>Composition-friendly architecture</li>
+</ul>
+<h3>Key Day 1 Rule</h3>
+<p><strong>Professional Python starts with trustworthy structure.</strong></p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 1 Homework / Study Checklist</h1>
+            <ul>
+  <li>Re-run the diagnostic script</li>
+  <li>Refine your requirements list</li>
+  <li>Enforce one invariant with a property</li>
+  <li>Add two specific custom exceptions</li>
+  <li>Refactor one branch-heavy workflow into collaborators</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day1_homework.ipynb</code> → <code>## Reflection and Submission Checklist</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Next Session Preview</h1>
+            <h3>Session 2 (Hours 5–8)</h3>
+<ul>
+  <li>Factory pattern for validated creation</li>
+  <li>Strategy pattern for swappable behavior</li>
+  <li><code>__repr__</code>, <code>__str__</code>, equality, and light type hints</li>
+  <li>Checkpoint 1: domain + service layer milestone</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Save your work.</p>
+<p>Commit the latest good state.</p>
+<p>Be ready to extend the core tomorrow.</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/slides/advanced/day-02/day-02-session-2.html
+++ b/slides/advanced/day-02/day-02-session-2.html
@@ -1,0 +1,1071 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 2 — Session 2 (Hours 5–8)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 2 — Session 2 (Hours 5–8)</h1>
+            <div class="subtitle">Python Programming (Advanced) • Factory, Strategy, Ergonomics, and Checkpoint 1</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 2 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 5: Pattern: Factory (practical creation + validation)</li>
+  <li>Hour 6: Pattern: Strategy (swap behaviors cleanly)</li>
+  <li>Hour 7: Pythonic class ergonomics (<code>repr</code> / <code>str</code> / equality) + light type hints</li>
+  <li>Hour 8: Checkpoint 1: domain + service layer milestone</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → <code>## Session 2 overview</code></li>
+  <li><code>Advanced/lessons/lecture/Day2_Hour1_Advanced.md</code> → <code># Day 2, Hour 1: Pattern: Factory (practical creation + validation)</code></li>
+  <li><code>Advanced/lessons/lecture/Day2_Hour2_Advanced.md</code> → <code># Day 2, Hour 2: Pattern: Strategy (swap behaviors cleanly)</code></li>
+  <li><code>Advanced/lessons/lecture/Day2_Hour3_Advanced.md</code> → <code># Day 2, Hour 3: Pythonic Class Ergonomics</code></li>
+  <li><code>Advanced/lessons/lecture/Day2_Hour4_Advanced.md</code> → <code># Day 2, Hour 4: Checkpoint 1: Domain + Service Layer Milestone</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session 2 Outcomes</h1>
+            <ul>
+  <li>Centralize creation rules with factories</li>
+  <li>Swap behavior without rewriting callers</li>
+  <li>Make models easier to inspect, print, and compare</li>
+  <li>Deliver a clean headless core for Checkpoint 1</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>In Scope</h1>
+            <ul>
+  <li>Validated object creation</li>
+  <li>Strategy dispatch with functions or collaborators</li>
+  <li>Readable object output and simple type hints</li>
+  <li>Core-only checkpoint work</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Not Yet</h1>
+            <ul>
+  <li>Database persistence</li>
+  <li>GUI callbacks</li>
+  <li>HTTP routes</li>
+  <li>Heavy typing abstractions or framework ceremony</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 5: Factory Pattern</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Move creation + normalization logic out of <code>__init__</code></li>
+  <li>Turn raw payloads into safe domain objects</li>
+  <li>Raise validation errors before bad objects spread</li>
+  <li>Explain why centralized creation improves consistency</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Factories Matter</h1>
+            <ul>
+  <li>External data is messy</li>
+  <li>Repeating validation in every caller causes drift</li>
+  <li><code>__init__</code> should initialize, not become a giant intake pipeline</li>
+  <li>A factory can:</li>
+  <li style="margin-left: 30px;">validate</li>
+  <li style="margin-left: 30px;">normalize</li>
+  <li style="margin-left: 30px;">apply defaults</li>
+  <li style="margin-left: 30px;">return a ready-to-use object</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Factory from Raw Data</h1>
+            <pre data-lang="python"><code>class UserFactory:
+    @classmethod
+    def from_dict(cls, data):
+        if &quot;name&quot; not in data:
+            raise ValidationError(&quot;Missing required field: &#x27;name&#x27;&quot;)
+
+        name = data[&quot;name&quot;].strip().title()
+        role = data.get(&quot;role&quot;, &quot;member&quot;).lower()
+        return User(full_name=name, role=role)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Factory Responsibilities</h1>
+            <ul>
+  <li>Validate required fields</li>
+  <li>Normalize messy input</li>
+  <li>Supply safe defaults</li>
+  <li>Reject unsupported values early</li>
+</ul>
+<h3>Better Than</h3>
+<ul>
+  <li>every route validating differently</li>
+  <li>every CLI prompt building objects ad hoc</li>
+  <li>huge constructors full of branching</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Build a Validated Factory</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create a <code>from_dict()</code> or <code>create_*()</code> factory</li>
+  <li>Validate at least one required field</li>
+  <li>Normalize one messy field</li>
+  <li>Return a safe tracker record or raise <code>ValidationError</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 5)</h1>
+            <p><span class="check">✓</span> Factory builds valid objects from raw payloads</p>
+<p><span class="check">✓</span> Missing or bad data fails clearly</p>
+<p><span class="check">✓</span> Creation logic is not duplicated in multiple callers</p>
+<p><span class="check">✓</span> The returned object is ready for service-layer use</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 5)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> validated factory for safe tracker records</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> use a classmethod factory</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> duplicating validation logic in every caller</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 5 | factory title: Refactor auth flow</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day2_homework.ipynb</code> → <code>## Part 1: Hour 5 - Pattern: Factory</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day2_Quiz.html</code> → <code>QUIZ_DATA</code> questions 1–5</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 5)</h1>
+            <p><strong>⚠️</strong> Letting invalid objects exist &quot;just for now&quot;</p>
+<p><strong>⚠️</strong> Hiding normalization logic in random callers</p>
+<p><strong>⚠️</strong> Making <code>__init__</code> do everything</p>
+<p><strong>⚠️</strong> Using vague exceptions with vague messages</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Why is a factory safer than repeating payload validation in five different places?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 6: Strategy Pattern</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Replace branch-heavy behavior selection</li>
+  <li>Use functions or collaborators as strategies</li>
+  <li>Dispatch dynamically from a small mapping</li>
+  <li>Keep core orchestration stable while behavior changes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Strategy in Plain English</h1>
+            <ul>
+  <li>We have one job with multiple ways to do it</li>
+  <li>We separate <strong>what happens</strong> from <strong>how it happens</strong></li>
+  <li>In Python, a strategy can just be a callable</li>
+</ul>
+<h3>Typical Use Cases</h3>
+<ul>
+  <li>sorting</li>
+  <li>filtering</li>
+  <li>exporting</li>
+  <li>notifications</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Dispatch Map</h1>
+            <pre data-lang="python"><code>def sort_by_name(record):
+    return record[&quot;name&quot;]
+
+
+sorting_strategies = {
+    &quot;name&quot;: sort_by_name,
+    &quot;id&quot;: sort_by_id,
+    &quot;created&quot;: sort_by_date,
+}</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Core Function Stays Simple</h1>
+            <pre data-lang="python"><code>def display_records_strategy(records, strategy_key):
+    strategy_func = sorting_strategies.get(strategy_key, sort_by_id)
+    sorted_records = sorted(records, key=strategy_func)
+    for record in sorted_records:
+        print(record)</code></pre>
+<ul>
+  <li>Caller does not need a giant <code>if/elif</code></li>
+  <li>New strategies are easier to add</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Strategy Selection</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Choose a behavior that varies:</li>
+  <li style="margin-left: 30px;">filter active vs all</li>
+  <li style="margin-left: 30px;">sort by name vs date</li>
+  <li style="margin-left: 30px;">notify via email vs console</li>
+  <li>Implement 2+ strategies</li>
+  <li>Use a dictionary dispatcher or injected collaborator</li>
+  <li>Run the same caller with multiple behaviors</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 6)</h1>
+            <p><span class="check">✓</span> Two or more strategies exist</p>
+<p><span class="check">✓</span> Behavior is selected dynamically</p>
+<p><span class="check">✓</span> Caller logic stays small</p>
+<p><span class="check">✓</span> A new strategy can be added without rewriting the main flow</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 6)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> switch behavior without rewriting the caller</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> inject behavior objects or callables</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> burying every algorithm in one <code>if/elif</code> chain</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 6 | strategy selected: EmailNotifier</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day2_homework.ipynb</code> → <code>## Part 2: Hour 6 - Pattern: Strategy</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day2_Quiz.html</code> → <code>QUIZ_DATA</code> questions 6–10</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 6)</h1>
+            <p><strong>⚠️</strong> Calling a function instead of passing the function object</p>
+<p><strong>⚠️</strong> Keeping the big branch chain in the main routine</p>
+<p><strong>⚠️</strong> Naming strategies unclearly</p>
+<p><strong>⚠️</strong> Mixing strategy selection with unrelated UI complexity</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> What changes when you add a third strategy to a good strategy-based design?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 7: Pythonic Class Ergonomics</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Differentiate <code>__str__</code> from <code>__repr__</code></li>
+  <li>Implement value-based equality with <code>__eq__</code></li>
+  <li>Add light type hints that improve readability and tooling</li>
+  <li>Prepare models for easier debugging and serialization</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Default Objects Are Not Enough</h1>
+            <pre data-lang="python"><code>print(task)
+# &lt;__main__.Task object at 0x...&gt;</code></pre>
+<ul>
+  <li>Not useful for logs</li>
+  <li>Not useful for debugging</li>
+  <li>Not helpful in a CLI or demo script</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Friendly + Developer Views</h1>
+            <pre data-lang="python"><code>class Task:
+    def __init__(self, t_id: int, title: str) -&gt; None:
+        self.id = t_id
+        self.title = title
+
+    def __repr__(self) -&gt; str:
+        return f&quot;Task(t_id={self.id}, title=&#x27;{self.title}&#x27;)&quot;
+
+    def __str__(self) -&gt; str:
+        return f&quot;[{self.id}] {self.title}&quot;</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Equality Matters, Too</h1>
+            <pre data-lang="python"><code>def __eq__(self, other: object) -&gt; bool:
+    if not isinstance(other, Task):
+        return False
+    return self.id == other.id and self.title == other.title</code></pre>
+<ul>
+  <li>Default equality checks identity</li>
+  <li>Custom equality can check useful data equivalence</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Light Type Hinting Rules</h1>
+            <ul>
+  <li>Keep it simple:</li>
+  <li style="margin-left: 30px;"><code>int</code></li>
+  <li style="margin-left: 30px;"><code>str</code></li>
+  <li style="margin-left: 30px;"><code>list</code></li>
+  <li style="margin-left: 30px;"><code>dict</code></li>
+  <li style="margin-left: 30px;"><code>-&gt; None</code></li>
+  <li>Use hints to document intent</li>
+  <li>Do not turn this hour into typing wizardry</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Make the Model Pleasant to Work With</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add <code>__repr__</code></li>
+  <li>Add <code>__str__</code></li>
+  <li>Add <code>__eq__</code> where value comparison helps</li>
+  <li>Add type hints to <code>__init__</code> and 3+ methods/functions</li>
+  <li>Optional: add <code>to_dict()</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 7)</h1>
+            <p><span class="check">✓</span> Model prints helpfully for users and developers</p>
+<p><span class="check">✓</span> Equality behavior is intentional</p>
+<p><span class="check">✓</span> Type hints improve readability without overcomplication</p>
+<p><span class="check">✓</span> <code>__str__</code> and <code>__repr__</code> return strings, not <code>print()</code></p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 7)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> string output and equality that support debugging and testing</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> implement <code>repr</code>, <code>str</code>, and equality clearly</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> unreadable model output</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 7 | repr: Task(title=&#x27;Write tests&#x27;, priority=&#x27;medium&#x27;)</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day2_homework.ipynb</code> → <code>## Part 3: Hour 7 - Pythonic class ergonomics</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day2_Quiz.html</code> → <code>QUIZ_DATA</code> questions 11–15</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 7)</h1>
+            <p><strong>⚠️</strong> <code>__str__</code> uses <code>print()</code> instead of returning a string</p>
+<p><strong>⚠️</strong> Overcomplicating hints with unnecessary imports</p>
+<p><strong>⚠️</strong> Equality based on the wrong fields</p>
+<p><strong>⚠️</strong> Forgetting that <code>repr()</code> serves developers first</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> When would you inspect <code>repr(obj)</code> instead of <code>str(obj)</code>?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 8: Checkpoint 1 — Domain + Service Layer Milestone</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Deliver a stable, headless core package</li>
+  <li>Demonstrate happy-path and sad-path flows</li>
+  <li>Show service-layer CRUD behavior</li>
+  <li>Prepare the codebase for packaging and persistence next</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>What Checkpoint 1 Proves</h1>
+            <ul>
+  <li>Models are real, not placeholder shells</li>
+  <li>Services coordinate use cases cleanly</li>
+  <li>Exceptions communicate invalid operations</li>
+  <li>Objects can serialize to dictionaries</li>
+  <li>The core works without a GUI, DB, or API layer</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Rubric Snapshot</h1>
+            <h3>Expect to Show</h3>
+<ul>
+  <li>at least 2 model/helper classes</li>
+  <li>add, list, search, update, delete behaviors</li>
+  <li>custom exceptions</li>
+  <li><code>to_dict()</code> or similar serialization helper</li>
+  <li>a small demo script that proves the design</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Shape for Grading</h1>
+            <pre data-lang="python"><code>print(&quot;--- Starting Checkpoint 1 Demo ---&quot;)
+print(&quot;1. Happy Path: Adding valid records...&quot;)
+print(&quot;2. Sad Path: Missing required fields...&quot;)
+print(&quot;3. Sad Path: Updating a missing record...&quot;)
+print(&quot;4. Serialization Check...&quot;)</code></pre>
+<ul>
+  <li>Make grading easy</li>
+  <li>Prove both success and failure paths deliberately</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Checkpoint 1 Build</h1>
+            <p><strong>Time: 45–60 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Review model and service separation</li>
+  <li>Fill missing CRUD operations</li>
+  <li>Confirm exceptions are raised intentionally</li>
+  <li>Add or refine <code>to_dict()</code></li>
+  <li>Build a demo script that shows:</li>
+  <li style="margin-left: 30px;">valid creation</li>
+  <li style="margin-left: 30px;">invalid data handling</li>
+  <li style="margin-left: 30px;">missing record handling</li>
+  <li style="margin-left: 30px;">serialization output</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 8)</h1>
+            <p><span class="check">✓</span> Headless core runs end to end</p>
+<p><span class="check">✓</span> Service layer does real work</p>
+<p><span class="check">✓</span> Sad paths fail cleanly</p>
+<p><span class="check">✓</span> Demo script proves the rubric without digging through the whole codebase</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 8)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> milestone that adds, validates, and lists tracker records</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> keep domain logic in the service layer</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> letting UI or raw dicts bypass the service layer</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 8 | checkpoint records: 2</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day2_homework.ipynb</code> → <code>## Part 4: Hour 8 - Checkpoint 1</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day2_Quiz.html</code> → <code>QUIZ_DATA</code> questions 16–20</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 8)</h1>
+            <p><strong>⚠️</strong> UI prompts inside service methods</p>
+<p><strong>⚠️</strong> Global state everywhere</p>
+<p><strong>⚠️</strong> Missing-record crashes turning into <code>IndexError</code> noise</p>
+<p><strong>⚠️</strong> Demo scripts that show only the happy path</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Why is a clean core milestone more valuable right now than adding a flashy interface?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 2 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Extended Today</h1>
+            <ul>
+  <li>Safer creation with factories</li>
+  <li>Cleaner behavior swaps with strategies</li>
+  <li>Better debugging ergonomics</li>
+  <li>A checkpointed service-layer core</li>
+</ul>
+<h3>Key Rule</h3>
+<p><strong>Make the core trustworthy before adding more surfaces.</strong></p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 2 Homework / Study Checklist</h1>
+            <ul>
+  <li>Re-run your factory with good and bad payloads</li>
+  <li>Add one more strategy</li>
+  <li>Confirm <code>repr</code>, <code>str</code>, and equality behavior</li>
+  <li>Verify the checkpoint demo proves both happy and sad paths</li>
+  <li>Match required labels exactly where autograding expects them</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day2_homework.ipynb</code> → <code>## Submission Checklist</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Next Session Preview</h1>
+            <h3>Session 3 (Hours 9–12)</h3>
+<ul>
+  <li>Package structure under <code>src/</code></li>
+  <li>Logging and developer diagnostics</li>
+  <li>Context managers and safe save patterns</li>
+  <li>Decorators for timing, auth, and validation</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Save the notebook.</p>
+<p>Commit the checkpoint.</p>
+<p>Come back ready to package the core properly.</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/slides/advanced/day-03/day-03-session-3.html
+++ b/slides/advanced/day-03/day-03-session-3.html
@@ -1,0 +1,1129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 3 — Session 3 (Hours 9–12)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 3 — Session 3 (Hours 9–12)</h1>
+            <div class="subtitle">Python Programming (Advanced) • Packages, Logging, Safe Saves, and Decorators</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 3 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 9: Project structure, packages, imports, and config</li>
+  <li>Hour 10: Logging and error reporting (practical)</li>
+  <li>Hour 11: Context managers + safer file operations</li>
+  <li>Hour 12: Decorators (timing / authorization / validation)</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → <code>## Session 3 overview</code></li>
+  <li><code>Advanced/lessons/lecture/Day3_Hour1_Advanced.md</code> → <code># Advanced Day 3, Hour 1: Project Structure, Packages, Imports, and Config</code></li>
+  <li><code>Advanced/lessons/lecture/Day3_Hour2_Advanced.md</code> → <code># Day 3, Hour 2: Logging and Error Reporting (Practical)</code></li>
+  <li><code>Advanced/lessons/lecture/Day3_Hour3_Advanced.md</code> → <code># Day 3, Hour 3: Context Managers + Safer File Operations</code></li>
+  <li><code>Advanced/lessons/lecture/Day3_Hour4_Advanced.md</code> → <code># Day 3, Hour 4: Decorators (Timing / Authorization / Validation)</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session 3 Outcomes</h1>
+            <ul>
+  <li>Package the core under <code>src/</code></li>
+  <li>Add logging that helps developers without spamming users</li>
+  <li>Save JSON more safely with temp-then-replace thinking</li>
+  <li>Use decorators for repeated edge behavior</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>In Scope</h1>
+            <ul>
+  <li>Packaging and import hygiene</li>
+  <li>File-based logging</li>
+  <li>Context managers and safe saves</li>
+  <li>Small, readable decorators</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Not Yet</h1>
+            <ul>
+  <li>Full production config systems</li>
+  <li>Secret-heavy deployment workflows</li>
+  <li>Decorator metaprogramming tricks</li>
+  <li>Database transactions</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 9: Project Structure + Imports + Config</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Move from a loose script pile to a usable package layout</li>
+  <li>Explain the role of <code>__init__.py</code></li>
+  <li>Avoid common import headaches</li>
+  <li>Centralize simple configuration</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Structure Matters Now</h1>
+            <ul>
+  <li>Yesterday&#x27;s checkpoint core needs a cleaner home</li>
+  <li>New layers are coming:</li>
+  <li style="margin-left: 30px;">logging</li>
+  <li style="margin-left: 30px;">persistence</li>
+  <li style="margin-left: 30px;">APIs</li>
+  <li style="margin-left: 30px;">tests</li>
+  <li>Brittle imports slow every later step</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Practical `src/` Layout</h1>
+            <pre data-lang="text"><code>project_root/
+    src/
+        tracker/
+            __init__.py
+            models.py
+            services.py
+            exceptions.py
+            config.py
+    demo.py
+    README.md</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Import Rules to Remember</h1>
+            <ul>
+  <li>Relative imports can help <strong>inside</strong> a package</li>
+  <li>Absolute imports are clearer <strong>from outside</strong> the package</li>
+  <li>Run from the project root or use <code>python -m ...</code></li>
+</ul>
+<h3>Three Headaches to Avoid</h3>
+<ol>
+  <li>Wrong entry file</li>
+  <li>Circular imports</li>
+  <li>Naming collisions like <code>json.py</code> or <code>logging.py</code></li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Clean Package Move</h1>
+            <pre data-lang="python"><code>from tracker.exceptions import ValidationError
+
+
+class Task:
+    def __init__(self, task_id: int, title: str, priority: str = &quot;medium&quot;) -&gt; None:
+        ...</code></pre>
+<ul>
+  <li>Move related files together</li>
+  <li>Fix imports intentionally</li>
+  <li>Re-run the demo after restructuring</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Light Configuration</h1>
+            <ul>
+  <li>Move hard-coded paths into <code>config.py</code></li>
+  <li>Good early config values:</li>
+  <li style="margin-left: 30px;">data directory</li>
+  <li style="margin-left: 30px;">log path</li>
+  <li style="margin-left: 30px;">default save filename</li>
+  <li>Keep it small and practical</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Restructure the Core</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create <code>src/tracker/</code></li>
+  <li>Add <code>__init__.py</code></li>
+  <li>Move models and services into the package</li>
+  <li>Update imports</li>
+  <li>Add a simple <code>config.py</code></li>
+  <li>Prove the demo still runs</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 9)</h1>
+            <p><span class="check">✓</span> Package layout exists</p>
+<p><span class="check">✓</span> Imports are consistent</p>
+<p><span class="check">✓</span> Demo runs from the intended entry point</p>
+<p><span class="check">✓</span> Config values are not scattered across random files</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 9)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> package layout + config module</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> packages + dedicated settings module</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> relative imports everywhere without discipline</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 9 | package root: tracker_app</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day3_homework.ipynb</code> → <code>## Part 1: Hour 9 - Project structure: packages, imports, and config</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day3_Quiz.html</code> → <code>QUIZ_DATA</code> questions 1–5</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 9)</h1>
+            <p><strong>⚠️</strong> Running modules directly from inside the package</p>
+<p><strong>⚠️</strong> Circular imports between services and models</p>
+<p><strong>⚠️</strong> Shadowing standard library module names</p>
+<p><strong>⚠️</strong> Hard-coded paths in multiple files</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> What usually causes <code>ModuleNotFoundError</code> right after a student &quot;cleans up&quot; project structure?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 10: Logging and Error Reporting</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Use <code>logging</code> instead of scattered <code>print()</code> debugging</li>
+  <li>Choose practical levels: DEBUG, INFO, WARNING, ERROR</li>
+  <li>Keep user messages separate from developer diagnostics</li>
+  <li>Write logs to <code>logs/app.log</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Big Idea</h1>
+            <p><strong>Logs are for developers. Error messages are for users.</strong></p>
+<ul>
+  <li>Users need calm, clear feedback</li>
+  <li>Developers need timestamps, context, and failure detail</li>
+  <li>More output is not the same as better diagnostics</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Practical Log Levels</h1>
+            <ul>
+  <li><code>DEBUG</code> → detailed development tracing</li>
+  <li><code>INFO</code> → normal important events</li>
+  <li><code>WARNING</code> → something odd happened, but recovery is possible</li>
+  <li><code>ERROR</code> → an operation failed</li>
+</ul>
+<h3>Example Signals</h3>
+<ul>
+  <li>&quot;created task 7&quot; → INFO</li>
+  <li>&quot;task 999 missing&quot; → WARNING</li>
+  <li>&quot;failed to save file&quot; → ERROR</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Configure Logging</h1>
+            <pre data-lang="python"><code>import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    filename=&quot;logs/app.log&quot;,
+)</code></pre>
+<pre data-lang="python"><code>logger = logging.getLogger(__name__)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Friendly User Message, Richer Log</h1>
+            <pre data-lang="python"><code>try:
+    service.get_task(999)
+except NotFoundError:
+    logger.warning(&quot;Attempted lookup for missing task_id=%s&quot;, 999)
+    print(&quot;Task 999 was not found.&quot;)</code></pre>
+<ul>
+  <li>Same event</li>
+  <li>Different audiences</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Add Logging</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create <code>logs/</code></li>
+  <li>Configure file logging</li>
+  <li>Add at least three log calls</li>
+  <li>Trigger one failure on purpose</li>
+  <li>Inspect <code>logs/app.log</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 10)</h1>
+            <p><span class="check">✓</span> <code>app.log</code> is created</p>
+<p><span class="check">✓</span> Logs show useful events, not noise</p>
+<p><span class="check">✓</span> User-facing messages stay readable</p>
+<p><span class="check">✓</span> Failures leave a developer trail</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 10)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> structured log messages for service events and failures</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> use logging levels instead of <code>print()</code> debugging</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> dumping raw secrets or stack noise into ordinary logs</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 10 | logger name: tracker.service</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day3_homework.ipynb</code> → <code>## Part 2: Hour 10 - Logging and error reporting</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day3_Quiz.html</code> → <code>QUIZ_DATA</code> questions 6–10</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 10)</h1>
+            <p><strong>⚠️</strong> Using logs as a substitute for clear code</p>
+<p><strong>⚠️</strong> Logging too little or too much</p>
+<p><strong>⚠️</strong> Showing full tracebacks to end users</p>
+<p><strong>⚠️</strong> Forgetting to create the log directory</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> When should you log at <code>WARNING</code> instead of <code>ERROR</code>?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 11: Context Managers + Safer File Operations</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain what a context manager really guarantees</li>
+  <li>Use <code>with</code> for safer resource handling</li>
+  <li>Understand why naive overwrites can corrupt data</li>
+  <li>Apply a write-temp-then-replace save pattern</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>The Mental Model for `with`</h1>
+            <ul>
+  <li>setup on entry</li>
+  <li>cleanup on exit</li>
+  <li>cleanup still happens if an exception occurs</li>
+</ul>
+<h3>Common Uses</h3>
+<ul>
+  <li>files</li>
+  <li>locks</li>
+  <li>database connections</li>
+  <li>temporary resources</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Direct Overwrites Are Risky</h1>
+            <pre data-lang="python"><code>with open(&quot;tasks.json&quot;, &quot;w&quot;) as file:
+    file.write(json_text)</code></pre>
+<ul>
+  <li>Better than manual close</li>
+  <li>Still risky if the write fails midway</li>
+  <li>Can leave a good file half-written or corrupted</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Safe Save Pattern</h1>
+            <ol>
+  <li>Resolve the real target path</li>
+  <li>Make sure the parent directory exists</li>
+  <li>Write new content to a temp file</li>
+  <li>Close it successfully</li>
+  <li>Replace the original file</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: `save_json_safe`</h1>
+            <pre data-lang="python"><code>from pathlib import Path
+import json
+
+
+def save_json_safe(path: str | Path, data: list[dict]) -&gt; None:
+    target_path = Path(path)
+    temp_path = target_path.with_suffix(target_path.suffix + &quot;.tmp&quot;)
+    with temp_path.open(&quot;w&quot;, encoding=&quot;utf-8&quot;) as file:
+        json.dump(data, file, indent=2)
+        file.write(&quot;\n&quot;)
+    temp_path.replace(target_path)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Safe Save Utility</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Implement <code>save_json_safe(path, data)</code></li>
+  <li>Use <code>with</code></li>
+  <li>Write a <code>.tmp</code> file next to the real file</li>
+  <li>Replace only after success</li>
+  <li>Simulate a failure and compare outcomes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 11)</h1>
+            <p><span class="check">✓</span> File work uses context managers</p>
+<p><span class="check">✓</span> Save logic writes to temp first</p>
+<p><span class="check">✓</span> Replace happens after success</p>
+<p><span class="check">✓</span> Student can explain why the pattern is safer</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 11)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> safe file operation flow that writes and reads tracker data</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> wrap file work in context managers</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> opening files without <code>with</code></li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 11 | file mode: context manager used</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day3_homework.ipynb</code> → <code>## Part 3: Hour 11 - Context managers + safer file operations</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day3_Quiz.html</code> → <code>QUIZ_DATA</code> questions 11–15</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 11)</h1>
+            <p><strong>⚠️</strong> Writing directly to the final file first</p>
+<p><strong>⚠️</strong> Putting temp files in unrelated locations</p>
+<p><strong>⚠️</strong> Forgetting to create the parent directory</p>
+<p><strong>⚠️</strong> Teaching &quot;it probably works&quot; instead of failure simulation</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> What is the main advantage of writing to a temporary file first?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 12: Decorators</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain decorators in plain language</li>
+  <li>Build a wrapper with <code><em>args</code> and <code></em>*kwargs</code></li>
+  <li>Add timing or authorization behavior without rewriting core functions</li>
+  <li>Use <code>functools.wraps</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Decorator Idea</h1>
+            <ul>
+  <li>A decorator takes a function</li>
+  <li>Wraps it</li>
+  <li>Returns a new function</li>
+</ul>
+<h3>Good Course Use Cases</h3>
+<ul>
+  <li>timing</li>
+  <li>logging entry/exit</li>
+  <li>toy auth checks</li>
+  <li>lightweight validation</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Essential Shape</h1>
+            <pre data-lang="python"><code>def my_decorator(func):
+    def wrapper(*args, **kwargs):
+        result = func(*args, **kwargs)
+        return result
+    return wrapper</code></pre>
+<ul>
+  <li>Accept the function</li>
+  <li>Pass through arguments</li>
+  <li>Return the result</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: `@timed`</h1>
+            <pre data-lang="python"><code>import time
+from functools import wraps
+
+
+def timed(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        start = time.perf_counter()
+        result = func(*args, **kwargs)
+        duration = time.perf_counter() - start
+        print(f&quot;{func.__name__} took {duration:.6f} seconds&quot;)
+        return result
+    return wrapper</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Readability Rule</h1>
+            <ul>
+  <li>Decorators should handle repeated edge behavior</li>
+  <li>They should stay small</li>
+  <li>They should not hide the main business story</li>
+</ul>
+<h3>Stop If...</h3>
+<ul>
+  <li>the wrapper is longer than the function it decorates</li>
+  <li>the decorator becomes a black box of business logic</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Decorator Practice</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Build a <code>@timed</code> decorator</li>
+  <li>Attach it to 2 service methods</li>
+  <li>Log the timing result</li>
+  <li>Preserve metadata with <code>@wraps</code></li>
+  <li>Optional: sketch a toy auth or validation decorator</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 12)</h1>
+            <p><span class="check">✓</span> Decorated functions still return the right result</p>
+<p><span class="check">✓</span> Timing or validation behavior is visible</p>
+<p><span class="check">✓</span> <code>@wraps</code> preserves helpful metadata</p>
+<p><span class="check">✓</span> Core function purpose remains clear</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 12)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> decorated service function with reusable wrappers</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> use decorators for cross-cutting concerns</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> stuffing business logic into decorators</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 12 | timing decorator: add_task took 0.002s</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day3_homework.ipynb</code> → <code>## Part 4: Hour 12 - Decorators</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day3_Quiz.html</code> → <code>QUIZ_DATA</code> questions 16–20</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 12)</h1>
+            <p><strong>⚠️</strong> Forgetting to <code>return result</code></p>
+<p><strong>⚠️</strong> Ignoring <code><em>args</code> / <code></em>*kwargs</code> pass-through</p>
+<p><strong>⚠️</strong> Losing function metadata without <code>@wraps</code></p>
+<p><strong>⚠️</strong> Hiding too much logic in the decorator</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> What breaks if the wrapper forgets to return the original function result?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 3 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Added Today</h1>
+            <ul>
+  <li>Package structure under <code>src/</code></li>
+  <li>Real logging habits</li>
+  <li>Safer JSON save patterns</li>
+  <li>Reusable wrappers through decorators</li>
+</ul>
+<h3>Key Rule</h3>
+<p><strong>Operational habits are part of software design, not an afterthought.</strong></p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 3 Homework / Study Checklist</h1>
+            <ul>
+  <li>Run the project from the intended entry point</li>
+  <li>Inspect <code>logs/app.log</code></li>
+  <li>Test a simulated save failure</li>
+  <li>Re-run a decorated service call</li>
+  <li>Match canonical labels where the notebook expects them</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day3_homework.ipynb</code> → <code>## Submission Checklist</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Next Session Preview</h1>
+            <h3>Session 4 (Hours 13–16)</h3>
+<ul>
+  <li>HTTP clients with <code>requests</code></li>
+  <li>Environment-variable and secrets habits</li>
+  <li>Capstone planning workshop</li>
+  <li>Checkpoint 2: persistence-ready core + JSON save/load</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Package it cleanly.</p>
+<p>Log what matters.</p>
+<p>Save data safely.</p>
+<p>Keep the wrappers readable.</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/slides/advanced/day-04/day-04-session-4.html
+++ b/slides/advanced/day-04/day-04-session-4.html
@@ -1,0 +1,1226 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 4 — Session 4 (Hours 13–16)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 4 — Session 4 (Hours 13–16)</h1>
+            <div class="subtitle">Python Programming (Advanced) • HTTP Clients, Security Habits, Capstone Planning, and Checkpoint 2</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 4 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 13: HTTP client work: <code>requests</code> + JSON contracts</li>
+  <li>Hour 14: Security basics — environment variables, safe secrets habits, and hashing concepts</li>
+  <li>Hour 15: Capstone planning workshop — scope, milestones, and delivery path</li>
+  <li>Hour 16: Checkpoint 2 — persistence-ready core + JSON save/load</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → <code>## Session 4 overview</code></li>
+  <li><code>Advanced/lessons/lecture/Day4_Hour1_Advanced.md</code> → <code># Day 4, Hour 1: HTTP Client Work – requests + JSON Contracts</code></li>
+  <li><code>Advanced/lessons/lecture/Day4_Hour2_Advanced.md</code> → <code># Day 4, Hour 2: Security Basics – Environment Variables, Safe Secrets Habits, and Hashing Concepts</code></li>
+  <li><code>Advanced/lessons/lecture/Day4_Hour3_Advanced.md</code> → <code># Day 4, Hour 3: Capstone Planning Workshop – Scope, Milestones, and Delivery Path</code></li>
+  <li><code>Advanced/lessons/lecture/Day4_Hour4_Advanced.md</code> → <code># Day 4, Hour 4: Checkpoint 2 – Persistence-Ready Core + JSON Save/Load</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session 4 Outcomes</h1>
+            <ul>
+  <li>Treat outside data as untrusted until checked</li>
+  <li>Keep secrets out of source control</li>
+  <li>Choose a realistic capstone path</li>
+  <li>Deliver a persistence-ready core that can survive restart</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>In Scope</h1>
+            <ul>
+  <li>HTTP client fundamentals</li>
+  <li>JSON contract validation</li>
+  <li>Environment-variable habits</li>
+  <li>Concept-level hashing discussion</li>
+  <li>Capstone MVP planning</li>
+  <li>JSON persistence checkpoint</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Not Yet</h1>
+            <ul>
+  <li>Production auth systems</li>
+  <li>Full deployment workflows</li>
+  <li>Enterprise schema tooling</li>
+  <li>Database integration beyond persistence-ready design</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 13: HTTP Client Work + JSON Contracts</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Send a <code>GET</code> request with <code>requests</code></li>
+  <li>Always set a timeout</li>
+  <li>Use <code>raise_for_status()</code></li>
+  <li>Validate the JSON shape before trusting it</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Big Shift for This Hour</h1>
+            <ul>
+  <li>Up to now, most data has lived inside our program</li>
+  <li>Today the program talks to something outside itself</li>
+  <li>Outside data may be:</li>
+  <li style="margin-left: 30px;">slow</li>
+  <li style="margin-left: 30px;">missing</li>
+  <li style="margin-left: 30px;">malformed</li>
+  <li style="margin-left: 30px;">structurally different from what we expected</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>HTTP Client Fundamentals</h1>
+            <ul>
+  <li>Client sends request</li>
+  <li>Server sends response</li>
+</ul>
+<h3>High-Level Pieces</h3>
+<ul>
+  <li>method</li>
+  <li>URL</li>
+  <li>optional params/headers/body</li>
+  <li>status code</li>
+  <li>response body</li>
+</ul>
+<h3>Today</h3>
+<ul>
+  <li>mainly <code>GET</code></li>
+  <li>JSON responses</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Reliability Habits</h1>
+            <ul>
+  <li><strong>Always set a timeout</strong></li>
+  <li>Prefer <code>raise_for_status()</code></li>
+  <li>Catch failure categories cleanly:</li>
+  <li style="margin-left: 30px;">timeout</li>
+  <li style="margin-left: 30px;">connection problem</li>
+  <li style="margin-left: 30px;">HTTP error</li>
+  <li style="margin-left: 30px;">invalid JSON</li>
+  <li style="margin-left: 30px;">contract mismatch</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>JSON Is a Contract</h1>
+            <h3>Check the Minimum Shape You Need</h3>
+<ul>
+  <li>payload type</li>
+  <li>required keys</li>
+  <li>expected value types</li>
+</ul>
+<pre data-lang="python"><code>response = requests.get(url, timeout=5)
+response.raise_for_status()
+data = response.json()</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Small Wrapper Function</h1>
+            <pre data-lang="python"><code>def fetch_task(url: str) -&gt; dict:
+    response = requests.get(url, timeout=5)
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict) or &quot;title&quot; not in data:
+        raise ValueError(&quot;Response contract mismatch&quot;)
+    return data</code></pre>
+<ul>
+  <li>Centralize request behavior</li>
+  <li>Avoid copy/paste request logic everywhere</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: API Consumer</h1>
+            <p><strong>Time: 15–25 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Send a <code>GET</code> request to a sample endpoint</li>
+  <li>Use <code>timeout=...</code></li>
+  <li>Call <code>raise_for_status()</code></li>
+  <li>Parse JSON</li>
+  <li>Validate required keys before use</li>
+  <li>Show a friendly failure message for one error case</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 13)</h1>
+            <p><span class="check">✓</span> Request uses a timeout</p>
+<p><span class="check">✓</span> Happy path parses JSON safely</p>
+<p><span class="check">✓</span> Failure handling is intentional</p>
+<p><span class="check">✓</span> Contract validation happens before downstream use</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 13)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> client call that reads JSON safely and prints labeled checks</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> check status codes and JSON keys</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> assuming every response has the shape you want</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 13 | request url: https://api.example.test/tasks</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day4_homework.ipynb</code> → <code>## Part 1: Hour 13 - HTTP client work</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day4_Quiz.html</code> → <code>QUIZ_DATA</code> questions 1–5</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 13)</h1>
+            <p><strong>⚠️</strong> No timeout</p>
+<p><strong>⚠️</strong> Parsing JSON before checking status</p>
+<p><strong>⚠️</strong> Trusting missing keys blindly</p>
+<p><strong>⚠️</strong> Returning raw error noise to end users</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Why is &quot;the service returned valid JSON&quot; not the same as &quot;the response matches our contract&quot;?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 14: Security Basics</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain why secrets should not live in source files</li>
+  <li>Load sensitive values from environment variables</li>
+  <li>Distinguish hashing from encryption conceptually</li>
+  <li>Keep this hour in appropriate scope</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Security Mindset Reset</h1>
+            <ul>
+  <li>We are teaching <strong>habits</strong>, not full security engineering</li>
+  <li>Good boundaries matter</li>
+</ul>
+<h3>Not This Hour</h3>
+<ul>
+  <li>OAuth</li>
+  <li>JWT flows</li>
+  <li>production identity systems</li>
+</ul>
+<h3>This Hour</h3>
+<ul>
+  <li>secret hygiene</li>
+  <li>env vars</li>
+  <li><code>.env.example</code></li>
+  <li>hashing concept demo</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hard-Coded Secrets Are a Trap</h1>
+            <pre data-lang="python"><code>ADMIN_KEY = &quot;super-secret-real-key&quot;</code></pre>
+<h3>Problems</h3>
+<ol>
+  <li>Secrets end up in version control</li>
+  <li>Rotation becomes painful</li>
+  <li>Unsafe sharing habits spread</li>
+  <li>Commit history keeps the mistake around</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Environment Variable Pattern</h1>
+            <pre data-lang="python"><code>import os
+
+
+def get_required_env(name: str) -&gt; str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f&quot;Missing required environment variable: {name}&quot;)
+    return value</code></pre>
+<ul>
+  <li>Code names what it needs</li>
+  <li>Environment supplies the real value</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>`.env.example` vs `.env`</h1>
+            <pre data-lang="env"><code>APP_API_KEY=your-api-key-here
+APP_ADMIN_KEY=replace-with-local-admin-key
+APP_ENV=development</code></pre>
+<ul>
+  <li><code>.env.example</code> may be committed</li>
+  <li><code>.env</code> should usually be ignored</li>
+  <li>placeholders only — never real secrets</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hashing vs Encryption</h1>
+            <ul>
+  <li><strong>Encryption</strong> is meant to be reversible with the right key</li>
+  <li><strong>Hashing</strong> is meant to be one-way</li>
+</ul>
+<h3>Classroom-Safe Demo Idea</h3>
+<ul>
+  <li>compute a digest</li>
+  <li>compare digests</li>
+  <li>do <strong>not</strong> claim this solves production auth</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Gated Admin Action</h1>
+            <pre data-lang="python"><code>import hashlib
+import secrets
+
+
+def sha256_digest(value: str) -&gt; str:
+    return hashlib.sha256(value.encode(&quot;utf-8&quot;)).hexdigest()
+
+
+authorized = secrets.compare_digest(
+    sha256_digest(expected_key),
+    sha256_digest(provided_key),
+)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Secure-ish Configuration</h1>
+            <p><strong>Time: 18–25 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Read one required value from the environment</li>
+  <li>Add a <code>.env.example</code> template plan</li>
+  <li>Add <code>.gitignore</code> guidance for local secret files</li>
+  <li>Gate one admin action using configuration, not a hard-coded literal</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 14)</h1>
+            <p><span class="check">✓</span> Secret value is not hard-coded in the source</p>
+<p><span class="check">✓</span> Missing env var fails clearly</p>
+<p><span class="check">✓</span> Learner can explain hashing vs encryption at a high level</p>
+<p><span class="check">✓</span> Scope stays disciplined and honest</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 14)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> secure config pattern that separates secrets from code</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> read secrets from env vars, store only hashes when appropriate</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> checking secrets into source control</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 14 | secret source: environment variable</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day4_homework.ipynb</code> → <code>## Part 2: Hour 14 - Security basics</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day4_Quiz.html</code> → <code>QUIZ_DATA</code> questions 6–10</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 14)</h1>
+            <p><strong>⚠️</strong> Real secrets in demo files</p>
+<p><strong>⚠️</strong> Committing <code>.env</code></p>
+<p><strong>⚠️</strong> Treating hashing and encryption as synonyms</p>
+<p><strong>⚠️</strong> Promising production-grade security from a classroom-safe example</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Why is a <code>.env.example</code> helpful even though it contains no real secret values?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 15: Capstone Planning Workshop</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Lock an MVP scope</li>
+  <li>Choose a delivery path</li>
+  <li>Break the project into milestones</li>
+  <li>Define &quot;done&quot; before the build gets bigger</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>What This Workshop Is Really For</h1>
+            <ul>
+  <li>Replace vague enthusiasm with a delivery plan</li>
+  <li>Protect the project from scope drift</li>
+  <li>Decide what proves value earliest</li>
+</ul>
+<h3>Strong Planning Questions</h3>
+<ul>
+  <li>Who is the user?</li>
+  <li>What is the primary workflow?</li>
+  <li>What is the smallest useful version?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Recommended Milestone Path</h1>
+            <ol>
+  <li>Core</li>
+  <li>Persistence</li>
+  <li>UI</li>
+  <li>Analytics</li>
+  <li>Tests</li>
+  <li>Package</li>
+</ol>
+<ul>
+  <li>Do not jump to a flashy shell around unstable logic</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Definition of Done Examples</h1>
+            <h3>Core</h3>
+<ul>
+  <li>service logic works in isolation</li>
+</ul>
+<h3>Persistence</h3>
+<ul>
+  <li>data survives restart</li>
+</ul>
+<h3>UI</h3>
+<ul>
+  <li>primary workflow works through the chosen surface</li>
+</ul>
+<h3>Tests</h3>
+<ul>
+  <li>major business rules and failure paths have repeatable checks</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Delivery Path Decision</h1>
+            <h3>GUI-First</h3>
+<ul>
+  <li>tangible demo quickly</li>
+  <li>risk: logic hides in callbacks</li>
+</ul>
+<h3>API-First</h3>
+<ul>
+  <li>clearer service boundaries</li>
+  <li>risk: less visually exciting at first</li>
+</ul>
+<h3>Non-Negotiable</h3>
+<ul>
+  <li>core logic still lives in reusable services</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Artifact Shape</h1>
+            <pre data-lang="text"><code>capstone_project/
+├── README.md
+├── src/
+├── tests/
+└── data/</code></pre>
+<h3>README Needs</h3>
+<ul>
+  <li>project goal</li>
+  <li>MVP features</li>
+  <li>setup steps</li>
+  <li>run steps</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Workshop: One-Page Capstone Plan</h1>
+            <p><strong>Time: 20 minutes</strong></p>
+<h3>Include</h3>
+<ul>
+  <li>chosen domain</li>
+  <li>primary user workflow</li>
+  <li>GUI-first or API-first decision</li>
+  <li>milestone list</li>
+  <li>persistence plan</li>
+  <li>key risks</li>
+  <li>test targets</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 15)</h1>
+            <p><span class="check">✓</span> Scope is realistic</p>
+<p><span class="check">✓</span> Delivery path is chosen and justified</p>
+<p><span class="check">✓</span> Milestones are sequenced clearly</p>
+<p><span class="check">✓</span> README skeleton or plan notes exist</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 15)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> milestone plan with one domain, one interface, and staged deliverables</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> keep scope narrow enough to finish</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> trying to build every optional feature before core CRUD is stable</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 15 | chosen domain: tracker</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day4_homework.ipynb</code> → <code>## Part 3: Hour 15 - Capstone planning workshop</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day4_Quiz.html</code> → <code>QUIZ_DATA</code> questions 11–15</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 15)</h1>
+            <p><strong>⚠️</strong> Wish-list scope instead of MVP scope</p>
+<p><strong>⚠️</strong> README postponed until the final hour</p>
+<p><strong>⚠️</strong> UI selected before the core is stable</p>
+<p><strong>⚠️</strong> No persistence or test plan in the roadmap</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> Which milestone do students most often try to jump to too early, and why is that risky?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 16: Checkpoint 2 — Persistence-Ready Core</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Separate domain, service, and persistence responsibilities</li>
+  <li>Save JSON using a safe-save pattern</li>
+  <li>Load saved state back into application objects</li>
+  <li>Handle missing files, invalid JSON, and validation failures cleanly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>What Checkpoint 2 Proves</h1>
+            <ul>
+  <li>The core survives beyond one run</li>
+  <li>The package layout under <code>src/</code> is intentional</li>
+  <li>State can be saved and restored</li>
+  <li>Logging captures meaningful persistence events</li>
+  <li>Custom exceptions still communicate domain and persistence issues</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Sample Persistence-Ready Layout</h1>
+            <pre data-lang="text"><code>project_root/
+├── demo_persistence.py
+├── logs/app.log
+├── data/state.json
+└── src/reading_tracker/
+    ├── errors.py
+    ├── logging_config.py
+    ├── models.py
+    ├── persistence.py
+    └── services.py</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Separation of Concerns</h1>
+            <ul>
+  <li><strong>models.py</strong> → structured domain data</li>
+  <li><strong>services.py</strong> → business rules</li>
+  <li><strong>persistence.py</strong> → JSON save/load</li>
+  <li><strong>errors.py</strong> → custom exceptions</li>
+  <li><strong>logging_config.py</strong> → file logging setup</li>
+</ul>
+<h3>Why It Matters</h3>
+<ul>
+  <li>JSON today</li>
+  <li>database later</li>
+  <li>less rewiring when storage changes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Safe Save + Load Shape</h1>
+            <pre data-lang="python"><code>class PersistenceError(Exception):
+    pass
+
+
+class JSONStateStore:
+    def save(self, state):
+        ...
+
+    def load(self):
+        ...</code></pre>
+<ul>
+  <li>save started</li>
+  <li>save succeeded</li>
+  <li>load started</li>
+  <li>file missing handled</li>
+  <li>invalid JSON handled</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Workflow</h1>
+            <h3>Save → Restart → Load</h3>
+<ol>
+  <li>Create a few records</li>
+  <li>Save to JSON safely</li>
+  <li>Recreate the service/store</li>
+  <li>Load state back in</li>
+  <li>Confirm records still exist</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Hands-On Checkpoint Build</h1>
+            <p><strong>Time: 15–25 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Organize or confirm package layout</li>
+  <li>Add a persistence layer</li>
+  <li>Implement safe save behavior</li>
+  <li>Load JSON back into objects</li>
+  <li>Log the key events</li>
+  <li>Demonstrate one failure case and one happy path</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Completion Criteria (Hour 16)</h1>
+            <p><span class="check">✓</span> Core state round-trips through JSON</p>
+<p><span class="check">✓</span> Save path is safer than direct overwrite</p>
+<p><span class="check">✓</span> Load handles missing/bad files intentionally</p>
+<p><span class="check">✓</span> The project is visibly more persistence-ready than it was yesterday</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 16)</h1>
+            <ul>
+  <li>Homework framing:</li>
+  <li style="margin-left: 30px;"><strong>Goal:</strong> core app that can add records and round-trip them through JSON</li>
+  <li style="margin-left: 30px;"><strong>Best practice:</strong> checkpoint save/load before expanding the interface</li>
+  <li style="margin-left: 30px;"><strong>Pitfall:</strong> delaying persistence checks until after major UI work</li>
+  <li>Quiz/canonical contract marker:</li>
+  <li style="margin-left: 30px;"><code>Hour 16 | checkpoint model: Task</code></li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day4_homework.ipynb</code> → <code>## Part 4: Hour 16 - Checkpoint 2</code></li>
+  <li><code>Advanced/quizzes/Advanced_Day4_Quiz.html</code> → <code>QUIZ_DATA</code> questions 16–20</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 16)</h1>
+            <p><strong>⚠️</strong> Dumping JSON logic everywhere instead of using a persistence layer</p>
+<p><strong>⚠️</strong> Direct overwrite with no safety net</p>
+<p><strong>⚠️</strong> Treating file absence as a crash-only situation</p>
+<p><strong>⚠️</strong> Adding more features before proving save/load works</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question:</strong> If the app works beautifully in memory but loses state after restart, what milestone is still incomplete?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 4 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Locked In Today</h1>
+            <ul>
+  <li>Reliable HTTP client habits</li>
+  <li>Safer secret/config practices</li>
+  <li>A concrete capstone roadmap</li>
+  <li>Persistence-ready core architecture</li>
+</ul>
+<h3>Key Rule</h3>
+<p><strong>Trustworthy software plans for failure, scope, and restart behavior.</strong></p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 4 Homework / Study Checklist</h1>
+            <ul>
+  <li>Re-run the HTTP wrapper with a failure case in mind</li>
+  <li>Remove any hard-coded secret from demo code</li>
+  <li>Finalize the one-page capstone plan</li>
+  <li>Test save -&gt; load round-trip behavior</li>
+  <li>Match the canonical output labels expected by the notebook</li>
+</ul>
+<h3>Source Alignment</h3>
+<ul>
+  <li><code>Advanced/assignments/Advanced_Day4_homework.ipynb</code> → <code>## Submission Checklist</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Next Step Framing</h1>
+            <h3>After Session 4</h3>
+<ul>
+  <li>keep the core stable</li>
+  <li>preserve scope discipline</li>
+  <li>carry forward logging and safe-save habits</li>
+  <li>use the capstone plan as the default decision filter</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Validate outside data.</p>
+<p>Keep secrets out of source.</p>
+<p>Plan the MVP.</p>
+<p>Prove persistence before expanding.</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/slides/advanced/day-05/day-05-session-5.html
+++ b/slides/advanced/day-05/day-05-session-5.html
@@ -1,0 +1,1073 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 5 — Session 5 (Hours 17–20)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 5 — Session 5 (Hours 17–20)</h1>
+            <div class="subtitle">Python Programming (Advanced) • GUI Foundations for the Tracker Capstone</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 5 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 17: GUI fundamentals with Tkinter / <code>ttk</code></li>
+  <li>Hour 18: Layout, spacing, and resizing</li>
+  <li>Hour 19: Forms, validation, and user feedback</li>
+  <li>Hour 20: Record lists, selection, and refresh</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Today&#x27;s Capstone Milestone</h1>
+            <ul>
+  <li>Move from CLI-style flow to event-driven desktop workflow</li>
+  <li>Keep the <strong>service layer</strong> as the home for business rules</li>
+  <li>Start building a tracker UI that can grow into CRUD workflows</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 5 overview (Hours 17–20); Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Section 1: Recap and Transition --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis</h1>
+            <ul>
+  <li>Build one working GUI action first</li>
+  <li>Use <code>grid()</code> intentionally for readable forms</li>
+  <li>Show validation feedback without crashes</li>
+  <li>Bind record selection to a <strong>stable ID</strong>, not display order</li>
+</ul>
+<h3>Canonical quiz/contracts to recognize</h3>
+<ul>
+  <li><code>Hour 17 | root window: tracker app</code></li>
+  <li><code>Hour 18 | layout manager: grid</code></li>
+  <li><code>Hour 19 | field read: title entry</code></li>
+  <li><code>Hour 20 | list widget: treeview</code></li>
+</ul>
+<p>&lt;!-- Sources: Advanced/assignments/Advanced_Day5_homework.ipynb — Part 1 through Part 4; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 17 through Hour 20 canonical contract questions --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 17: GUI Fundamentals</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain why GUI programs are <strong>event-driven</strong></li>
+  <li>Create a small window with labels, entries, and buttons</li>
+  <li>Wire a button to a callback</li>
+  <li>Route validation through the service layer</li>
+  <li>Show visible success/error feedback</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 17: GUI fundamentals (Tkinter/ttk): event loop, widgets, callbacks; Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>The Mental Model Shift</h1>
+            <h3>CLI mindset</h3>
+<ol>
+  <li>Start</li>
+  <li>Read input</li>
+  <li>Do work</li>
+  <li>Print output</li>
+  <li>Exit</li>
+</ol>
+<h3>GUI mindset</h3>
+<ul>
+  <li>Open a window</li>
+  <li>Wait for events</li>
+  <li>React through callbacks</li>
+  <li>Stay responsive until the user closes the app</li>
+</ul>
+<p><strong>Key phrase</strong>: The GUI handles interaction; the service layer handles rules.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Section 1: Recap and Transition; Section 2: The GUI Mental Model --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Core Building Blocks</h1>
+            <ul>
+  <li><code>mainloop()</code> keeps the app alive and listening</li>
+  <li><code>Label</code> shows text</li>
+  <li><code>Entry</code> captures user input</li>
+  <li><code>Button</code> triggers a callback</li>
+  <li><code>messagebox</code> gives simple popup feedback</li>
+  <li><code>StringVar</code> helps connect UI state to Python values</li>
+</ul>
+<h3>Keep callbacks short</h3>
+<ul>
+  <li>Read form values</li>
+  <li>Call the service</li>
+  <li>Update the interface</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour1_Advanced.md — What mainloop() Does; Widgets and Callbacks; Demo Teaching Points to Repeat --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Thin Callback Pattern</h1>
+            <pre data-lang="python"><code>def on_add(self) -&gt; None:
+    try:
+        record = self.service.add_record(
+            self.name_var.get(),
+            self.email_var.get(),
+        )
+    except ValidationError as exc:
+        self.status_var.set(f&quot;Error: {exc}&quot;)
+        return
+
+    self.status_var.set(f&quot;Added {record.name}&quot;)</code></pre>
+<h3>Why this pattern works</h3>
+<ul>
+  <li>UI gathers input</li>
+  <li>Service validates and stores</li>
+  <li>UI presents the outcome</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Section 3: Core Design Pattern for This Hour; Demo Code --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Hello GUI + Add Form</h1>
+            <h3>Instructor flow</h3>
+<ol>
+  <li>Create the service class first</li>
+  <li>Build a small <code>ContactApp</code> / tracker app class</li>
+  <li>Add two fields and an <strong>Add</strong> button</li>
+  <li>Wire <code>command=self.on_add</code></li>
+  <li>Show one bad submission and one good submission</li>
+  <li>Point directly to <code>root.mainloop()</code></li>
+</ol>
+<h3>Watch for</h3>
+<ul>
+  <li>Where the widgets live</li>
+  <li>Where the callback lives</li>
+  <li>Where the validation rule lives</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Live demo (Hour 17); Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Demo Steps --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: First Working GUI Action</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create a Tkinter window for your tracker domain</li>
+  <li>Add at least two inputs</li>
+  <li>Add one working action button</li>
+  <li>Show status or messagebox feedback</li>
+  <li>Keep business rules outside the widget-building code</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> GUI launches reliably</p>
+<p><span class="check">✓</span> One callback works end to end</p>
+<p><span class="check">✓</span> Validation comes from a service/helper</p>
+<p><span class="check">✓</span> User sees success or error clearly</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Hello GUI + Add form; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 1: Hour 17 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 17)</h1>
+            <p><strong>⚠️</strong> Forgetting <code>mainloop()</code></p>
+<p><strong>⚠️</strong> Writing <code>command=self.on_add()</code> instead of <code>command=self.on_add</code></p>
+<p><strong>⚠️</strong> Burying business rules directly in callbacks</p>
+<p><strong>⚠️</strong> Clicking a button and giving the user no visible feedback</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What does <code>mainloop()</code> do, and why should callbacks stay small?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 17 best practice and pitfall --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 18: Layout and Usability</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Use <code>grid()</code> for form-style layouts</li>
+  <li>Group related controls with frames</li>
+  <li>Add consistent spacing and alignment</li>
+  <li>Configure the layout to resize sensibly</li>
+  <li>Avoid mixing geometry managers in the same parent</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 18: Layout and usability; Advanced/lessons/lecture/Day5_Hour2_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>`pack()` vs `grid()`</h1>
+            <h3>Use `pack()` when</h3>
+<ul>
+  <li>You want simple stacking</li>
+</ul>
+<h3>Use `grid()` when</h3>
+<ul>
+  <li>You need rows + columns</li>
+  <li>You are building a form</li>
+  <li>Labels and inputs should line up cleanly</li>
+</ul>
+<blockquote>Do not mix `pack()` and `grid()` in the same parent widget.</blockquote>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour2_Advanced.md — <code>pack()</code> and <code>grid()</code>; The Rule About Mixing Geometry Managers --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Layout Rules That Matter</h1>
+            <ul>
+  <li>Use frames as layout boundaries</li>
+  <li>Add consistent <code>padx</code> / <code>pady</code></li>
+  <li>Use <code>sticky=&quot;w&quot;</code> or <code>sticky=&quot;ew&quot;</code> intentionally</li>
+  <li>Give growing columns a weight</li>
+</ul>
+<pre data-lang="python"><code>main_frame.columnconfigure(1, weight=1)
+ttk.Entry(form_frame).grid(row=0, column=1, sticky=&quot;ew&quot;)</code></pre>
+<h3>Usability checklist</h3>
+<ol>
+  <li>Are related items grouped?</li>
+  <li>Is spacing consistent?</li>
+  <li>Is the main action easy to find?</li>
+  <li>Does resize behavior make sense?</li>
+</ol>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour2_Advanced.md — Usability Principles for Basic Desktop GUIs; Column Weights and Resizing --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Refactor a Messy Layout</h1>
+            <h3>Demo target</h3>
+<ul>
+  <li>One main frame</li>
+  <li>Two visual regions</li>
+  <li style="margin-left: 30px;">Form area</li>
+  <li style="margin-left: 30px;">Preview/list area</li>
+  <li><code>grid()</code> for the form</li>
+  <li>Safe nested <code>pack()</code> only inside a different parent such as a button bar</li>
+</ul>
+<h3>Success signal</h3>
+<ul>
+  <li>The app looks intentional</li>
+  <li>Resize behavior is acceptable</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Live demo (Hour 18); Advanced/lessons/lecture/Day5_Hour2_Advanced.md — Live Demo — Refactoring a Messy Layout --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Improve Layout and Resizing</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Rebuild the GUI using at least one frame</li>
+  <li>Convert the form area to <code>grid()</code></li>
+  <li>Add consistent spacing</li>
+  <li>Test the window at more than one size</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> UI is readable and aligned</p>
+<p><span class="check">✓</span> Resizing does not break the layout</p>
+<p><span class="check">✓</span> One layout strategy per container</p>
+<p><span class="check">✓</span> Main action stays obvious</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Improve layout; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 2: Hour 18 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 18)</h1>
+            <p><strong>⚠️</strong> Mixing <code>pack</code> and <code>grid</code> in the same container</p>
+<p><strong>⚠️</strong> Forgetting <code>sticky</code>, so fields do not align or stretch</p>
+<p><strong>⚠️</strong> Inconsistent padding</p>
+<p><strong>⚠️</strong> Never testing resize behavior</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is <code>grid()</code> usually a better fit for forms?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 18 canonical contract and pitfall --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 19: Forms, Validation, and Feedback</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Validate before saving</li>
+  <li>Normalize input before checking rules</li>
+  <li>Show friendly, actionable feedback</li>
+  <li>Keep predictable validation out of crash paths</li>
+  <li>Separate service validation from UI presentation</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 19: Forms + validation feedback patterns; Advanced/lessons/lecture/Day5_Hour3_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Good Validation Helps the User Succeed</h1>
+            <h3>Weak message</h3>
+<p><code>Invalid input</code></p>
+<h3>Better message</h3>
+<p><code>Email is required</code></p>
+<h3>Best message</h3>
+<p><code>Enter an email address such as name@example.com</code></p>
+<h3>Normalize first</h3>
+<ul>
+  <li><code>strip()</code> whitespace</li>
+  <li>lowercase email-like fields</li>
+  <li>clean obvious formatting noise before validation</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour3_Advanced.md — Validation Should Be Helpful, Not Punitive; Normalize Before You Validate --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Service vs UI Responsibilities</h1>
+            <h3>Service layer</h3>
+<ul>
+  <li>Decides whether data is valid</li>
+  <li>Returns structured errors or raises the right exception</li>
+</ul>
+<h3>UI layer</h3>
+<ul>
+  <li>Places messages near the right field</li>
+  <li>Moves focus to the first invalid control</li>
+  <li>Clears old errors</li>
+  <li>Resets the form after success</li>
+</ul>
+<pre data-lang="python"><code>errors = {
+    &quot;name&quot;: &quot;Name is required.&quot;,
+    &quot;email&quot;: &quot;Enter an email address such as name@example.com.&quot;,
+}</code></pre>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour3_Advanced.md — Service Errors vs UI Errors; A Clean Validation Pattern --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Validated Tracker Form</h1>
+            <h3>Demo highlights</h3>
+<ul>
+  <li>Inline field-level errors</li>
+  <li>Summary status message</li>
+  <li>Disabled/re-enabled Save button during submit</li>
+  <li>Focus moved to the first invalid field</li>
+  <li>App stays stable after bad input</li>
+</ul>
+<h3>Instructor prompt</h3>
+<p>Ask learners to identify:</p>
+<ol>
+  <li>Where <code>.strip()</code> happens</li>
+  <li>Where errors are structured</li>
+  <li>Why inline feedback often beats a popup</li>
+</ol>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Live demo (Hour 19); Advanced/lessons/lecture/Day5_Hour3_Advanced.md — Live Demo — Inline Validation and Actionable Feedback --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Validation Feedback Without Crashing</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add required-field checks</li>
+  <li>Normalize user input</li>
+  <li>Display at least one inline error</li>
+  <li>Add a summary status message</li>
+  <li>Keep the app available for immediate correction</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> Missing data is rejected clearly</p>
+<p><span class="check">✓</span> Errors are actionable</p>
+<p><span class="check">✓</span> No raw traceback shown to the user</p>
+<p><span class="check">✓</span> Valid entries save successfully</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Add validation UI; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 3: Hour 19 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 19)</h1>
+            <p><strong>⚠️</strong> Silent failure after bad input</p>
+<p><strong>⚠️</strong> Vague messages with no next step</p>
+<p><strong>⚠️</strong> Treating predictable validation as a crash-worthy exception</p>
+<p><strong>⚠️</strong> Forgetting to clear old errors before the next save</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is “Enter an email address such as name@example.com” better than “Invalid email”?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 19 best practice and pitfall --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 20: Record Lists and Selection</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Show multiple records in a list or table</li>
+  <li>Use <code>Treeview</code> or <code>Listbox</code> appropriately</li>
+  <li>Refresh safely without duplicate stale rows</li>
+  <li>React to selection events</li>
+  <li>Map selection to a stable record ID</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 20: Record list UI; Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>`Listbox` vs `Treeview`</h1>
+            <h3>`Listbox`</h3>
+<ul>
+  <li>Lightweight</li>
+  <li>Good for one visible string per row</li>
+</ul>
+<h3>`Treeview`</h3>
+<ul>
+  <li>Better for multi-column records</li>
+  <li>Good fit for tracker-style data</li>
+  <li>Easier to grow into sorting and richer browsing</li>
+</ul>
+<h3>Selection rule</h3>
+<p>Selection should lead to a <strong>record ID</strong>, not just a row position.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Choosing the Right List Widget; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 4: Hour 20 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Safe Refresh Pattern</h1>
+            <ol>
+  <li>Clear existing rows</li>
+  <li>Fetch current records</li>
+  <li>Insert fresh rows</li>
+  <li>Reset or refresh the details pane</li>
+</ol>
+<pre data-lang="python"><code>self.tree.delete(*self.tree.get_children())
+for record in records:
+    self.tree.insert(&quot;&quot;, &quot;end&quot;, iid=str(record.record_id), values=(...))</code></pre>
+<h3>Why this matters</h3>
+<ul>
+  <li>No duplicated rows</li>
+  <li>No stale details</li>
+  <li>No “selection points at the wrong thing” bug</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Refreshing Safely; Demo Code --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: List + Details Browser</h1>
+            <h3>Demo flow</h3>
+<ul>
+  <li>Add a <code>Treeview</code></li>
+  <li>Bind <code>&lt;&lt;TreeviewSelect&gt;&gt;</code></li>
+  <li>Show details for the selected record</li>
+  <li>Add a Refresh button</li>
+  <li>Handle empty-state cases safely</li>
+</ul>
+<h3>Empty-state behavior</h3>
+<ul>
+  <li>Empty list is still a valid state</li>
+  <li>No selection should clear or reset details</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: Treeview showing records; Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Live Demo — Treeview with Selection and Details Pane --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Record Browser</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add a list area for saved records</li>
+  <li>Add a details pane</li>
+  <li>Bind selection to a callback</li>
+  <li>Add Refresh</li>
+  <li>Show safe behavior when there are no records</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> List populates and updates</p>
+<p><span class="check">✓</span> Details follow the selected record</p>
+<p><span class="check">✓</span> No crash on empty selection</p>
+<p><span class="check">✓</span> Refresh clears stale rows first</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: List + details; Advanced/assignments/Advanced_Day5_homework.ipynb — Part 4: Hour 20 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 20)</h1>
+            <p><strong>⚠️</strong> Using display order as identity</p>
+<p><strong>⚠️</strong> Not clearing old rows before refresh</p>
+<p><strong>⚠️</strong> Crashing when no selection exists</p>
+<p><strong>⚠️</strong> Leaving stale details visible after the list changes</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What should happen if the user clicks Refresh when there are zero records?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 20 best practice and pitfall --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 5 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Built Toward</h1>
+            <ul>
+  <li>Event-driven thinking instead of CLI-only flow</li>
+  <li>A cleaner form layout with <code>grid()</code> and frames</li>
+  <li>Validation that helps users recover</li>
+  <li>A record browser that is safe to refresh and select</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Capstone checkpoint coming next</h1>
+            <ul>
+  <li>Update + delete workflows</li>
+  <li>Cleaner controller architecture</li>
+  <li>JSON persistence + polish</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 5 overview; Advanced/lessons/lecture/Day5_Hour4_Advanced.md — Wrap-Up --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails</h1>
+            <h3>Stay in scope today</h3>
+<p><span class="check">✓</span> Tkinter / <code>ttk</code> fundamentals</p>
+<p><span class="check">✓</span> Small, maintainable callbacks</p>
+<p><span class="check">✓</span> Service-layer validation</p>
+<p><span class="check">✓</span> Stable IDs for selection</p>
+<h3>Not today&#x27;s goal</h3>
+<p><span class="cross">✗</span> Fancy theming</p>
+<p><span class="cross">✗</span> Framework switching</p>
+<p><span class="cross">✗</span> ORM/database work</p>
+<p><span class="cross">✗</span> Big “all-features-at-once” refactors</p>
+<h3>Homework / quiz prep</h3>
+<ul>
+  <li>Be able to explain <strong>why</strong> <code>mainloop()</code> matters</li>
+  <li>Be able to justify <code>grid()</code> for forms</li>
+  <li>Be able to show a friendly validation path</li>
+  <li>Be able to explain why stable IDs beat list positions</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day5_Hour1_Advanced.md — Wrap-Up; Advanced/quizzes/Advanced_Day5_Quiz.html — Hour 17 through Hour 20 explanations --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Session 6 next:</p>
+<ul>
+  <li>Update + delete through the GUI</li>
+  <li>Controller cleanup</li>
+  <li>JSON persistence and checkpoint demo</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 6 overview (Hours 21–24) --&gt;</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/slides/advanced/day-06/day-06-session-6.html
+++ b/slides/advanced/day-06/day-06-session-6.html
@@ -1,0 +1,1006 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 6 — Session 6 (Hours 21–24)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 6 — Session 6 (Hours 21–24)</h1>
+            <div class="subtitle">Python Programming (Advanced) • GUI CRUD Wiring, Architecture, and Milestone Readiness</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 6 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 21: Update and delete workflows in the GUI</li>
+  <li>Hour 22: Controller separation and callback cleanup</li>
+  <li>Hour 23: JSON persistence and GUI polish</li>
+  <li>Hour 24: Checkpoint 3 GUI milestone demo</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day goal</h1>
+            <ul>
+  <li>Turn a promising interface into a trustworthy mini-application</li>
+  <li>Keep stable IDs as the bridge between UI state and domain operations</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 6 overview (Hours 21–24); Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Session context --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis</h1>
+            <ul>
+  <li>Round-trip update/delete through the current source of truth</li>
+  <li>Refactor into a controller-style app structure</li>
+  <li>Add JSON load/save before the GUI checkpoint</li>
+  <li>Practice the demo path, not just isolated screenshots</li>
+</ul>
+<h3>Canonical quiz/contracts to recognize</h3>
+<ul>
+  <li><code>Hour 21 | selected id: task-002</code></li>
+  <li><code>Hour 22 | ui class: TrackerApp</code></li>
+  <li><code>Hour 23 | persistence hook: save on demand</code></li>
+  <li><code>Hour 24 | demo start: app opens cleanly</code></li>
+</ul>
+<p>&lt;!-- Sources: Advanced/assignments/Advanced_Day6_homework.ipynb — Part 1 through Part 4; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 21 through Hour 24 canonical contract questions --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 21: Update and Delete Workflows</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Use <strong>select → load → edit → save update</strong></li>
+  <li>Delete with confirmation</li>
+  <li>Refresh after each change</li>
+  <li>Handle missing-record cases cleanly</li>
+  <li>Target records by <strong>stable ID</strong>, not list index</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 21: CRUD wiring in GUI: update and delete workflows; Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Learning objectives --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Why Update/Delete Are Harder Than Add</h1>
+            <h3>Create</h3>
+<ul>
+  <li>Read form</li>
+  <li>Validate</li>
+  <li>Save new record</li>
+  <li>Refresh</li>
+</ul>
+<h3>Update/Delete</h3>
+<ul>
+  <li>Identify the correct record</li>
+  <li>Keep selection state accurate</li>
+  <li>Avoid stale widgets after refresh</li>
+  <li>Recover if the record is already gone</li>
+</ul>
+<blockquote>Display order is not identity. Stable IDs are.</blockquote>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Why add is easy and update/delete are trickier; Stable IDs: the core design choice --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Standard Update Flow</h1>
+            <ol>
+  <li>User selects a record</li>
+  <li>UI loads that record into the form</li>
+  <li>User edits fields</li>
+  <li>UI sends <code>selected_id</code> + form values to the service</li>
+  <li>Service updates the correct record</li>
+  <li>UI refreshes the list and resets state intentionally</li>
+</ol>
+<pre data-lang="python"><code>service.update_item(selected_id, name, category, status, notes)</code></pre>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Editing pattern: select -&gt; load into form -&gt; save update; Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Implement the standard GUI update flow --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Delete Flow and Confirmation</h1>
+            <h3>Delete path</h3>
+<ul>
+  <li>Detect a valid selection</li>
+  <li>Ask for confirmation</li>
+  <li>Delete by ID</li>
+  <li>Refresh the list</li>
+  <li>Clear stale form values and selection</li>
+</ul>
+<h3>User-facing rule</h3>
+<ul>
+  <li>Destructive actions should be explicit</li>
+  <li>“No selection” is a normal state to handle</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Confirm delete with messagebox; Delete workflow, step by step; Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Graceful error handling with <code>messagebox</code> --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Wiring Update + Delete</h1>
+            <h3>Instructor flow</h3>
+<ol>
+  <li>Select a record in <code>Treeview</code></li>
+  <li>Load values into the form</li>
+  <li>Update one field</li>
+  <li>Refresh and prove the correct record changed</li>
+  <li>Delete another record with confirmation</li>
+  <li>Show <code>NotFoundError</code> or missing-record handling gracefully</li>
+</ol>
+<h3>Watch for</h3>
+<ul>
+  <li>Which value is the true ID</li>
+  <li>What refresh does after each operation</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: update flow and delete confirmation; Show handling NotFoundError gracefully; Advanced/lessons/lecture/Day6_Hour1_Advanced.md — Live demo guidance --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: GUI Update/Delete Round Trip</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Implement Update using the selected record</li>
+  <li>Implement Delete with confirmation</li>
+  <li>Refresh the list after each change</li>
+  <li>Clear or reset stale form state</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> Update works reliably</p>
+<p><span class="check">✓</span> Delete works reliably</p>
+<p><span class="check">✓</span> UI stays in sync after each change</p>
+<p><span class="check">✓</span> Selection maps to a stable ID</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Update/Delete; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 1: Hour 21 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 21)</h1>
+            <p><strong>⚠️</strong> Mutating stale widget state without reloading</p>
+<p><strong>⚠️</strong> Using list index as the real ID</p>
+<p><strong>⚠️</strong> Deleting while the UI still points at stale selection</p>
+<p><strong>⚠️</strong> Forgetting to refresh after update/delete</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is a stable ID better than relying on a visual row index?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 21 best practice and pitfall --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 22: GUI Architecture and Controller Separation</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Recognize callback spaghetti</li>
+  <li>Refactor toward an <code>App</code> / controller class</li>
+  <li>Keep callbacks thin</li>
+  <li>Separate widget creation from service logic</li>
+  <li>Manage selection and status state clearly</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 22: GUI architecture; Advanced/lessons/lecture/Day6_Hour2_Advanced.md — Learning objectives --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>What Callback Spaghetti Looks Like</h1>
+            <ul>
+  <li>Top-level functions with unclear ownership</li>
+  <li>Globals for widgets and selection state</li>
+  <li>Duplicate form-reading code</li>
+  <li>Duplicate refresh code</li>
+  <li>Business rules embedded directly in callbacks</li>
+  <li>Fragile bugs when state changes in one place but not another</li>
+</ul>
+<h3>Smell test</h3>
+<p>If adding one button means editing scattered unrelated code, structure is the problem.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day6_Hour2_Advanced.md — What callback spaghetti looks like --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Target Architecture</h1>
+            <h3>Model / domain</h3>
+<ul>
+  <li><code>TrackerItem</code></li>
+  <li>Exceptions</li>
+</ul>
+<h3>Service layer</h3>
+<ul>
+  <li>Add, update, delete, list, get by ID</li>
+</ul>
+<h3>UI / controller class</h3>
+<ul>
+  <li>Builds widgets</li>
+  <li>Reads form values</li>
+  <li>Calls the service</li>
+  <li>Refreshes the screen</li>
+  <li>Owns selection + status state</li>
+</ul>
+<pre data-lang="text"><code>widgets -&gt; App/controller -&gt; service -&gt; model</code></pre>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Thin UI callbacks call service layer; Advanced/lessons/lecture/Day6_Hour2_Advanced.md — The target structure for this capstone --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Refactor into `TrackerApp`</h1>
+            <h3>Refactor target methods</h3>
+<ul>
+  <li><code>build_ui()</code></li>
+  <li><code>refresh()</code></li>
+  <li><code>on_add()</code></li>
+  <li><code>on_update()</code></li>
+  <li><code>on_delete()</code></li>
+  <li><code>load_selected_record()</code></li>
+</ul>
+<h3>Key rule</h3>
+<ul>
+  <li>Change one boundary at a time</li>
+  <li>Preserve working behavior while cleaning structure</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Refactor to an App class with methods: build_ui(), refresh(), on_add(), on_delete(); Advanced/lessons/lecture/Day6_Hour2_Advanced.md — Refactoring into an <code>App</code> controller class --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Refactor Without Breaking Behavior</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create an <code>App</code> class that owns the UI</li>
+  <li>Move service calls out of widget construction code</li>
+  <li>Keep callbacks small and readable</li>
+  <li>Verify that behavior is unchanged after the refactor</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> Code is easier to read</p>
+<p><span class="check">✓</span> Functionality is preserved</p>
+<p><span class="check">✓</span> State ownership is clearer</p>
+<p><span class="check">✓</span> Circular imports are avoided</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Refactor GUI; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 2: Hour 22 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 22)</h1>
+            <p><strong>⚠️</strong> Over-refactoring midstream and breaking working code</p>
+<p><strong>⚠️</strong> Callback spaghetti hidden inside a class instead of removed</p>
+<p><strong>⚠️</strong> Circular imports between UI and service modules</p>
+<p><strong>⚠️</strong> Letting the controller become the business brain</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What is one sign that your GUI code needs refactoring?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 22 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 23: Persistence + Polish Sprint</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Load JSON on startup</li>
+  <li>Save after add/update/delete</li>
+  <li>Handle missing or invalid JSON gracefully</li>
+  <li>Add one small usability improvement</li>
+  <li>Prepare for a confident checkpoint demo</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 23: GUI mini-project sprint: persistence + polish; Advanced/lessons/lecture/Day6_Hour3_Advanced.md — Learning objectives --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Why JSON Is the Right Milestone Here</h1>
+            <ul>
+  <li>JSON is transparent and easy to inspect</li>
+  <li>JSON is portable and simple to debug</li>
+  <li>JSON is enough for <strong>this</strong> milestone</li>
+  <li>SQLite comes next session</li>
+</ul>
+<h3>Sequencing matters</h3>
+<ul>
+  <li>Good architecture today makes the storage swap easier tomorrow</li>
+  <li>Stability beats novelty in a checkpoint week</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day6_Hour3_Advanced.md — Why JSON now instead of SQLite now --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Persistence Hook Pattern</h1>
+            <h3>Minimum behavior</h3>
+<ul>
+  <li>Load on startup</li>
+  <li>Save after add</li>
+  <li>Save after update</li>
+  <li>Save after delete</li>
+</ul>
+<h3>Optional polish</h3>
+<ul>
+  <li>File menu</li>
+  <li>About/help dialog</li>
+  <li>Status bar message</li>
+  <li>Save shortcut such as <code>Ctrl+S</code></li>
+</ul>
+<p><strong>Quiz/homework cue</strong>: <code>Hour 23 | persistence hook: save on demand</code></p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Load data on startup; save after changes; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 3: Hour 23; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 23 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Load → Change → Save → Restart</h1>
+            <h3>Instructor flow</h3>
+<ol>
+  <li>Start the app and load records</li>
+  <li>Add or update one record</li>
+  <li>Save automatically or on demand</li>
+  <li>Restart the app</li>
+  <li>Prove data persisted</li>
+  <li>Show a calm error path for malformed JSON</li>
+</ol>
+<h3>Design takeaway</h3>
+<ul>
+  <li>Persistence is part of user trust</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: start app -&gt; load -&gt; add -&gt; save -&gt; restart -&gt; load; Advanced/lessons/lecture/Day6_Hour3_Advanced.md — Opening: why persistence changes the feel of an app --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Mini-Project Sprint</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add load on startup and save after CRUD</li>
+  <li>Handle missing/corrupt JSON without crashing</li>
+  <li>Add one usability improvement</li>
+  <li>Prepare a short milestone demo path</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> GUI persists data across runs</p>
+<p><span class="check">✓</span> User feedback is clear</p>
+<p><span class="check">✓</span> Core workflow works before visual polish</p>
+<p><span class="check">✓</span> Restart behavior is demonstrable</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: GUI milestone sprint; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 3: Hour 23 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 23)</h1>
+            <p><strong>⚠️</strong> Polishing visuals before save/load actually works</p>
+<p><strong>⚠️</strong> Forgetting to save after update/delete</p>
+<p><strong>⚠️</strong> Crashing on malformed JSON</p>
+<p><strong>⚠️</strong> Treating JSON as “temporary” and never testing restart behavior</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What usability improvement did you add that you would want in a real tool?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 23 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 24: Checkpoint 3 — GUI Milestone Demo</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Checkpoint outcome</h1>
+            <ul>
+  <li>Launch the GUI</li>
+  <li>Perform CRUD through the interface</li>
+  <li>Prove JSON persistence across restart</li>
+  <li>Explain where the service layer lives</li>
+  <li>Explain how the app finds the correct record for update/delete</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 24: Checkpoint 3: GUI milestone demo; Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Learning objectives --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Required Demo Path</h1>
+            <h3>Part A — Launch and orient</h3>
+<ul>
+  <li>Open the app cleanly</li>
+  <li>Point out form, list, and feedback area</li>
+</ul>
+<h3>Part B — CRUD</h3>
+<ul>
+  <li>Add a record</li>
+  <li>Update the correct record</li>
+  <li>Delete a record with confirmation</li>
+</ul>
+<h3>Part C — Persistence</h3>
+<ul>
+  <li>Save if needed</li>
+  <li>Close and reopen</li>
+  <li>Show that records reload</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Concrete learner demo prompt; Advanced/quizzes/Advanced_Day6_Quiz.html — Hour 24 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>What the Checkpoint Rubric Rewards</h1>
+            <ul>
+  <li>GUI works reliably</li>
+  <li>Persistence works reliably</li>
+  <li>Errors are handled reasonably</li>
+  <li>Callbacks are not doing all the business logic</li>
+  <li>Stable IDs are used instead of list positions</li>
+  <li>Learner can explain one next improvement</li>
+</ul>
+<h3>Best practice reminder</h3>
+<p>Checkpoint the <strong>full path</strong>, not isolated screenshots.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Concrete grading rubric; Advanced/assignments/Advanced_Day6_homework.ipynb — Part 4: Hour 24 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Failure Modes to Triage</h1>
+            <h3>If restart loses data</h3>
+<ul>
+  <li>Check save path</li>
+  <li>Check JSON write timing</li>
+  <li>Check that list reloads from saved data</li>
+</ul>
+<h3>If update/delete hits the wrong record</h3>
+<ul>
+  <li>Print the selected ID</li>
+  <li>Verify the service method uses that ID</li>
+  <li>Confirm the UI cleared stale selection after refresh</li>
+</ul>
+<h3>If the demo feels fragile</h3>
+<ul>
+  <li>Simplify the path</li>
+  <li>Stabilize the required features first</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Common failure modes and triage guidance --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 6 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Strengthened</h1>
+            <ul>
+  <li>Real update/delete workflows</li>
+  <li>Cleaner GUI architecture</li>
+  <li>Persistence that survives restart</li>
+  <li>A concrete checkpoint story</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails</h1>
+            <p><span class="check">✓</span> Stable CRUD path</p>
+<p><span class="check">✓</span> JSON persistence for this milestone</p>
+<p><span class="check">✓</span> Clean UI/service boundary</p>
+<p><span class="check">✓</span> Demo-ready behavior</p>
+<p><span class="cross">✗</span> Not yet: database backend swap</p>
+<p><span class="cross">✗</span> Not required: heavy visual theming</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 6 overview; Advanced/lessons/lecture/Day6_Hour4_Advanced.md — Debrief and next-step reflection --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Session 7 next:</p>
+<ul>
+  <li>From objects to tables</li>
+  <li>SQLite CRUD with safe queries</li>
+  <li>Row mapping and database hardening</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 7 overview (Hours 25–28) --&gt;</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/slides/advanced/day-07/day-07-session-7.html
+++ b/slides/advanced/day-07/day-07-session-7.html
@@ -1,0 +1,1007 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 7 — Session 7 (Hours 25–28)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 7 — Session 7 (Hours 25–28)</h1>
+            <div class="subtitle">Python Programming (Advanced) • From Objects to Tables with SQLite</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 7 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 25: Schema thinking + repository boundary</li>
+  <li>Hour 26: <code>sqlite3</code> CRUD with parameterized queries</li>
+  <li>Hour 27: Row mapping back into domain objects</li>
+  <li>Hour 28: Transactions, integrity, and <code>init_db()</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Today&#x27;s milestone</h1>
+            <ul>
+  <li>Move from JSON-ready architecture to database-ready architecture</li>
+  <li>Keep the service layer clean while the repository absorbs SQL details</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 7 overview (Hours 25–28); Advanced/lessons/lecture/Day7_Hour2_Advanced.md — Opening Script --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis</h1>
+            <ul>
+  <li>Design the table from the domain model before coding</li>
+  <li>Use parameter placeholders for every query with values</li>
+  <li>Centralize row-to-object mapping</li>
+  <li>Make startup safe with <code>init_db()</code> and meaningful constraints</li>
+</ul>
+<h3>Canonical quiz/contracts to recognize</h3>
+<ul>
+  <li><code>Hour 25 | table name: tasks</code></li>
+  <li><code>Hour 26 | insert result: task-101 saved</code></li>
+  <li><code>Hour 27 | row type: sqlite3.Row</code></li>
+  <li><code>Hour 28 | init script: schema ready</code></li>
+</ul>
+<p>&lt;!-- Sources: Advanced/assignments/Advanced_Day7_homework.ipynb — Part 1 through Part 4; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 25 through Hour 28 canonical contract questions --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 25: Schema Thinking + Repository Idea</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Map object attributes to table columns</li>
+  <li>Choose a stable primary key</li>
+  <li>Decide what is required vs optional</li>
+  <li>Name the CRUD operations before writing SQL</li>
+  <li>Define a repository interface for the core record type</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 25: From objects to tables: schema thinking + repository idea; Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Learning Outcomes --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>From Object Shape to Table Shape</h1>
+            <h3>Python view</h3>
+<pre data-lang="python"><code>@dataclass(slots=True)
+class Expense:
+    expense_id: int
+    title: str
+    amount: float
+    category: str
+    spent_on: date
+    notes: str | None = None</code></pre>
+<h3>Database view</h3>
+<ul>
+  <li>One object ≈ one row</li>
+  <li>Attributes ≈ columns</li>
+  <li>Collection ≈ table</li>
+  <li>Stable ID ≈ primary key</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Schema Thinking: From One Object to One Row --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Draft the Schema Before the CRUD Code</h1>
+            <pre data-lang="sql"><code>CREATE TABLE expenses (
+    expense_id INTEGER PRIMARY KEY,
+    title TEXT NOT NULL,
+    amount REAL NOT NULL,
+    category TEXT NOT NULL,
+    spent_on TEXT NOT NULL,
+    notes TEXT
+);</code></pre>
+<h3>Design questions to answer first</h3>
+<ul>
+  <li>Which fields are required?</li>
+  <li>Which fields are optional?</li>
+  <li>Which field is true identity?</li>
+  <li>Which values are derived vs stored?</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Table Design: Columns, Primary Keys, and Constraints --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Why a Repository Boundary Helps</h1>
+            <ul>
+  <li>Service code should ask for behaviors, not write SQL directly</li>
+  <li>Repository isolates DB details</li>
+  <li>Later storage changes are less disruptive</li>
+  <li>Tests can target repository or service behavior more cleanly</li>
+</ul>
+<h3>Repository sketch</h3>
+<pre data-lang="python"><code>class ExpenseRepository(Protocol):
+    def add(self, item: NewExpense) -&gt; Expense: ...
+    def list_all(self) -&gt; list[Expense]: ...
+    def get_by_id(self, expense_id: int) -&gt; Expense | None: ...</code></pre>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Repository isolates DB details; Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Repository idea --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Design Schema + Interface</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Draft a schema for your tracker&#x27;s main record</li>
+  <li>Choose a stable ID type</li>
+  <li>List the CRUD methods the app will need</li>
+  <li>Write a repository interface or stub class</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> Schema draft exists</p>
+<p><span class="check">✓</span> Repository methods are defined</p>
+<p><span class="check">✓</span> Required vs optional fields are explicit</p>
+<p><span class="check">✓</span> Update/delete are planned around IDs</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Design schema; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 1: Hour 25 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>DB Quality Gate (Starts Now)</h1>
+            <ul>
+  <li>All SQL uses <code>?</code> placeholders — no string concatenation</li>
+  <li>DB writes are committed via context manager or explicit <code>commit()</code></li>
+  <li>Every table has a stable primary key</li>
+  <li>Update/delete always target IDs</li>
+  <li>Log or print the target ID during early debugging</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is a repository useful even for a small project?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — DB Quality Gate; Quick check / exit ticket; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 25 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 26: `sqlite3` CRUD with Parameterized Queries</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Create/connect to a database file</li>
+  <li>Use <code>CREATE TABLE IF NOT EXISTS</code></li>
+  <li>Insert and list records safely</li>
+  <li>Understand why <code>?</code> placeholders matter</li>
+  <li>Debug missing commits and DB-path mistakes</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 26: sqlite3 CRUD with parameterized queries; Advanced/lessons/lecture/Day7_Hour2_Advanced.md — Learning Outcomes --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>`sqlite3` Fundamentals</h1>
+            <pre data-lang="python"><code>from pathlib import Path
+import sqlite3
+
+db_path = Path(&quot;data&quot;) / &quot;expenses.db&quot;
+db_path.parent.mkdir(exist_ok=True)
+
+with sqlite3.connect(db_path) as connection:
+    print(&quot;Connected.&quot;)</code></pre>
+<h3>Key ideas</h3>
+<ul>
+  <li>SQLite is just a file on disk</li>
+  <li>Use <code>pathlib</code> for paths</li>
+  <li>Use a context manager for safer commit/rollback behavior</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour2_Advanced.md — sqlite3 Fundamentals --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Safe SQL: Use Parameters, Not String Building</h1>
+            <h3>Avoid</h3>
+<pre data-lang="python"><code>unsafe_sql = f&quot;SELECT * FROM expenses WHERE title = &#x27;{user_title}&#x27;&quot;</code></pre>
+<h3>Prefer</h3>
+<pre data-lang="python"><code>safe_sql = &quot;SELECT * FROM expenses WHERE title = ?&quot;
+rows = connection.execute(safe_sql, (&quot;Lunch&quot;,)).fetchall()</code></pre>
+<h3>Why</h3>
+<ul>
+  <li>Safer quoting/escaping</li>
+  <li>Lower injection risk</li>
+  <li>More predictable query structure</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour2_Advanced.md — Parameterized Queries: The Safety Rule of the Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: First SQLite Repository Methods</h1>
+            <h3>Demo flow</h3>
+<ol>
+  <li>Create the DB file</li>
+  <li>Create the table with <code>IF NOT EXISTS</code></li>
+  <li>Implement <code>add()</code></li>
+  <li>Implement <code>list_all()</code></li>
+  <li>Print the DB path and inserted result</li>
+</ol>
+<p><strong>Quiz/homework cue</strong>: <code>Hour 26 | insert result: task-101 saved</code></p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: create db file; create table; insert one row; select rows; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 2: Hour 26; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 26 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: First SQLite Integration</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create a DB file in <code>data/</code></li>
+  <li>Create the table</li>
+  <li>Implement <code>repo.add()</code></li>
+  <li>Implement <code>repo.list_all()</code></li>
+  <li>Print results to confirm real persistence</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> DB file created</p>
+<p><span class="check">✓</span> Insert and list work</p>
+<p><span class="check">✓</span> Queries use parameters</p>
+<p><span class="check">✓</span> Writes are committed</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: First SQLite integration; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 2: Hour 26 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 26)</h1>
+            <p><strong>⚠️</strong> Forgetting <code>commit()</code> / assuming the write stuck</p>
+<p><strong>⚠️</strong> String-formatting SQL</p>
+<p><strong>⚠️</strong> Writing to one DB file and reading from another</p>
+<p><strong>⚠️</strong> Skipping the DB path print during debugging</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What does the <code>?</code> placeholder do in <code>sqlite3</code>?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 26 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 27: Row Mapping Back into Objects</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Convert rows into dataclass/domain objects</li>
+  <li>Use <code>sqlite3.Row</code> for readable mapping</li>
+  <li>Implement <code>get_by_id</code>, <code>update</code>, and <code>delete</code></li>
+  <li>Convert stored text back into richer Python types</li>
+  <li>Surface missing-record errors clearly</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 27: Row mapping: converting rows to objects; Advanced/lessons/lecture/Day7_Hour3_Advanced.md — Learning Outcomes --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Why Raw Rows Are Not Enough</h1>
+            <pre data-lang="python"><code>(1, &quot;Coffee beans&quot;, 18.5, &quot;Groceries&quot;, &quot;2026-01-13&quot;, &quot;Medium roast&quot;)</code></pre>
+<h3>Problems with raw tuples</h3>
+<ul>
+  <li>Callers must remember column order</li>
+  <li>Type conversion gets repeated</li>
+  <li>Storage details leak upward</li>
+  <li>Small schema changes become fragile</li>
+</ul>
+<h3>Better goal</h3>
+<p>Return domain objects from the repository.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour3_Advanced.md — Opening Script: Why Raw Rows Are Not Enough --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Use `sqlite3.Row` + a Mapping Helper</h1>
+            <pre data-lang="python"><code>connection.row_factory = sqlite3.Row
+
+def from_row(row: sqlite3.Row) -&gt; Expense:
+    return Expense(
+        expense_id=row[&quot;expense_id&quot;],
+        title=row[&quot;title&quot;],
+        amount=row[&quot;amount&quot;],
+        category=row[&quot;category&quot;],
+        spent_on=date.fromisoformat(row[&quot;spent_on&quot;]),
+        notes=row[&quot;notes&quot;],
+    )</code></pre>
+<h3>Rule</h3>
+<p>Keep mapping logic in one place.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour3_Advanced.md — Mapping Options: Tuple Order versus Named Columns; Centralize the mapping helper --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Complete CRUD with Mapped Objects</h1>
+            <h3>Demo flow</h3>
+<ul>
+  <li>Set <code>row_factory</code></li>
+  <li>Implement <code>list_all()</code> and <code>get_by_id()</code></li>
+  <li>Implement <code>update()</code> with a <code>WHERE</code> clause</li>
+  <li>Implement <code>delete()</code></li>
+  <li>Re-read or check affected row count after update</li>
+  <li>Raise <code>NotFoundError</code> at the service layer when needed</li>
+</ul>
+<h3>Watch for</h3>
+<ul>
+  <li>Mismatched column names/order</li>
+  <li>Missing <code>WHERE</code> in <code>UPDATE</code></li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: repo.get_by_id returns a model object; Show NotFoundError when no row; Advanced/lessons/lecture/Day7_Hour3_Advanced.md — Live Demo Part 1 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Finish Repo CRUD</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Implement <code>get_by_id</code></li>
+  <li>Implement <code>update</code></li>
+  <li>Implement <code>delete</code></li>
+  <li>Ensure service code handles missing records clearly</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> CRUD repository methods are complete</p>
+<p><span class="check">✓</span> Row mapping is centralized</p>
+<p><span class="check">✓</span> Service layer handles missing IDs</p>
+<p><span class="check">✓</span> Update/delete target the correct row</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Implement get/update/delete; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 3: Hour 27 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 27)</h1>
+            <p><strong>⚠️</strong> Leaking raw tuples to the rest of the app</p>
+<p><strong>⚠️</strong> Mismatched column ordering/names</p>
+<p><strong>⚠️</strong> <code>UPDATE</code> without <code>WHERE</code></p>
+<p><strong>⚠️</strong> Forgetting to verify that the intended row changed</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What is the fastest safe way to confirm your <code>UPDATE</code> query worked?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 27 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 28: Transactions, Integrity, and `init_db()`</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain transactions in practical terms</li>
+  <li>Use context-manager commits/rollbacks</li>
+  <li>Write an idempotent <code>init_db()</code></li>
+  <li>Add a small set of meaningful constraints</li>
+  <li>Remember the SQLite foreign key reminder</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 28: Transactions + integrity + initialization patterns; Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Learning Outcomes --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Reliability Means More Than “It Worked Once”</h1>
+            <h3>A trustworthy DB layer has:</h3>
+<ol>
+  <li>Predictable startup</li>
+  <li>Structural guardrails against bad data</li>
+  <li>Multi-step writes that succeed together or fail together</li>
+</ol>
+<h3>Plain-language transaction rule</h3>
+<p>Either <strong>all</strong> related writes happen, or <strong>none</strong> of them do.</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Opening Script: From Working to Reliable; Transactions in Plain English --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Safe Initialization Pattern</h1>
+            <pre data-lang="python"><code>def init_db(db_path: Path) -&gt; None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with connect(db_path) as connection:
+        connection.execute(create_table_sql)</code></pre>
+<h3>Why `init_db()` matters</h3>
+<ul>
+  <li>Startup becomes predictable</li>
+  <li>Schema creation is safe to repeat</li>
+  <li>New environments require less manual setup</li>
+</ul>
+<h3>Integrity examples</h3>
+<ul>
+  <li><code>NOT NULL</code></li>
+  <li><code>CHECK(amount &gt;= 0)</code></li>
+  <li>Stable primary key</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: init_db() function and calling it once at startup; Add basic constraints (NOT NULL for required fields); Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Live Demo Part 1 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Hardening the DB Layer</h1>
+            <h3>Demo flow</h3>
+<ul>
+  <li>Create <code>connect()</code> helper</li>
+  <li>Enable <code>PRAGMA foreign_keys = ON</code></li>
+  <li>Run <code>init_db()</code> on startup</li>
+  <li>Show one grouped transaction</li>
+  <li>Demonstrate rollback on failure</li>
+</ul>
+<p><strong>Quiz/homework cue</strong>: <code>Hour 28 | init script: schema ready</code></p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Mention foreign keys lightly and accurately; Live Demo Part 1; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 28 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Hardening Sprint</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Write <code>init_db(db_path)</code></li>
+  <li>Ensure it is safe to run more than once</li>
+  <li>Add basic constraints</li>
+  <li>Test one failure path in a grouped write</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> DB initializes reliably</p>
+<p><span class="check">✓</span> Constraints protect storage</p>
+<p><span class="check">✓</span> Grouped writes behave predictably</p>
+<p><span class="check">✓</span> Startup is calmer and more repeatable</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Hardening DB layer; Advanced/assignments/Advanced_Day7_homework.ipynb — Part 4: Hour 28 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 28)</h1>
+            <p><strong>⚠️</strong> Partially applied writes</p>
+<p><strong>⚠️</strong> Schema drift after code changes</p>
+<p><strong>⚠️</strong> Assuming foreign keys are on automatically</p>
+<p><strong>⚠️</strong> Manual setup steps hidden outside startup</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why should <code>init_db()</code> be safe to run multiple times?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day7_Quiz.html — Hour 28 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 7 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What We Added</h1>
+            <ul>
+  <li>Table-first thinking</li>
+  <li>Safe <code>sqlite3</code> CRUD</li>
+  <li>Clean row mapping</li>
+  <li>More dependable startup and writes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails</h1>
+            <p><span class="check">✓</span> Standard-library SQLite</p>
+<p><span class="check">✓</span> Parameterized SQL</p>
+<p><span class="check">✓</span> Repository boundary</p>
+<p><span class="check">✓</span> Practical constraints and transactions</p>
+<p><span class="cross">✗</span> Not today: ORM migration frameworks</p>
+<p><span class="cross">✗</span> Not required: multi-table deep design</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day7_Hour1_Advanced.md — Instructor note; Advanced/lessons/lecture/Day7_Hour4_Advanced.md — Instructor note --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Session 8 next:</p>
+<ul>
+  <li>Deeper SQL or tiny ORM exposure</li>
+  <li>Plug SQLite into the app</li>
+  <li>Search, pagination, and the data-driven checkpoint</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 8 overview (Hours 29–32) --&gt;</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/slides/advanced/day-08/day-08-session-8.html
+++ b/slides/advanced/day-08/day-08-session-8.html
@@ -1,0 +1,1016 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 8 — Session 8 (Hours 29–32)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 8 — Session 8 (Hours 29–32)</h1>
+            <div class="subtitle">Python Programming (Advanced) • Data-Driven App Integration and Checkpoint 4</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 8 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 29: Deeper SQL practice, with ORM exposure as an optional extension</li>
+  <li>Hour 30: Plug the SQLite repository into the app</li>
+  <li>Hour 31: Search/filter + pagination patterns</li>
+  <li>Hour 32: Checkpoint 4 data-driven app milestone</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day goal</h1>
+            <ul>
+  <li>Make SQLite the actual source of truth</li>
+  <li>Add practical search</li>
+  <li>Prove persistence end to end</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Session 8 overview (Hours 29–32); Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Opening Script --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis</h1>
+            <ul>
+  <li>Default to deeper SQL practice for the required build path</li>
+  <li>Treat ORM as optional exposure, not mandatory scope</li>
+  <li>Keep the service contract stable during the storage swap</li>
+  <li>Apply stable ordering before slicing pages</li>
+  <li>Prove persistence-backed behavior at the checkpoint</li>
+</ul>
+<h3>Canonical quiz/contracts to recognize</h3>
+<ul>
+  <li><code>Hour 29 | chosen path: deeper SQL practice</code></li>
+  <li><code>Hour 30 | repository plugged in: yes</code></li>
+  <li><code>Hour 31 | search term: report</code></li>
+  <li><code>Hour 32 | db path: data/tracker.db</code></li>
+</ul>
+<p>&lt;!-- Sources: Advanced/assignments/Advanced_Day8_homework.ipynb — Part 1 through Part 4; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 29 through Hour 32 canonical contract questions --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 29: Deeper SQL Practice First, ORM Optional</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain what an ORM does in plain language</li>
+  <li>Compare ORM convenience vs SQL transparency</li>
+  <li>Implement one practical extension safely</li>
+  <li>Stay within the course scope</li>
+</ul>
+<h3>Default class path</h3>
+<ul>
+  <li><strong>Required</strong>: deeper SQL practice</li>
+  <li><strong>Optional extension</strong>: tiny SQLAlchemy slice if the environment supports it</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 29: Optional ORM slice (SQLAlchemy) OR deeper SQL practice; Advanced/assignments/Advanced_Day8_homework.ipynb — Part 1: Hour 29 - Deeper SQL practice (required) with ORM as an optional extension; Advanced/lessons/lecture/Day8_Hour1_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>The Real Tradeoff</h1>
+            <h3>ORM advantages</h3>
+<ul>
+  <li>Less repetitive mapping code</li>
+  <li>Object-style query API</li>
+  <li>Useful abstraction for common patterns</li>
+</ul>
+<h3>ORM disadvantages</h3>
+<ul>
+  <li>Extra dependency</li>
+  <li>More abstraction to debug</li>
+  <li>Hidden SQL can slow learning if the basics are still shaky</li>
+</ul>
+<h3>SQL advantages</h3>
+<ul>
+  <li>Transparent</li>
+  <li>Portable</li>
+  <li>Great for small apps and practical summaries</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour1_Advanced.md — What an ORM Does; What Raw SQL Gives You; The Real Comparison --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Path A vs Path B</h1>
+            <h3>Path A — tiny ORM exposure</h3>
+<ul>
+  <li>One model class</li>
+  <li>One session</li>
+  <li>One query</li>
+</ul>
+<h3>Path B — deeper SQL practice</h3>
+<ul>
+  <li><code>GROUP BY</code></li>
+  <li><code>COUNT(*)</code></li>
+  <li>Summary queries that answer real app questions</li>
+</ul>
+<p><strong>Recommendation</strong>: finish one path well; do not split your hour in half and complete neither.</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab (choose one); Advanced/lessons/lecture/Day8_Hour1_Advanced.md — Message to Learners; Live Demo --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: SQL Summary Query</h1>
+            <pre data-lang="python"><code>def summarize_by_status(db_path: str) -&gt; list[tuple[str, int]]:
+    query = &quot;&quot;&quot;
+        SELECT status, COUNT(*) AS total
+        FROM records
+        GROUP BY status
+        ORDER BY total DESC, status ASC
+    &quot;&quot;&quot;</code></pre>
+<h3>Why this path fits today</h3>
+<ul>
+  <li>No extra package install</li>
+  <li>Learners still see real SQL</li>
+  <li>The database answers the question directly</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour1_Advanced.md — Demo Track B: Deeper SQL Practice --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Choose One Depth Path</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Required baseline</h3>
+<ul>
+  <li>Complete the deeper SQL path first</li>
+  <li>Add one safe summary or reporting query</li>
+  <li>Explain one ORM tradeoff even if you stay with SQL</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> One path completed cleanly</p>
+<p><span class="check">✓</span> Tradeoffs explained at a high level</p>
+<p><span class="check">✓</span> Query or ORM slice remains small and readable</p>
+<p><span class="check">✓</span> App stability is preserved</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Completion criteria (Hour 29); Advanced/assignments/Advanced_Day8_homework.ipynb — Part 1: Hour 29 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 29)</h1>
+            <p><strong>⚠️</strong> Adding ORM complexity before understanding the query shape</p>
+<p><strong>⚠️</strong> Switching approaches midstream</p>
+<p><strong>⚠️</strong> Treating “more abstraction” as “automatically better”</p>
+<p><strong>⚠️</strong> Letting this hour derail the milestone path</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What is one advantage and one disadvantage of an ORM?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 29 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 30: Integrate the DB into the App</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Swap storage without rewriting the whole app</li>
+  <li>Keep the service contract stable</li>
+  <li>Use beginner-friendly dependency injection</li>
+  <li>Avoid two conflicting sources of truth</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 30: Integrate DB into the app; Advanced/lessons/lecture/Day8_Hour2_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Same Service Contract, New Storage Engine</h1>
+            <h3>Stable pieces</h3>
+<ul>
+  <li>Model classes</li>
+  <li>Validation logic</li>
+  <li>Service method names</li>
+  <li>UI callbacks / routes</li>
+</ul>
+<h3>Pieces that change</h3>
+<ul>
+  <li>Repository implementation</li>
+  <li>SQL statements</li>
+  <li>Row mapping</li>
+  <li><code>init_db()</code> and connection setup</li>
+</ul>
+<blockquote>The service should depend on what the repo can do, not how it stores data.</blockquote>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour2_Advanced.md — The One Big Idea; What Should Stay Stable --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Beginner-Friendly Dependency Injection</h1>
+            <pre data-lang="python"><code>repo = SQLiteTrackerRepository(&quot;data/tracker.db&quot;)
+service = TrackerService(repo=repo)</code></pre>
+<h3>Avoid</h3>
+<pre data-lang="python"><code>class TrackerService:
+    def __init__(self):
+        self.repo = SQLiteTrackerRepository(&quot;data/tracker.db&quot;)</code></pre>
+<h3>Why</h3>
+<ul>
+  <li>Easier to test</li>
+  <li>Easier to swap storage</li>
+  <li>Cleaner architecture</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour2_Advanced.md — Dependency Injection Without the Jargon Overload --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>One Source of Truth</h1>
+            <h3>Once SQLite is live</h3>
+<ul>
+  <li>SQLite is the live persistence layer</li>
+  <li>JSON can become export/import, not parallel truth</li>
+</ul>
+<h3>Danger pattern</h3>
+<ul>
+  <li>GUI writes to JSON</li>
+  <li>Search reads from SQLite</li>
+  <li>Nobody knows which state is current</li>
+</ul>
+<p><strong>Quiz/homework cue</strong>: <code>Hour 30 | repository plugged in: yes</code></p>
+<p>&lt;!-- Sources: Advanced/assignments/Advanced_Day8_homework.ipynb — Part 2: Hour 30; Advanced/lessons/lecture/Day8_Hour2_Advanced.md — The Risk of Two Sources of Truth; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 30 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Storage Swap With Minimal Drama</h1>
+            <h3>Demo flow</h3>
+<ol>
+  <li>Build the repo</li>
+  <li>Call <code>repo.init_db()</code></li>
+  <li>Construct the service with that repo</li>
+  <li>Launch the app</li>
+  <li>Show that add/list/update/delete still work</li>
+  <li>Restart and verify persistence</li>
+</ol>
+<h3>Success condition</h3>
+<ul>
+  <li>UI changes very little</li>
+  <li>Storage changes a lot</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: service = TrackerService(repo=SQLiteRepo(...)); Show UI still works after swap; Advanced/lessons/lecture/Day8_Hour2_Advanced.md — Live Demo of the Storage Swap --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Wire the Repository Under the Service</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Replace JSON/in-memory persistence with SQLite</li>
+  <li>Keep the service layer interface stable</li>
+  <li>Confirm CRUD works after the swap</li>
+  <li>Remove confusion about live storage</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> App persists via SQLite</p>
+<p><span class="check">✓</span> UI/API still functions</p>
+<p><span class="check">✓</span> One source of truth is clear</p>
+<p><span class="check">✓</span> Restart behavior is verified</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Wire it up; Advanced/assignments/Advanced_Day8_homework.ipynb — Part 2: Hour 30 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 30)</h1>
+            <p><strong>⚠️</strong> UI calling <code>sqlite3</code> directly</p>
+<p><strong>⚠️</strong> JSON and SQLite both acting “live”</p>
+<p><strong>⚠️</strong> Forgetting to refresh after DB writes</p>
+<p><strong>⚠️</strong> Rebuilding more layers than necessary</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What interface stayed the same when you swapped storage?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 30 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 31: Search, Filter, and Pagination</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Add a practical search feature</li>
+  <li>Use parameterized <code>LIKE</code> safely</li>
+  <li>Understand <code>LIMIT</code> and <code>OFFSET</code></li>
+  <li>Keep paging logic in the repository layer</li>
+  <li>Preserve stable ordering across pages</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 31: Search/filter + pagination patterns; Advanced/lessons/lecture/Day8_Hour3_Advanced.md — Learning Outcomes for This Hour --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Search vs Filter</h1>
+            <h3>Search</h3>
+<ul>
+  <li>Partial text match</li>
+  <li>e.g. title contains <code>&quot;invoice&quot;</code></li>
+</ul>
+<h3>Filter</h3>
+<ul>
+  <li>Narrow by exact or controlled value</li>
+  <li>e.g. status equals <code>&quot;open&quot;</code></li>
+</ul>
+<h3>Practical method shape</h3>
+<pre data-lang="python"><code>def search(term: str = &quot;&quot;, status: str | None = None,
+           limit: int = 20, offset: int = 0) -&gt; list[Record]:
+    ...</code></pre>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour3_Advanced.md — Filtering vs Searching --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Safe `LIKE` + Stable Pagination</h1>
+            <pre data-lang="python"><code>wildcard = f&quot;%{term.strip().lower()}%&quot;
+query = &quot;&quot;&quot;
+    SELECT id, title, category, status
+    FROM records
+    WHERE lower(title) LIKE ?
+    ORDER BY id ASC
+    LIMIT ? OFFSET ?
+&quot;&quot;&quot;</code></pre>
+<h3>Rules to keep</h3>
+<ul>
+  <li>Add <code>%</code> to the <strong>parameter value</strong></li>
+  <li>Normalize case for a friendlier search</li>
+  <li>Sort before paginating</li>
+</ul>
+<p><strong>Quiz/homework cue</strong>: <code>Hour 31 | search term: report</code></p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour3_Advanced.md — Safe Search with <code>LIKE</code>; Why Pagination Exists; Advanced/assignments/Advanced_Day8_homework.ipynb — Part 3: Hour 31; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 31 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo: Search Repository + Optional UI Hook</h1>
+            <h3>Demo flow</h3>
+<ul>
+  <li>Add <code>search_records(term, status, limit, offset)</code></li>
+  <li>Reset page to zero on a new search</li>
+  <li>Add optional Next/Prev buttons</li>
+  <li>Repopulate the visible table from fresh results</li>
+</ul>
+<h3>Usability guardrails</h3>
+<ul>
+  <li>Empty result sets are valid</li>
+  <li>Clear stale rows before repopulating</li>
+  <li>Do not hand-build SQL with user values</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Demo: repo.search(q, limit, offset); Demo: next/prev buttons in UI (optional); Advanced/lessons/lecture/Day8_Hour3_Advanced.md — Live Demo --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Practical Search Feature</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add a search box or script input</li>
+  <li>Implement a repository search method</li>
+  <li>Optional: add paging with limit 20 and Next/Prev</li>
+  <li>Keep results predictable with stable ordering</li>
+</ul>
+<h3>Completion Criteria</h3>
+<p><span class="check">✓</span> Search returns correct results</p>
+<p><span class="check">✓</span> No SQL injection risk</p>
+<p><span class="check">✓</span> Paging does not reorder records unpredictably</p>
+<p><span class="check">✓</span> Empty search results behave cleanly</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Lab: Search feature; Advanced/assignments/Advanced_Day8_homework.ipynb — Part 3: Hour 31 --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 31)</h1>
+            <p><strong>⚠️</strong> Building SQL with string concatenation</p>
+<p><strong>⚠️</strong> Forgetting wildcards in <code>LIKE</code></p>
+<p><strong>⚠️</strong> Paginating unsorted results</p>
+<p><strong>⚠️</strong> Leaving stale UI rows after search</p>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Where should wildcard <code>%</code> be added: in the SQL string or the parameter value?</p>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Common pitfalls to watch for / Quick check; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 31 explanation --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 32: Checkpoint 4 — Data-Driven App Milestone</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Required deliverables</h1>
+            <ul>
+  <li>SQLite repo with CRUD</li>
+  <li><code>init_db()</code> on startup</li>
+  <li>Database as source of truth</li>
+  <li>Basic search feature</li>
+  <li>Demo proving persistence across restarts</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md — Hour 32: Checkpoint 4: Data-driven app milestone; Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Clarify the Deliverables --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Fast-Grade Demo Workflow</h1>
+            <ol>
+  <li>Launch the app</li>
+  <li>Create a record</li>
+  <li>Search for it</li>
+  <li>Close the app</li>
+  <li>Reopen the app</li>
+  <li>Confirm the record still exists</li>
+  <li>Update it</li>
+  <li>Delete it</li>
+</ol>
+<h3>Why this works</h3>
+<ul>
+  <li>It reveals path issues fast</li>
+  <li>It reveals stale in-memory state fast</li>
+  <li>It proves SQLite is really live</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Show the Fast-Grade Workflow --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Validation Checklist</h1>
+            <pre data-lang="text"><code>[ ] Database file exists in the expected path
+[ ] init_db runs safely on startup
+[ ] Add creates a new row in SQLite
+[ ] List reads from SQLite, not stale in-memory data
+[ ] Search returns expected results
+[ ] Update targets the correct record ID
+[ ] Delete removes the intended record
+[ ] Restart proves persistence
+[ ] Common errors do not crash the app</code></pre>
+<p><strong>Quiz/homework cue</strong>: <code>Hour 32 | db path: data/tracker.db</code></p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Validation Checklist for Learners; Advanced/quizzes/Advanced_Day8_Quiz.html — Hour 32 canonical contract --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Common Failure Modes to Triage</h1>
+            <h3>Data disappears after restart</h3>
+<ul>
+  <li>Check commit behavior</li>
+  <li>Check DB path</li>
+  <li>Check whether the UI still reads cached objects</li>
+</ul>
+<h3>Wrong record changes</h3>
+<ul>
+  <li>Print the target ID</li>
+  <li>Verify the <code>WHERE</code> clause</li>
+  <li>Check stale selected state</li>
+</ul>
+<h3>Search returns odd results</h3>
+<ul>
+  <li>Test the repo method by itself first</li>
+  <li>Check wildcard placement</li>
+  <li>Check row clearing in the UI</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Coaching Notes for Common Failure Modes --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Session 8 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What Success Looks Like</h1>
+            <ul>
+  <li>SQLite is now the real source of truth</li>
+  <li>Storage swaps did not break the service contract</li>
+  <li>Search is practical and safe</li>
+  <li>The checkpoint demo is honest and repeatable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails</h1>
+            <p><span class="check">✓</span> Stable milestone first</p>
+<p><span class="check">✓</span> Practical search and persistence</p>
+<p><span class="check">✓</span> Small optional ORM exposure only if environment allows</p>
+<p><span class="check">✓</span> Clear repo/service/UI boundaries</p>
+<p><span class="cross">✗</span> Not required: fancy joins, migrations, or advanced ORM topics</p>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour1_Advanced.md — Scope Guardrails; Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Stability is the priority --&gt;</p>
+        </section>
+
+        <section class="slide">
+            <h1>Thank You!</h1>
+            <p>Next milestone after Day 8:</p>
+<ul>
+  <li>refine architecture</li>
+  <li>expand data features carefully</li>
+  <li>keep reliability ahead of novelty</li>
+</ul>
+<p>&lt;!-- Sources: Advanced/lessons/lecture/Day8_Hour4_Advanced.md — Opening Script; Reflection and exit ticket framing --&gt;</p>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/slides/advanced/day-09/day-09-session-9.html
+++ b/slides/advanced/day-09/day-09-session-9.html
@@ -1,0 +1,1176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 9 — Session 9 (Hours 33–36)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 9 — Session 9 (Hours 33–36)</h1>
+            <div class="subtitle">Python Programming (Advanced) • REST APIs and Flask Foundations</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 9 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 33: REST fundamentals + Flask app setup</li>
+  <li>Hour 34: CRUD endpoints for the main resource</li>
+  <li>Hour 35: Serialization + validation</li>
+  <li>Hour 36: App structure + dependency wiring</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Capstone Through-Line</h1>
+            <ul>
+  <li>Expose the existing tracker logic through a Flask API</li>
+  <li>Keep the service layer as the center of truth</li>
+  <li>Build for maintainability, not framework novelty</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Alignment Sources</h1>
+            <ul>
+  <li>Runbook: <code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → Session 9 overview; Hours 33–36</li>
+  <li>Lecture: <code>Advanced/lessons/lecture/Day9_Hour1_Advanced.md</code> through <code>Day9_Hour4_Advanced.md</code></li>
+  <li>Homework: <code>Advanced/assignments/Advanced_Day9_homework.ipynb</code></li>
+  <li>Quiz: <code>Advanced/quizzes/Advanced_Day9_Quiz.html</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Today’s Output Target</h1>
+            <ul>
+  <li>A working Flask surface over the tracker project</li>
+  <li>Predictable JSON responses</li>
+  <li>A structure that can keep growing tomorrow</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Success Criteria</h1>
+            <ul>
+  <li><code>/health</code> responds with JSON</li>
+  <li>Main resource supports CRUD behavior</li>
+  <li>Error responses use one consistent JSON shape</li>
+  <li>Write-ready app structure uses explicit dependency wiring</li>
+  <li>Homework and quiz checkpoints are visible in the day’s build flow</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            <ul>
+  <li>Stay in course scope: Flask + clean contracts + practical structure</li>
+  <li>Do <strong>not</strong> drift into deployment, OAuth, JWT, or API versioning</li>
+  <li>Reuse service and repository logic instead of rebuilding business rules in routes</li>
+  <li>Choose one resource name and keep it consistent in your own project</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 33: REST Fundamentals + Flask App Setup</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain REST-style resources in plain language</li>
+  <li>Distinguish <code>GET</code> from <code>POST</code></li>
+  <li>Create a minimal Flask app</li>
+  <li>Return JSON instead of default HTML errors</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why an API Matters Now</h1>
+            <ul>
+  <li>The capstone already has logic and persistence</li>
+  <li>Flask becomes a <strong>new interface</strong>, not a new project</li>
+  <li>An API lets other tools call the same application behavior</li>
+  <li>Strong layering now makes later integration easier</li>
+</ul>
+<pre data-lang="text"><code>Client -&gt; Flask route -&gt; service -&gt; repository -&gt; SQLite</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>REST in Plain English</h1>
+            <ul>
+  <li><strong>Resource</strong>: the thing the API exposes</li>
+  <li><strong>Route</strong>: URL pattern connected to code</li>
+  <li><strong>Method</strong>: <code>GET</code>, <code>POST</code>, <code>PUT</code>, <code>DELETE</code></li>
+  <li><strong>Status code</strong>: fast signal of what happened</li>
+  <li><strong>JSON contract</strong>: predictable request/response shape</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Useful Day 9 status codes</h1>
+            <ul>
+  <li><code>200</code> success</li>
+  <li><code>201</code> created</li>
+  <li><code>400</code> bad input</li>
+  <li><code>404</code> missing resource</li>
+  <li><code>500</code> unexpected failure</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Minimal Flask Starter</h1>
+            <pre data-lang="python"><code>from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.get(&quot;/health&quot;)
+def health():
+    return jsonify({&quot;status&quot;: &quot;ok&quot;})</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Teaching point</h1>
+            <ul>
+  <li>Start with one honest route before adding CRUD</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Consistent Error Contract</h1>
+            <pre data-lang="json"><code>{
+  &quot;error&quot;: {
+    &quot;code&quot;: &quot;not_found&quot;,
+    &quot;message&quot;: &quot;Record 12 was not found.&quot;,
+    &quot;request_id&quot;: &quot;a1b2c3d4&quot;
+  }
+}</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Why it matters</h1>
+            <ul>
+  <li>Clients can depend on one structure</li>
+  <li>Logs and user-facing errors connect more cleanly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Flow: Hour 33</h1>
+            <ol>
+  <li>Create <code>app = Flask(__name__)</code></li>
+  <li>Add <code>/health</code></li>
+  <li>Run the server locally</li>
+  <li>Test with browser, <code>curl</code>, or a small Python call</li>
+  <li>Trigger one intentional failure and show JSON output</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Flask Starter + Smoke Test</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create a small Flask app</li>
+  <li>Add <code>/health</code></li>
+  <li>Return JSON on success</li>
+  <li>Add one reusable error helper</li>
+  <li>Verify the app from outside the Flask file</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>App starts reliably</li>
+  <li><code>/health</code> returns JSON</li>
+  <li>Learner can explain what a route does</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 33)</h1>
+            <p><strong>⚠️</strong> Mixing setup, routing, and service logic in one giant file</p>
+<p><strong>⚠️</strong> Returning HTML errors while success paths return JSON</p>
+<p><strong>⚠️</strong> Treating the API as a separate project instead of a new interface</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 33)</h1>
+            <ul>
+  <li>Homework goal: build a Flask app with a health route and clear REST basics</li>
+  <li>Best practice: start with one small health endpoint before layering CRUD</li>
+  <li>Quiz-ready anchor: <code>Hour 33 | framework: Flask</code></li>
+  <li>Deliverable check: can you show a health route and explain why it matters?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is a health endpoint a smart first step before building CRUD routes?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 34: CRUD Endpoints for the Main Resource</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Implement <code>GET</code>, <code>POST</code>, <code>PUT</code>, and <code>DELETE</code></li>
+  <li>Keep routes thin</li>
+  <li>Connect handlers to the service layer</li>
+  <li>Return the right status codes for the outcome</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Canonical Route Set</h1>
+            <ul>
+  <li><code>GET /records</code></li>
+  <li><code>POST /records</code></li>
+  <li><code>GET /records/&lt;id&gt;</code></li>
+  <li><code>PUT /records/&lt;id&gt;</code></li>
+  <li><code>DELETE /records/&lt;id&gt;</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Naming note</h1>
+            <ul>
+  <li>Lecture examples use <code>records</code></li>
+  <li>Homework/quiz output anchors may use <code>tasks</code></li>
+  <li>Your project should pick <strong>one</strong> resource name and stay consistent</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Thin Route Handler Mindset</h1>
+            <h3>Route responsibilities</h3>
+<ul>
+  <li>Read request input</li>
+  <li>Call the service</li>
+  <li>Catch known exceptions</li>
+  <li>Return JSON + status code</li>
+</ul>
+<h3>Avoid in the route</h3>
+<ul>
+  <li>Direct SQL</li>
+  <li>Deep business logic</li>
+  <li>Hidden global state</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Safe JSON Parsing Pattern</h1>
+            <pre data-lang="python"><code>payload = request.get_json(silent=True)
+if payload is None:
+    return error_response(
+        &quot;invalid_json&quot;,
+        &quot;Request body must be valid JSON.&quot;,
+        400,
+    )</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Key distinction</h1>
+            <ul>
+  <li>Bad input → <code>400</code></li>
+  <li>Missing resource → <code>404</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>CRUD Example</h1>
+            <pre data-lang="python"><code>@app.post(&quot;/records&quot;)
+def create_record():
+    payload = request.get_json(silent=True)
+    if payload is None:
+        return error_response(&quot;invalid_json&quot;, &quot;Request body must be valid JSON.&quot;, 400)
+
+    record = service.add_record(
+        title=payload.get(&quot;title&quot;, &quot;&quot;),
+        category=payload.get(&quot;category&quot;, &quot;&quot;),
+        status=payload.get(&quot;status&quot;, &quot;open&quot;),
+    )
+    return jsonify(record.to_dict()), 201</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Flow: Hour 34</h1>
+            <ol>
+  <li>Add list + create routes</li>
+  <li>Add get-by-id</li>
+  <li>Add update + delete</li>
+  <li>Show one success case</li>
+  <li>Show one validation or not-found case</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Smoke test habit</h1>
+            <ul>
+  <li>Verify behavior from outside the Flask app</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Build the CRUD Surface</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add the full CRUD route set</li>
+  <li>Route everything through the service layer</li>
+  <li>Return consistent JSON</li>
+  <li>Test at least one success and one failure for each major path</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>CRUD endpoints respond predictably</li>
+  <li>Status codes match the actual outcome</li>
+  <li>Learner can explain <code>400</code> vs <code>404</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 34)</h1>
+            <p><strong>⚠️</strong> Returning <code>200</code> for everything</p>
+<p><strong>⚠️</strong> Writing business rules in Flask handlers</p>
+<p><strong>⚠️</strong> Forgetting to test malformed requests</p>
+<p><strong>⚠️</strong> Letting route names drift between files</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 34)</h1>
+            <ul>
+  <li>Homework goal: a small set of CRUD endpoints for the tracker resource</li>
+  <li>Best practice: use HTTP verbs and status codes consistently</li>
+  <li>Pitfall to avoid: wrong status codes make clients harder to trust</li>
+  <li>Quiz-ready anchor: <code>Hour 34 | endpoint: POST /tasks</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: When should a route return <code>400</code> instead of <code>404</code>?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 35: Serialization + Validation</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Centralize request parsing</li>
+  <li>Centralize response serialization</li>
+  <li>Keep validation rules coherent</li>
+  <li>Use intentional negative cases to test the contract</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>API Contracts Are Promises</h1>
+            <ul>
+  <li>Requests should arrive in a predictable shape</li>
+  <li>Responses should leave in a predictable shape</li>
+  <li>Failure paths should look consistent too</li>
+  <li>“It works” is not enough if every endpoint behaves differently</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Serializer Helper</h1>
+            <pre data-lang="python"><code>def serialize_record(record) -&gt; dict:
+    return {
+        &quot;id&quot;: record.id,
+        &quot;title&quot;: record.title,
+        &quot;category&quot;: record.category,
+        &quot;status&quot;: record.status,
+        &quot;priority&quot;: record.priority,
+    }</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Benefit</h1>
+            <ul>
+  <li>One change point instead of copy/paste edits across routes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Parser + Validation Helper</h1>
+            <pre data-lang="python"><code>def parse_record_payload(payload: dict) -&gt; dict:
+    title = str(payload.get(&quot;title&quot;, &quot;&quot;)).strip()
+    category = str(payload.get(&quot;category&quot;, &quot;&quot;)).strip()
+    status = str(payload.get(&quot;status&quot;, &quot;open&quot;)).strip().lower()
+
+    if not title:
+        raise ValidationError(&quot;Title is required.&quot;)
+    if not category:
+        raise ValidationError(&quot;Category is required.&quot;)
+    if status not in {&quot;open&quot;, &quot;in_progress&quot;, &quot;done&quot;}:
+        raise ValidationError(&quot;Status is invalid.&quot;)
+
+    return {&quot;title&quot;: title, &quot;category&quot;: category, &quot;status&quot;: status}</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Where Validation Should Live</h1>
+            <ul>
+  <li>Parser helpers normalize and reject malformed payloads</li>
+  <li>Service layer enforces domain invariants</li>
+  <li>Routes should <strong>not</strong> duplicate the same rules repeatedly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Negative test ideas</h1>
+            <ul>
+  <li>invalid JSON</li>
+  <li>missing title</li>
+  <li>missing category</li>
+  <li>invalid status value</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Cleaner Route Pattern</h1>
+            <pre data-lang="python"><code>@app.post(&quot;/records&quot;)
+def create_record():
+    payload = request.get_json(silent=True)
+    if payload is None:
+        return error_response(&quot;invalid_json&quot;, &quot;Request body must be valid JSON.&quot;, 400)
+
+    try:
+        parsed = parse_record_payload(payload)
+        record = service.add_record(**parsed)
+    except ValidationError as exc:
+        return error_response(&quot;validation_error&quot;, str(exc), 400)
+
+    return jsonify(serialize_record(record)), 201</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Make the API Coherent</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Add one serializer helper</li>
+  <li>Add one parser/validator helper</li>
+  <li>Replace ad hoc route logic with helpers</li>
+  <li>Run a few negative cases intentionally</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Output shape is consistent across routes</li>
+  <li>Validation rules live in one obvious place</li>
+  <li>Learner can explain at least one negative test result</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 35)</h1>
+            <p><strong>⚠️</strong> Different key sets across endpoints</p>
+<p><strong>⚠️</strong> Validation logic duplicated in multiple routes</p>
+<p><strong>⚠️</strong> Plain-text errors in one handler and JSON in another</p>
+<p><strong>⚠️</strong> Negative cases never tested until demo time</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 35)</h1>
+            <ul>
+  <li>Homework goal: manual serializers and validators for tracker payloads</li>
+  <li>Best practice: one consistent request/response contract</li>
+  <li>Pitfall to avoid: different key sets confuse clients</li>
+  <li>Quiz-ready anchor: <code>Hour 35 | request fields checked: title, priority</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is centralizing parsing and serialization safer than rebuilding dictionaries inside each route?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 36: App Structure + Dependency Wiring</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain why growing apps need structure</li>
+  <li>Refactor toward a <code>create_app()</code> pattern</li>
+  <li>Wire dependencies explicitly</li>
+  <li>Avoid circular imports and hidden globals</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>When Structure Starts to Matter</h1>
+            <ul>
+  <li>Single-file apps are great for learning</li>
+  <li>Growth creates import noise and setup confusion</li>
+  <li>Testing gets harder when construction happens at import time</li>
+  <li>Clear startup makes the app easier to reason about</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Simple Application Factory</h1>
+            <pre data-lang="python"><code>def create_app():
+    app = Flask(__name__)
+    repo = SQLiteTrackerRepository(&quot;data/tracker.db&quot;)
+    repo.init_db()
+    service = TrackerService(repo=repo)
+    register_routes(app, service)
+    return app</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Why it helps</h1>
+            <ul>
+  <li>One visible startup path</li>
+  <li>Explicit dependencies</li>
+  <li>Easier testing later</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Structure Options for This Course</h1>
+            <h3>Minimum good structure</h3>
+<ul>
+  <li><code>api/app.py</code> for startup</li>
+  <li><code>api/routes.py</code> for route registration</li>
+  <li>service + repository modules stay separate</li>
+</ul>
+<h3>Optional structure</h3>
+<ul>
+  <li>Flask blueprints if the learner is ready</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Guardrail</h1>
+            <ul>
+  <li>Do not overframework the capstone</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Architecture Risks</h1>
+            <ul>
+  <li>Global service creation at import time</li>
+  <li><code>routes.py</code> importing <code>app.py</code> and vice versa</li>
+  <li>Repository construction hidden in random modules</li>
+  <li>Learners changing file layout without updating imports deliberately</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Refactor Sprint</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Move routes into a dedicated module or grouping</li>
+  <li>Add <code>create_app()</code></li>
+  <li>Construct repository + service in one clear place</li>
+  <li>Re-test <code>/health</code> and main resource routes</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Startup is predictable</li>
+  <li>Route wiring is readable</li>
+  <li>API still behaves the same after refactor</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 36)</h1>
+            <p><strong>⚠️</strong> Circular imports</p>
+<p><strong>⚠️</strong> Hidden global singletons</p>
+<p><strong>⚠️</strong> Refactoring too much at once</p>
+<p><strong>⚠️</strong> Losing a working route while reorganizing</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 36)</h1>
+            <ul>
+  <li>Homework goal: an app structure that can grow beyond one file</li>
+  <li>Best practice: use an app factory and optional blueprints to organize startup</li>
+  <li>Pitfall to avoid: global singletons hide dependencies and hurt testing</li>
+  <li>Quiz-ready anchor: <code>Hour 36 | app factory: create_app</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What problem does <code>create_app()</code> solve that a global <code>service = ...</code> pattern does not?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 9 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>What Learners Should Leave With</h1>
+            <ul>
+  <li>A Flask entry point</li>
+  <li>CRUD routes around one main resource</li>
+  <li>Manual parser + serializer helpers</li>
+  <li>A maintainable startup path for tomorrow’s security and client work</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Homework Focus</h1>
+            <ul>
+  <li>Build deterministic outputs in <code>Advanced_Day9_homework.ipynb</code></li>
+  <li>Keep the contract stable enough for autograder-style labels</li>
+  <li>Rehearse the hour anchors:</li>
+  <li style="margin-left: 30px;"><code>framework: Flask</code></li>
+  <li style="margin-left: 30px;"><code>endpoint: POST /tasks</code></li>
+  <li style="margin-left: 30px;"><code>request fields checked: title, priority</code></li>
+  <li style="margin-left: 30px;"><code>app factory: create_app</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Exit Ticket</h1>
+            <ol>
+  <li>Which route feels strongest right now?</li>
+  <li>Which failure case still needs testing?</li>
+  <li>What part of your API structure will make tomorrow easier?</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Looking Ahead</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Next Session</h1>
+            <ul>
+  <li>Protect write routes with an API key</li>
+  <li>Build a Python client</li>
+  <li>Choose an integration path</li>
+  <li>Demo the API milestone confidently</li>
+</ul>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/slides/advanced/day-10/day-10-session-10.html
+++ b/slides/advanced/day-10/day-10-session-10.html
@@ -1,0 +1,1151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 10 — Session 10 (Hours 37–40)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 10 — Session 10 (Hours 37–40)</h1>
+            <div class="subtitle">Python Programming (Advanced) • API Security, Clients, and Milestone Demo</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 10 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 37: API security basics with an API key gate</li>
+  <li>Hour 38: Consuming your own API with Python client functions</li>
+  <li>Hour 39: Integration choice — GUI to API or parallel UI/API</li>
+  <li>Hour 40: Checkpoint 5 API milestone demo</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day Goal</h1>
+            <ul>
+  <li>Move from “API exists” to “API is controlled, usable, and demo-ready”</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Alignment Sources</h1>
+            <ul>
+  <li>Runbook: <code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → Session 10 overview; Hours 37–40</li>
+  <li>Lecture: <code>Advanced/lessons/lecture/Day10_Hour1_Advanced.md</code> through <code>Day10_Hour4_Advanced.md</code></li>
+  <li>Homework: <code>Advanced/assignments/Advanced_Day10_homework.ipynb</code></li>
+  <li>Quiz: <code>Advanced/quizzes/Advanced_Day10_Quiz.html</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Theme</h1>
+            <ul>
+  <li>Protect the write surface</li>
+  <li>Use the API from the outside</li>
+  <li>Choose an integration path intentionally</li>
+  <li>Stabilize for checkpoint evidence</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Success Criteria</h1>
+            <ul>
+  <li>Write routes require an API key</li>
+  <li>Client calls use timeouts and predictable error handling</li>
+  <li>The project has a clear integration story</li>
+  <li>Checkpoint 5 shows health, CRUD, protection, and architecture explanation</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            <ul>
+  <li>This is <strong>not</strong> full authentication or identity management</li>
+  <li>API keys live in configuration, not source control</li>
+  <li>Choose the architecture that best protects the milestone</li>
+  <li>Stabilize before adding extra features</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 37: API Security Basics</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain why writes need stronger protection than reads</li>
+  <li>Load a key from configuration</li>
+  <li>Require <code>X-API-Key</code> on <code>POST</code>, <code>PUT</code>, and <code>DELETE</code></li>
+  <li>Return clear <code>401</code> and <code>403</code> responses</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Security Framing Without Panic</h1>
+            <ul>
+  <li>We are adding a <strong>course-level gate</strong></li>
+  <li>We are <strong>not</strong> building OAuth, JWT, or full auth systems</li>
+  <li>The lesson is about:</li>
+  <li style="margin-left: 30px;">safer configuration</li>
+  <li style="margin-left: 30px;">boundary checks</li>
+  <li style="margin-left: 30px;">consistent failure responses</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Rule of thumb</h1>
+            <ul>
+  <li>Reads may be open</li>
+  <li>Writes deserve protection</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>What an API Key Is — and Is Not</h1>
+            <ul>
+  <li>A shared secret checked at the HTTP boundary</li>
+  <li>Good enough for course-level protection of write operations</li>
+  <li><strong>Not</strong> a user identity system</li>
+  <li><strong>Not</strong> a replacement for a production auth stack</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Keep the Secret Out of Source</h1>
+            <pre data-lang="python"><code>import os
+
+API_KEY = os.getenv(&quot;TRACKER_API_KEY&quot;, &quot;&quot;)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Safe handling habits</h1>
+            <ul>
+  <li>Do not hard-code the key</li>
+  <li>Do not commit real values</li>
+  <li><code>.env.example</code> may hold placeholders only</li>
+  <li>Do not log the actual secret</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Header + Status Code Pattern</h1>
+            <h3>Client sends</h3>
+<pre data-lang="text"><code>X-API-Key: &lt;value&gt;</code></pre>
+<h3>Server responds</h3>
+<ul>
+  <li><code>401</code> when the key is missing</li>
+  <li><code>403</code> when the key is present but wrong</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Key habit</h1>
+            <ul>
+  <li>Pick a rule and apply it consistently</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Guard Helper Example</h1>
+            <pre data-lang="python"><code>def require_api_key():
+    provided = request.headers.get(&quot;X-API-Key&quot;, &quot;&quot;)
+
+    if not provided:
+        return error_response(&quot;missing_api_key&quot;, &quot;API key is required.&quot;, 401)
+
+    if not API_KEY or not hmac.compare_digest(provided, API_KEY):
+        return error_response(&quot;invalid_api_key&quot;, &quot;API key is invalid.&quot;, 403)
+
+    return None</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Flow: Hour 37</h1>
+            <ol>
+  <li>Read the key from config</li>
+  <li>Add the helper</li>
+  <li>Protect write routes</li>
+  <li>Test three cases:</li>
+</ol>
+<ul>
+  <li style="margin-left: 30px;">no key</li>
+  <li style="margin-left: 30px;">wrong key</li>
+  <li style="margin-left: 30px;">correct key</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Teaching point</h1>
+            <ul>
+  <li>Security work is incomplete until the failure cases are tested</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Protect the Write Surface</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Load the key from configuration</li>
+  <li>Protect <code>POST</code>, <code>PUT</code>, and <code>DELETE</code></li>
+  <li>Return structured auth failures</li>
+  <li>Add placeholder documentation for secret setup</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Every write route is protected</li>
+  <li>Auth failures still use JSON</li>
+  <li>Learner can explain why the service layer stays header-free</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 37)</h1>
+            <p><strong>⚠️</strong> Hard-coding the key</p>
+<p><strong>⚠️</strong> Protecting some write routes but forgetting one</p>
+<p><strong>⚠️</strong> Logging the real secret</p>
+<p><strong>⚠️</strong> Treating missing and wrong keys as the same case without intention</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 37)</h1>
+            <ul>
+  <li>Homework goal: a simple API key check around write operations</li>
+  <li>Best practice: environment-based key in course scope</li>
+  <li>Pitfall to avoid: hard-coded credentials in source or logs</li>
+  <li>Quiz-ready anchor: <code>Hour 37 | protected route: POST /tasks</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why should the API key check live in the route layer instead of inside the service layer?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 38: Consuming Your Own API</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Write small client functions</li>
+  <li>Set request timeouts</li>
+  <li>Pass auth headers for protected operations</li>
+  <li>Turn server-side failures into readable client feedback</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Become Your Own Client?</h1>
+            <ul>
+  <li>An API can feel fine from the inside but awkward from the outside</li>
+  <li>Client code reveals:</li>
+  <li style="margin-left: 30px;">confusing contracts</li>
+  <li style="margin-left: 30px;">inconsistent errors</li>
+  <li style="margin-left: 30px;">missing timeouts</li>
+  <li style="margin-left: 30px;">unreliable route behavior</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Healthy mindset</h1>
+            <ul>
+  <li>Let the API prove itself from the consumer’s side</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Shape of a Simple Client Module</h1>
+            <ul>
+  <li>Keep it flat and readable</li>
+  <li>Each function should:</li>
+  <li style="margin-left: 30px;">build the URL</li>
+  <li style="margin-left: 30px;">send the request</li>
+  <li style="margin-left: 30px;">set a timeout</li>
+  <li style="margin-left: 30px;">handle errors predictably</li>
+  <li style="margin-left: 30px;">return parsed JSON or a small mapped result</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Timeout + Header Pattern</h1>
+            <pre data-lang="python"><code>import requests
+
+def create_record(payload: dict, api_key: str) -&gt; dict:
+    response = requests.post(
+        f&quot;{BASE_URL}/records&quot;,
+        json=payload,
+        headers={&quot;X-API-Key&quot;: api_key},
+        timeout=5,
+    )
+    response.raise_for_status()
+    return response.json()</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Habit to keep</h1>
+            <ul>
+  <li>Never let requests hang indefinitely</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Friendly Error Handling</h1>
+            <pre data-lang="python"><code>def safe_create_record(payload: dict, api_key: str):
+    try:
+        return create_record(payload, api_key)
+    except requests.Timeout:
+        print(&quot;The API request timed out.&quot;)
+    except requests.HTTPError as exc:
+        print(f&quot;Request failed: {exc}&quot;)
+    return None</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Teaching point</h1>
+            <ul>
+  <li>The client should help the user understand what failed</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Build the Client Module</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Required functions</h3>
+<ul>
+  <li><code>list_records</code></li>
+  <li><code>create_record</code></li>
+  <li><code>update_record</code></li>
+  <li><code>delete_record</code></li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Timeout is visible in each request path</li>
+  <li>Write operations pass the header</li>
+  <li>Learner can explain the difference between timeout and validation failure</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 38)</h1>
+            <p><strong>⚠️</strong> No timeout</p>
+<p><strong>⚠️</strong> Forgetting headers on <code>PUT</code> or <code>DELETE</code></p>
+<p><strong>⚠️</strong> Copy-pasting base URLs everywhere</p>
+<p><strong>⚠️</strong> Swallowing errors with no visible message</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 38)</h1>
+            <ul>
+  <li>Homework goal: a reusable Python client for the tracker API</li>
+  <li>Best practice: wrap requests in small client functions</li>
+  <li>Pitfall to avoid: raw requests calls scattered everywhere</li>
+  <li>Quiz-ready anchor: <code>Hour 38 | client base url: http://localhost:5000</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What problem does <code>timeout=5</code> solve that a successful happy-path demo might hide?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 39: Integration Choice</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Describe two valid integration patterns</li>
+  <li>Choose the safer path for the current project state</li>
+  <li>Prove the system stays coherent</li>
+  <li>Explain tradeoffs clearly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Two Valid Paths</h1>
+            <h3>Option A: GUI talks to API</h3>
+<pre data-lang="text"><code>GUI -&gt; client functions -&gt; API -&gt; service -&gt; repository -&gt; database</code></pre>
+<h3>Option B: Parallel GUI and API</h3>
+<pre data-lang="text"><code>GUI -&gt; service -&gt; repository -&gt; database
+API -&gt; service -&gt; repository -&gt; database</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Important</h1>
+            <ul>
+  <li>Both are valid in this course</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Option A: GUI to API</h1>
+            <h3>Benefits</h3>
+<ul>
+  <li>One outward-facing contract</li>
+  <li>GUI exercises the same HTTP behavior as other clients</li>
+  <li>Good practice for decoupled systems</li>
+</ul>
+<h3>Tradeoffs</h3>
+<ul>
+  <li>More moving parts</li>
+  <li>More failure points</li>
+  <li>GUI must handle network-style issues</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Option B: Parallel GUI and API</h1>
+            <h3>Benefits</h3>
+<ul>
+  <li>Faster to stabilize</li>
+  <li>Lower integration friction</li>
+  <li>Still demonstrates architecture reuse</li>
+</ul>
+<h3>Tradeoffs</h3>
+<ul>
+  <li>GUI does not exercise the HTTP contract directly</li>
+  <li>Fields and behavior can drift if discipline slips</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>How to Choose Well</h1>
+            <ul>
+  <li>If the API and client are stable, Option A is reasonable</li>
+  <li>If the project still feels shaky, Option B often protects the milestone better</li>
+  <li>Choosing the safer path is a <strong>professional decision</strong>, not a weaker one</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Integration Sprint</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Choose Option A or B intentionally</li>
+  <li>Document the choice briefly</li>
+  <li>Prove both surfaces touch the same underlying data</li>
+  <li>Fix at least one mismatch if it appears</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>The architecture choice is explicit</li>
+  <li>The system still looks like <strong>one</strong> application</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 39)</h1>
+            <p><strong>⚠️</strong> GUI and API using different field names</p>
+<p><strong>⚠️</strong> Stale GUI data after writes</p>
+<p><strong>⚠️</strong> Accidentally creating two database files</p>
+<p><strong>⚠️</strong> Drifting into a hybrid design nobody can explain</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 39)</h1>
+            <ul>
+  <li>Homework goal: an integration story that connects the interface to the API cleanly</li>
+  <li>Best practice: pick one path and document the communication flow</li>
+  <li>Pitfall to avoid: parallel flows without a clear source of truth</li>
+  <li>Quiz-ready anchor: <code>Hour 39 | chosen path: gui talks to api</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: When would Option B be the smarter choice even if Option A feels more impressive?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 40: Checkpoint 5 — API Milestone Demo</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Demonstrate a working API backed by SQLite</li>
+  <li>Show security and error handling in action</li>
+  <li>Explain the layer connections</li>
+  <li>Identify the weakest part of the milestone honestly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>What Counts as Success</h1>
+            <ul>
+  <li>Flask API with CRUD routes</li>
+  <li>SQLite-backed persistence</li>
+  <li>Consistent JSON errors</li>
+  <li>API key protection on write operations</li>
+  <li>Optional Python client if available</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Reminder</h1>
+            <ul>
+  <li>Today rewards stability more than feature count</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Fast-Grade Demo Sequence</h1>
+            <ol>
+  <li><code>GET /health</code></li>
+  <li><code>GET /records</code></li>
+  <li><code>POST /records</code> with valid key</li>
+  <li><code>PUT /records/&lt;id&gt;</code> with valid key</li>
+  <li><code>DELETE /records/&lt;id&gt;</code> with valid key</li>
+  <li>one missing or invalid key failure</li>
+  <li>one invalid input or not-found failure</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Stabilization Checklist</h1>
+            <pre data-lang="text"><code>[ ] API starts reliably
+[ ] /health returns JSON
+[ ] Create returns 201
+[ ] Update returns 200
+[ ] Delete returns 200
+[ ] Invalid input returns 400 JSON
+[ ] Missing/wrong key returns 401/403 JSON
+[ ] Data persists in SQLite</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Rehearsal Mindset</h1>
+            <ul>
+  <li>Confirm payloads before demo time</li>
+  <li>Confirm headers before demo time</li>
+  <li>Confirm database path before demo time</li>
+  <li>Reproduce failures intentionally</li>
+  <li>Fix the weakest route first</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope guardrail</h1>
+            <ul>
+  <li>Stabilize before adding any “nice-to-have” endpoint</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Failure Modes</h1>
+            <p><strong>⚠️</strong> HTML error page instead of JSON</p>
+<p><strong>⚠️</strong> One write route forgot the API key check</p>
+<p><strong>⚠️</strong> Service exceptions leaking uncaught</p>
+<p><strong>⚠️</strong> Payload shape not matching parser rules</p>
+<p><strong>⚠️</strong> Different database paths in different environments</p>
+        </section>
+
+        <section class="slide">
+            <h1>Showcase Prompt</h1>
+            <ul>
+  <li>Show one healthy path</li>
+  <li>Show one protected failure</li>
+  <li>Explain the architecture in one minute</li>
+  <li>Name the most fragile part honestly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Good demo standard</h1>
+            <ul>
+  <li>believable</li>
+  <li>repeatable</li>
+  <li>explainable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 40)</h1>
+            <ul>
+  <li>Homework goal: a checkpoint demo showing the secured API and client path</li>
+  <li>Best practice: checkpoint the full request flow from caller to response</li>
+  <li>Pitfall to avoid: proving only one endpoint and calling it a milestone</li>
+  <li>Quiz-ready anchor: <code>Hour 40 | api demo health: ok</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What makes an API milestone feel maintainable, not just functional?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 10 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>End-of-Day Evidence</h1>
+            <ul>
+  <li>Key-based protection is working</li>
+  <li>Client code can consume the API safely</li>
+  <li>Integration choice is deliberate</li>
+  <li>Checkpoint 5 can be demoed without guesswork</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Homework Focus</h1>
+            <ul>
+  <li>Keep output deterministic in <code>Advanced_Day10_homework.ipynb</code></li>
+  <li>Rehearse the anchor lines:</li>
+  <li style="margin-left: 30px;"><code>protected route: POST /tasks</code></li>
+  <li style="margin-left: 30px;"><code>client base url: http://localhost:5000</code></li>
+  <li style="margin-left: 30px;"><code>chosen path: gui talks to api</code></li>
+  <li style="margin-left: 30px;"><code>api demo health: ok</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Exit Ticket</h1>
+            <ol>
+  <li>Which endpoint is strongest in your demo flow?</li>
+  <li>What did the client reveal about your API?</li>
+  <li>Which architecture choice did you make — and why?</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Looking Ahead</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Next Session</h1>
+            <ul>
+  <li>Turn stored data into summaries</li>
+  <li>Build report-ready charts</li>
+  <li>Try a limited regression workflow or fallback analysis</li>
+  <li>Add analytics as a real capstone feature</li>
+</ul>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/slides/advanced/day-11/day-11-session-11.html
+++ b/slides/advanced/day-11/day-11-session-11.html
@@ -1,0 +1,1125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 11 — Session 11 (Hours 41–44)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 11 — Session 11 (Hours 41–44)</h1>
+            <div class="subtitle">Python Programming (Advanced) • Analytics, Visualization, and Reporting</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 11 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 41: pandas essentials — loading, cleaning, summarizing</li>
+  <li>Hour 42: visualization with matplotlib</li>
+  <li>Hour 43: regression demo or equivalent analysis</li>
+  <li>Hour 44: integrate analytics into the capstone</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day Goal</h1>
+            <ul>
+  <li>Turn capstone data into a repeatable reporting pipeline</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Alignment Sources</h1>
+            <ul>
+  <li>Runbook: <code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → Session 11 overview; Hours 41–44</li>
+  <li>Lecture: <code>Advanced/lessons/lecture/Day11_Hour1_Advanced.md</code> through <code>Day11_Hour4_Advanced.md</code></li>
+  <li>Homework: <code>Advanced/assignments/Advanced_Day11_homework.ipynb</code></li>
+  <li>Quiz: <code>Advanced/quizzes/Advanced_Day11_Quiz.html</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Theme</h1>
+            <ul>
+  <li>Use the <strong>same dataset</strong> all day</li>
+  <li>Clean before trusting</li>
+  <li>Visualize with intention</li>
+  <li>Package analytics as a feature, not a notebook fragment</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Success Criteria</h1>
+            <ul>
+  <li>Exported data loads into pandas cleanly</li>
+  <li>At least one summary artifact is saved</li>
+  <li>At least one readable chart lands in <code>reports/</code></li>
+  <li>Analysis stays within course scope</li>
+  <li>Report generation becomes repeatable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            <ul>
+  <li>Start from the capstone dataset when possible</li>
+  <li>Do not force machine learning if the data does not fit</li>
+  <li>A clear summary + one strong chart beats a flashy but shallow notebook</li>
+  <li>Repeatability matters more than manual heroics</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 41: pandas Essentials</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Load capstone data into a DataFrame</li>
+  <li>Inspect shape, columns, and types</li>
+  <li>Clean common data issues</li>
+  <li>Compute useful summaries and grouped counts</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>The Analytics Mindset</h1>
+            <ul>
+  <li>We are not leaving the capstone behind</li>
+  <li>We are adding a reporting lens to the same project</li>
+  <li>Strong analysis starts with:</li>
+  <li style="margin-left: 30px;">inspection</li>
+  <li style="margin-left: 30px;">cleaning</li>
+  <li style="margin-left: 30px;">simple, honest summaries</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day 11 reminder</h1>
+            <ul>
+  <li>Use the same dataset from Hour 41 through Hour 44</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>First Inspection Steps</h1>
+            <pre data-lang="python"><code>import pandas as pd
+
+df = pd.read_csv(&quot;reports/records_export.csv&quot;)
+print(df.head())
+print(df.shape)
+print(df.dtypes)
+print(df.isna().sum())</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Habit</h1>
+            <ul>
+  <li>Inspect before you interpret</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Cleaning Moves</h1>
+            <pre data-lang="python"><code>df[&quot;category&quot;] = df[&quot;category&quot;].str.strip().str.lower()
+df[&quot;priority&quot;] = pd.to_numeric(df[&quot;priority&quot;], errors=&quot;coerce&quot;)
+df[&quot;status&quot;] = df[&quot;status&quot;].fillna(&quot;unknown&quot;)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Typical issues</h1>
+            <ul>
+  <li>whitespace</li>
+  <li>missing values</li>
+  <li>numeric strings</li>
+  <li>inconsistent casing</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Summary Patterns Worth Starting With</h1>
+            <ul>
+  <li>total row count</li>
+  <li>counts by category</li>
+  <li>counts by status</li>
+  <li>mean or sum of a numeric field</li>
+</ul>
+<pre data-lang="python"><code>summary = df.groupby(&quot;status&quot;).size().reset_index(name=&quot;count&quot;)
+print(summary)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Flow: Load, Clean, Summarize</h1>
+            <ol>
+  <li>Load exported data</li>
+  <li>Inspect <code>head()</code>, <code>shape</code>, and <code>dtypes</code></li>
+  <li>Make one explainable cleaning choice</li>
+  <li>Group and summarize</li>
+  <li>Save a reusable summary artifact</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Build the First Analytics Pass</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Locate or export one CSV</li>
+  <li>Load it into pandas</li>
+  <li>Inspect the structure</li>
+  <li>Make at least one cleaning decision</li>
+  <li>Compute at least three metrics</li>
+  <li>Save a summary CSV into <code>reports/</code></li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Learner can explain one cleaning choice</li>
+  <li>Summary artifact is saved and reusable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 41)</h1>
+            <p><strong>⚠️</strong> Analyzing before inspecting</p>
+<p><strong>⚠️</strong> Cleaning data in ways you cannot explain</p>
+<p><strong>⚠️</strong> Ignoring missing values</p>
+<p><strong>⚠️</strong> Forgetting to save the summary artifact</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 41)</h1>
+            <ul>
+  <li>Homework goal: a small cleaned DataFrame with labeled summary outputs</li>
+  <li>Best practice: normalize and clean before trusting counts</li>
+  <li>Pitfall to avoid: summarizing dirty data hides real problems</li>
+  <li>Quiz-ready anchor: <code>Hour 41 | dataframe rows: 5</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What can <code>df.dtypes</code> reveal before you compute a single summary?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 42: Visualization with Matplotlib</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Create at least one readable chart</li>
+  <li>Label title and axes clearly</li>
+  <li>Save plots into <code>reports/</code></li>
+  <li>Avoid common figure-management mistakes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Chart Design Matters</h1>
+            <ul>
+  <li>A chart is a compressed explanation</li>
+  <li>If the labels are weak, the chart stops helping</li>
+  <li>Good plots should stand on their own without narration</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Minimum readability checklist</h1>
+            <ul>
+  <li>title</li>
+  <li>x-axis label</li>
+  <li>y-axis label</li>
+  <li>readable categories</li>
+  <li>saved artifact path</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Start from Aggregated Data</h1>
+            <ul>
+  <li>Counts by category are often a strong first chart</li>
+  <li>Counts by status are usually easy to explain</li>
+  <li>Time-based summaries can support line charts later</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Practical rule</h1>
+            <ul>
+  <li>Plot the <strong>summary</strong>, not the raw noise</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Bar Chart Pattern</h1>
+            <pre data-lang="python"><code>import matplotlib.pyplot as plt
+
+plt.figure(figsize=(8, 4))
+plt.bar(summary[&quot;category&quot;], summary[&quot;count&quot;])
+plt.title(&quot;Records by Category&quot;)
+plt.xlabel(&quot;Category&quot;)
+plt.ylabel(&quot;Count&quot;)
+plt.xticks(rotation=45, ha=&quot;right&quot;)
+plt.tight_layout()
+plt.savefig(&quot;reports/category_counts.png&quot;)
+plt.close()</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Chart Choice Is Communication</h1>
+            <ul>
+  <li>Bar chart → category comparisons</li>
+  <li>Line chart → trend over time</li>
+  <li>Choose the chart that matches the question</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Teaching point</h1>
+            <ul>
+  <li>Plotting is not just syntax; it is storytelling</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Save a Report-Ready Plot</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Reuse a cleaned dataset or summary</li>
+  <li>Create at least one chart</li>
+  <li>Label title + axes</li>
+  <li>Save the artifact into <code>reports/</code></li>
+  <li>Open the file and confirm readability</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Another learner can understand the plot quickly</li>
+  <li>The saved file works as a reusable artifact</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 42)</h1>
+            <p><strong>⚠️</strong> Unlabeled axes</p>
+<p><strong>⚠️</strong> Overlapping category labels</p>
+<p><strong>⚠️</strong> Plotting raw data when a summary would be clearer</p>
+<p><strong>⚠️</strong> Forgetting <code>tight_layout()</code> or <code>plt.close()</code></p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 42)</h1>
+            <ul>
+  <li>Homework goal: a saved matplotlib chart that supports the tracker report</li>
+  <li>Best practice: clear labels, titles, and saved artifact path</li>
+  <li>Pitfall to avoid: an unlabeled chart communicates very little</li>
+  <li>Quiz-ready anchor: <code>Hour 42 | chart type: bar</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is saving the plot to <code>reports/</code> better than leaving it only inside a notebook session?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 43: Regression Demo or Equivalent Analysis</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain when regression makes sense</li>
+  <li>Describe why train/test split matters</li>
+  <li>Run one small predictive workflow if appropriate</li>
+  <li>Use a fallback analysis if the data does not support regression</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrail</h1>
+            <ul>
+  <li>We are <strong>not</strong> becoming ML engineers in one hour</li>
+  <li>This is a limited workflow demo</li>
+  <li>The runbook explicitly allows a fallback analysis</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Smart decision</h1>
+            <ul>
+  <li>If the dataset does not fit, do more honest analysis instead</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>When Regression Makes Sense</h1>
+            <ul>
+  <li>Target must be numeric</li>
+  <li>Features should be numeric and clean enough</li>
+  <li>The question should genuinely involve prediction</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Keep evaluation simple</h1>
+            <ul>
+  <li>One metric is enough for today</li>
+  <li>Explain the result in plain language</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Tiny Workflow Example</h1>
+            <pre data-lang="python"><code>from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_absolute_error
+from sklearn.model_selection import train_test_split
+
+X = df[[&quot;priority&quot;]]
+y = df[&quot;hours_to_complete&quot;]
+
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, random_state=42
+)
+
+model = LinearRegression()
+model.fit(X_train, y_train)
+predictions = model.predict(X_test)
+mae = mean_absolute_error(y_test, predictions)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>What This Demo Is Really Teaching</h1>
+            <ul>
+  <li>Prepare features + target</li>
+  <li>Hold back test data</li>
+  <li>Fit a model</li>
+  <li>Predict on unseen data</li>
+  <li>Report one metric honestly</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>If regression is a bad fit</h1>
+            <ul>
+  <li>Add another summary</li>
+  <li>Add another chart</li>
+  <li>Explain why the fallback is better</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Predictive Slice or Honest Fallback</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Decide whether the data supports regression</li>
+  <li>Run the workflow or choose fallback analysis</li>
+  <li>Report one metric or observation</li>
+  <li>Write one sentence explaining the result</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Learner can justify the method choice</li>
+  <li>The outcome is explained in plain language</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 43)</h1>
+            <p><strong>⚠️</strong> Forcing regression onto non-numeric data</p>
+<p><strong>⚠️</strong> Treating the demo as production-ready analytics</p>
+<p><strong>⚠️</strong> Skipping cleaning and blaming the tool</p>
+<p><strong>⚠️</strong> Reporting a metric without explaining it</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 43)</h1>
+            <ul>
+  <li>Homework goal: a simple regression example with one labeled prediction</li>
+  <li>Best practice: keep the forecast practical and limited</li>
+  <li>Pitfall to avoid: overstating a quick demo as production-ready analytics</li>
+  <li>Quiz-ready anchor: <code>Hour 43 | model: linear regression</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: Why is “regression is not the right fit here” sometimes the most advanced answer?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 44: Integrate Analytics into the Capstone</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Add a report-generation path to the capstone</li>
+  <li>Produce export, summary, and chart artifacts repeatably</li>
+  <li>Document how the report runs</li>
+  <li>Treat analytics as part of the product</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Analytics as a Feature</h1>
+            <ul>
+  <li>The capstone should not only store data</li>
+  <li>It should also summarize and communicate data intentionally</li>
+  <li>A report feature turns analysis into something reusable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Product mindset</h1>
+            <ul>
+  <li>one command</li>
+  <li>or one button</li>
+  <li>same cleaned pipeline every time</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Repeatable Report Pipeline</h1>
+            <ol>
+  <li>export data</li>
+  <li>load + clean data</li>
+  <li>compute summaries</li>
+  <li>generate charts</li>
+  <li>save artifacts to <code>reports/</code></li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Anti-pattern</h1>
+            <ul>
+  <li>hidden manual steps between those stages</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Example Entry Point</h1>
+            <pre data-lang="python"><code>from reports.export_data import export_records_csv
+from reports.analyze import build_summary
+from reports.plotting import create_plots
+
+def main():
+    csv_path = export_records_csv()
+    summary_path = build_summary(csv_path)
+    create_plots(summary_path)
+    print(&quot;Report artifacts generated in reports/&quot;)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Add the Report Feature</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create or refine an export step</li>
+  <li>Generate a summary table</li>
+  <li>Save at least one chart</li>
+  <li>Put outputs in <code>reports/</code></li>
+  <li>Document how to run the feature</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Another learner could trigger the report tomorrow</li>
+  <li>Artifacts appear in predictable places</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 44)</h1>
+            <p><strong>⚠️</strong> Hard-coded paths that work on only one machine</p>
+<p><strong>⚠️</strong> Report logic scattered across scripts and notebooks</p>
+<p><strong>⚠️</strong> Missing README guidance</p>
+<p><strong>⚠️</strong> Hand-edited intermediate files</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 44)</h1>
+            <ul>
+  <li>Homework goal: a report feature that connects data outputs to the tracker project</li>
+  <li>Best practice: combine summaries, charts, and predictions into one readable feature</li>
+  <li>Pitfall to avoid: disconnected notebook snippets weaken the capstone</li>
+  <li>Quiz-ready anchor: <code>Hour 44 | report file: reports/weekly_summary.txt</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What makes a report feature repeatable instead of “works when I remember the steps”?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 11 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>End-of-Day Evidence</h1>
+            <ul>
+  <li>Data is loaded and cleaned intentionally</li>
+  <li>Summaries answer real questions</li>
+  <li>Charts are readable and saved</li>
+  <li>The capstone now has a report-generation path</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Homework Focus</h1>
+            <ul>
+  <li>Keep outputs deterministic in <code>Advanced_Day11_homework.ipynb</code></li>
+  <li>Rehearse the anchor lines:</li>
+  <li style="margin-left: 30px;"><code>dataframe rows: 5</code></li>
+  <li style="margin-left: 30px;"><code>chart type: bar</code></li>
+  <li style="margin-left: 30px;"><code>model: linear regression</code></li>
+  <li style="margin-left: 30px;"><code>report file: reports/weekly_summary.txt</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Exit Ticket</h1>
+            <ol>
+  <li>Which cleaning decision changed your analysis most?</li>
+  <li>What question does your chart answer?</li>
+  <li>Is regression the right fit for your data — why or why not?</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Looking Ahead</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Next Session</h1>
+            <ul>
+  <li>Lock in quality with pytest</li>
+  <li>Use coverage strategically</li>
+  <li>Package the project for handoff</li>
+  <li>Finish with a final capstone demo and reflection</li>
+</ul>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/slides/advanced/day-12/day-12-session-12.html
+++ b/slides/advanced/day-12/day-12-session-12.html
@@ -1,0 +1,1080 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced Day 12 — Session 12 (Hours 45–48)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+            
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+            
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+            
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+        
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+        
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+        
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+        
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+        
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+        
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+        
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+        
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+        
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+        
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+        
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+        
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+        
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+        
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+        
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+        
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+         
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+        
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+        
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+        
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+        
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+        
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+        
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+        
+        #nav-hint:hover {
+            opacity: 1;
+        }
+        
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+        
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+        
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+            
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+            
+            .slide h1 {
+                font-size: 2rem;
+            }
+            
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+            
+            p, li {
+                font-size: 1rem;
+            }
+        }
+        
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+        
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+        
+        em, i {
+            font-style: italic;
+        }
+        
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+        
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+        
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+        
+        <section class="slide title-slide">
+            <h1>Advanced Day 12 — Session 12 (Hours 45–48)</h1>
+            <div class="subtitle">Python Programming (Advanced) • Testing, Packaging, and Final Delivery</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 12 Overview</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Topics Covered Today</h1>
+            <ul>
+  <li>Hour 45: testing with pytest for the service layer</li>
+  <li>Hour 46: coverage, edge cases, and a lightweight integration test</li>
+  <li>Hour 47: packaging and delivery</li>
+  <li>Hour 48: final capstone demo, certification-style review, and retrospective</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day Goal</h1>
+            <ul>
+  <li>Finish the capstone with quality, delivery confidence, and explanation clarity</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Alignment Sources</h1>
+            <ul>
+  <li>Runbook: <code>Advanced/Instructor/Python_Advanced_Instructor_Runbook_4hr_Days.md</code> → Session 12 overview; Hours 45–48</li>
+  <li>Lecture: <code>Advanced/lessons/lecture/Day12_Hour1_Advanced.md</code> through <code>Day12_Hour4_Advanced.md</code></li>
+  <li>Homework: <code>Advanced/assignments/Advanced_Day12_homework.ipynb</code></li>
+  <li>Quiz: <code>Advanced/quizzes/Advanced_Day12_Quiz.html</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Theme</h1>
+            <ul>
+  <li>Quality supports confidence</li>
+  <li>Packaging supports handoff</li>
+  <li>The final demo should show a system, not random features</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Session Success Criteria</h1>
+            <ul>
+  <li>Core service behavior is covered by pytest tests</li>
+  <li>Coverage is used as a guide, not a vanity metric</li>
+  <li>README + requirements support a fresh-run test</li>
+  <li>Final demos show architecture, persistence, analytics, and growth</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Scope Guardrails for Today</h1>
+            <ul>
+  <li>Prioritize service-layer and repository-confidence tests over UI testing</li>
+  <li>Do not chase 100% coverage blindly</li>
+  <li>Package the runnable source release before optional executables</li>
+  <li>Final demos should be concise, stable, and explainable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 45: Testing with pytest</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Write focused service-layer unit tests</li>
+  <li>Use fixtures and plain <code>assert</code></li>
+  <li>Cover success and failure paths</li>
+  <li>Explain why UI testing is not the priority here</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Why Testing Fits Here</h1>
+            <ul>
+  <li>The capstone now has enough structure to test meaningfully</li>
+  <li>Service logic and exception patterns are stable enough to protect</li>
+  <li>Testing now reinforces quality instead of chasing a moving target</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Framing</h1>
+            <ul>
+  <li>Tests are fast feedback</li>
+  <li>Tests are not punishment</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>pytest Basics</h1>
+            <ul>
+  <li>Plain test functions stay readable</li>
+  <li>Arrange → Act → Assert is enough structure</li>
+  <li>Fixtures reduce repeated setup</li>
+  <li>Negative tests matter as much as happy paths</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Fixture + Test Pattern</h1>
+            <pre data-lang="python"><code>@pytest.fixture
+def service():
+    repo = InMemoryTrackerRepository()
+    return TrackerService(repo=repo)
+
+def test_add_and_get_record(service):
+    created = service.add_record(&quot;Write report&quot;, &quot;ops&quot;, &quot;open&quot;)
+    fetched = service.get_record(created.id)
+    assert fetched.title == &quot;Write report&quot;</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Negative Test Pattern</h1>
+            <pre data-lang="python"><code>def test_add_record_rejects_empty_title(service):
+    with pytest.raises(ValidationError):
+        service.add_record(&quot;&quot;, &quot;ops&quot;, &quot;open&quot;)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Teaching point</h1>
+            <ul>
+  <li>Good tests protect behaviors learners actually care about</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Write the First Real Test Suite</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Create a test file such as <code>tests/test_service.py</code></li>
+  <li>Add at least five tests</li>
+  <li>Include at least two negative tests</li>
+  <li>Run pytest and confirm the suite passes</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Test names communicate the behavior clearly</li>
+  <li>The suite focuses on logic, not UI callbacks</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 45)</h1>
+            <p><strong>⚠️</strong> Testing UI callbacks directly</p>
+<p><strong>⚠️</strong> One test checking too many behaviors</p>
+<p><strong>⚠️</strong> Shared mutable state without reset</p>
+<p><strong>⚠️</strong> Happy-path-only thinking</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 45)</h1>
+            <ul>
+  <li>Homework goal: a small pytest suite for core service-layer rules</li>
+  <li>Best practice: focused unit tests around behavior and validation</li>
+  <li>Pitfall to avoid: testing private implementation details</li>
+  <li>Quiz-ready anchor: <code>Hour 45 | test runner: pytest</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What should a strong unit test avoid if you want refactors to stay safe?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 46: Coverage + Edge Cases + Integration</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Run a basic coverage report</li>
+  <li>Find high-value gaps</li>
+  <li>Add edge-case tests</li>
+  <li>Prove one meaningful boundary with an integration-style test</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Coverage with Perspective</h1>
+            <ul>
+  <li>Coverage shows which lines executed</li>
+  <li>Coverage does <strong>not</strong> prove the tests are meaningful</li>
+  <li>Use it as a flashlight, not a scorecard</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Smart question</h1>
+            <ul>
+  <li>Which uncovered branch is most likely to matter in a real bug?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Coverage Commands</h1>
+            <pre data-lang="bash"><code>coverage run -m pytest
+coverage report -m</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Great edge-case candidates</h1>
+            <ul>
+  <li>missing record</li>
+  <li>invalid input</li>
+  <li>empty search result</li>
+  <li>auth helper failure</li>
+  <li>duplicate ID assumptions</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lightweight Integration Test</h1>
+            <pre data-lang="python"><code>def test_service_and_sqlite_repo_work_together(tmp_path):
+    db_path = tmp_path / &quot;tracker.db&quot;
+    repo = SQLiteTrackerRepository(str(db_path))
+    repo.init_db()
+    service = TrackerService(repo=repo)
+
+    created = service.add_record(&quot;Ship deck&quot;, &quot;training&quot;, &quot;open&quot;)
+    fetched = service.get_record(created.id)
+
+    assert fetched.title == &quot;Ship deck&quot;</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Harden the Suite</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Run coverage</li>
+  <li>Identify at least two valuable missing branches</li>
+  <li>Add two tests for those branches</li>
+  <li>Add one integration-style test</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Coverage changes testing priorities intelligently</li>
+  <li>Integration proves a real boundary, not a giant workflow</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 46)</h1>
+            <p><strong>⚠️</strong> Chasing 100% blindly</p>
+<p><strong>⚠️</strong> Executing code without useful assertions</p>
+<p><strong>⚠️</strong> Turning one integration test into an end-to-end maze</p>
+<p><strong>⚠️</strong> Adding coverage numbers without discussing risk</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 46)</h1>
+            <ul>
+  <li>Homework goal: a tighter test suite with edge-case and integration confidence</li>
+  <li>Best practice: add edge cases and one lightweight integration test after unit tests pass</li>
+  <li>Pitfall to avoid: chasing a number instead of meaningful scenarios</li>
+  <li>Quiz-ready anchor: <code>Hour 46 | coverage target: service layer</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: How can high coverage still miss real bugs?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 47: Packaging and Delivery</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Explain the difference between “runs here” and “ships”</li>
+  <li>Refine <code>README.md</code>, <code>requirements.txt</code>, and <code>requirements-dev.txt</code></li>
+  <li>Perform a fresh-run smoke test</li>
+  <li>Identify hidden dependency or path assumptions</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>What Shipping Really Means</h1>
+            <ul>
+  <li>Repeatable install</li>
+  <li>Repeatable run</li>
+  <li>Honest documentation</li>
+  <li>Clear entry point</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Course minimum</h1>
+            <ul>
+  <li>A runnable source release</li>
+  <li>Optional packaging extras only if time permits</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Deliverable Recipe</h1>
+            <ul>
+  <li><code>README.md</code> with exact setup + run steps</li>
+  <li><code>requirements.txt</code> for runtime dependencies</li>
+  <li><code>requirements-dev.txt</code> for dev tooling</li>
+  <li><code>.gitignore</code> for environment and build outputs</li>
+  <li>one verified entry point</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Fresh-Run Sequence</h1>
+            <pre data-lang="bash"><code>python -m venv .venv
+.venv\Scripts\activate
+python -m pip install -r requirements.txt
+python -m pytest
+python api/app.py</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Teaching point</h1>
+            <ul>
+  <li>If the steps are not written clearly, the deliverable is weaker than it looks</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Lab: Make the Project Shareable</h1>
+            <p><strong>Time: 25–35 minutes</strong></p>
+<h3>Tasks</h3>
+<ul>
+  <li>Update <code>README.md</code></li>
+  <li>Verify runtime and dev dependencies</li>
+  <li>Check <code>.gitignore</code></li>
+  <li>Perform a fresh-run smoke test</li>
+  <li>Fix one missing setup step if discovered</li>
+</ul>
+<h3>Completion Criteria</h3>
+<ul>
+  <li>Another learner could follow the setup without guessing</li>
+  <li>Entry points and environment variables are documented</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfalls (Hour 47)</h1>
+            <p><strong>⚠️</strong> Missing dependency in <code>requirements.txt</code></p>
+<p><strong>⚠️</strong> Undocumented environment variables</p>
+<p><strong>⚠️</strong> Entry-point confusion between GUI, API, and scripts</p>
+<p><strong>⚠️</strong> Relative paths that only work from one folder</p>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 47)</h1>
+            <ul>
+  <li>Homework goal: a documented runnable delivery package for the capstone</li>
+  <li>Best practice: package the runnable app before optional build tooling</li>
+  <li>Pitfall to avoid: spending all packaging time on an executable</li>
+  <li>Quiz-ready anchor: <code>Hour 47 | requirements file: ready</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What does a fresh-run test reveal that “it works on my machine” usually hides?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 48: Final Demo + Review + Retrospective</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Demonstrate the minimum capstone deliverables clearly</li>
+  <li>Explain architecture choices and tradeoffs</li>
+  <li>Practice certification-style code reading</li>
+  <li>Name one next step for continued growth</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Capstone Minimum Deliverables</h1>
+            <ul>
+  <li>model + service layer</li>
+  <li>SQLite persistence</li>
+  <li>one interface surface: GUI or API</li>
+  <li>analytics/reporting</li>
+  <li>tests</li>
+  <li>packaging readiness</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Final-hour mindset</h1>
+            <ul>
+  <li>coherence over perfection</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Strong Demo Flow</h1>
+            <ol>
+  <li>one-sentence problem statement</li>
+  <li>create or retrieve data</li>
+  <li>show persistence</li>
+  <li>show interface surface</li>
+  <li>show one analytics/report artifact</li>
+  <li>mention testing or packaging evidence</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Timebox</h1>
+            <ul>
+  <li>aim for 3–5 minutes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Questions Worth Answering During Demos</h1>
+            <ul>
+  <li>Why did you choose this architecture?</li>
+  <li>What part was hardest to stabilize?</li>
+  <li>What tradeoff did you make intentionally?</li>
+  <li>What would you improve next?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Coaching note</h1>
+            <ul>
+  <li>Bring the story back to user flow + architecture if details take over</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Certification-Style Review Prompt</h1>
+            <pre data-lang="python"><code>class Tracker:
+    def __init__(self):
+        self.items = []
+
+    def add(self, item):
+        self.items.append(item)
+
+t = Tracker()
+t.add(&quot;alpha&quot;)
+print(len(t.items))</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Ask</h1>
+            <ul>
+  <li>What prints?</li>
+  <li>Why?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Retrospective Prompts</h1>
+            <ul>
+  <li>What can you do now that you could not do before?</li>
+  <li>What still feels shaky but understandable?</li>
+  <li>What will you practice next while the material is fresh?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Ask learners to capture</h1>
+            <ol>
+  <li>one skill to apply immediately</li>
+  <li>one skill to keep practicing</li>
+  <li>one artifact they are proud of</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Homework + Quiz Emphasis (Hour 48)</h1>
+            <ul>
+  <li>Homework goal: a final capstone walkthrough and certification-style review summary</li>
+  <li>Best practice: connect the whole course back to one coherent architecture</li>
+  <li>Pitfall to avoid: a demo without reflection</li>
+  <li>Quiz-ready anchor: <code>Hour 48 | final demo domain: tracker</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quick Check</h1>
+            <p><strong>Question</strong>: What makes a final demo convincing even if the project is not perfect?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Day 12 Wrap-Up</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>End-of-Day Evidence</h1>
+            <ul>
+  <li>Tests protect core behavior</li>
+  <li>Coverage informs smarter improvements</li>
+  <li>Packaging supports a clean handoff</li>
+  <li>The final demo proves understanding, not just feature count</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Homework Focus</h1>
+            <ul>
+  <li>Keep outputs deterministic in <code>Advanced_Day12_homework.ipynb</code></li>
+  <li>Rehearse the anchor lines:</li>
+  <li style="margin-left: 30px;"><code>test runner: pytest</code></li>
+  <li style="margin-left: 30px;"><code>coverage target: service layer</code></li>
+  <li style="margin-left: 30px;"><code>requirements file: ready</code></li>
+  <li style="margin-left: 30px;"><code>final demo domain: tracker</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Final Exit Ticket</h1>
+            <ol>
+  <li>Which test gives you the most confidence?</li>
+  <li>What did the fresh-run test teach you?</li>
+  <li>What part of your capstone best shows your growth?</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Course Close</h1>
+            
+        </section>
+
+        <section class="slide">
+            <h1>You Can Now</h1>
+            <ul>
+  <li>design layered Python applications</li>
+  <li>persist and query data</li>
+  <li>expose and consume APIs</li>
+  <li>build analytics/reporting paths</li>
+  <li>test core logic</li>
+  <li>package a runnable deliverable</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Next step</h1>
+            <ul>
+  <li>keep the capstone alive through one deliberate improvement</li>
+</ul>
+        </section>
+    </div>
+    
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+    
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+        
+        // Initialize
+        totalCounter.textContent = totalSlides;
+        
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+            
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+            
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+            
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+            
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+        
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+        
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+        
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+        
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+        
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+        
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+        
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+        
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+        
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add complete Advanced day slide decks for days 1-12 under `Advanced/lessons/slides`
- align the new decks to the existing course structure and the Advanced runbook, lecture notes, homework, and quizzes
- update the Marp and workflow configuration so both Basics and Advanced slide sources build correctly

## Changes
- add 12 new Advanced slide-source decks, one 4-hour session deck per day
- narrow `.marprc.yml` to slide-source input and normalize `_site/slides` output paths
- update `.github/workflows/marp-action.yml` to build Advanced slides into `_site/slides/advanced`
- remove README artifact selection from the published slide landing logic and prefer real deck outputs

## Validation
- built Basics slides with Marp using `Basics/lessons/slides`
- built Advanced slides with Marp using `Advanced/lessons/slides`
- confirmed 12 Advanced source decks produced 12 Advanced HTML outputs locally