### PR TITLE
Add Basics Day 12 slide deck

### DIFF
--- a/Basics/generate_slides.py
+++ b/Basics/generate_slides.py
@@ -516,17 +516,15 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             }}
         }}
         
-        // Load slide from URL hash
-        window.addEventListener('load', () => {{
-            const hash = window.location.hash.slice(1);
-            if (hash) {{
-                const slideNum = parseInt(hash) - 1;
-                if (!isNaN(slideNum)) {{
-                    currentSlide = slideNum;
-                }}
+        // Load slide from URL hash immediately and clamp invalid values.
+        const hash = window.location.hash.slice(1);
+        if (hash) {{
+            const slideNum = parseInt(hash) - 1;
+            if (!isNaN(slideNum)) {{
+                currentSlide = Math.max(0, Math.min(slideNum, totalSlides - 1));
             }}
-            updateSlideDisplay(false);
-        }});
+        }}
+        updateSlideDisplay(false);
     </script>
 </body>
 </html>"""

--- a/Basics/lessons/slides/day-12/day-12-session-12.html
+++ b/Basics/lessons/slides/day-12/day-12-session-12.html
@@ -403,12 +403,8 @@
 
         <section class="slide">
             <h1>Day 12 Goal</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Finish With a Working Story</h1>
-            <ul>
+            <p><strong>Finish With a Working Story</strong></p>
+<ul>
   <li>Build a small command-line capstone project</li>
   <li>Save and load data with JSON in a <code>data/</code> folder</li>
   <li>Organize code with functions, modules, and at least one class</li>
@@ -419,21 +415,14 @@
 
         <section class="slide">
             <h1>Capstone Theme Choices</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Choose One CLI Personal Organizer</h1>
-            <ul>
+            <p><strong>Choose One CLI Personal Organizer</strong></p>
+<ul>
   <li>Tasks</li>
   <li>Contacts</li>
   <li>Notes</li>
 </ul>
-        </section>
-
-        <section class="slide">
-            <h1>Keep It Basics-Scope</h1>
-            <ul>
+<p><strong>Keep It Basics-Scope</strong></p>
+<ul>
   <li>No web frameworks</li>
   <li>No databases</li>
   <li>No GUI frameworks</li>
@@ -443,12 +432,8 @@
 
         <section class="slide">
             <h1>Required Capstone Features</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Minimum Requirements</h1>
-            <ul>
+            <p><strong>Minimum Requirements</strong></p>
+<ul>
   <li>Menu loop</li>
   <li>Functions split into modules</li>
   <li>At least one class</li>
@@ -464,22 +449,15 @@
 
         <section class="slide">
             <h1>Hour 45: Kickoff + Scaffold</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Learning Outcomes</h1>
-            <ul>
+            <p><strong>Learning Outcomes</strong></p>
+<ul>
   <li>Define capstone requirements</li>
   <li>Plan the first build steps</li>
   <li>Create the project skeleton</li>
   <li>Make one action work end to end</li>
 </ul>
-        </section>
-
-        <section class="slide">
-            <h1>Deliverable</h1>
-            <p>Skeleton + load/save + one CRUD action working.</p>
+<p><strong>Deliverable</strong></p>
+<p>Skeleton + load/save + one CRUD action working.</p>
         </section>
 
         <section class="slide">
@@ -558,31 +536,20 @@ def load_items():
 
         <section class="slide">
             <h1>Hour 46: Build Sprint</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Learning Outcomes</h1>
-            <ul>
+            <p><strong>Learning Outcomes</strong></p>
+<ul>
   <li>Complete the required CRUD feature set</li>
   <li>Improve UX and robustness</li>
   <li>Test features as they are added</li>
 </ul>
-        </section>
-
-        <section class="slide">
-            <h1>Build Order</h1>
-            <p>Add → list → search → update/delete → save/load retest</p>
+<p><strong>Build Order</strong></p>
+<p>Add → list → search → update/delete → save/load retest</p>
         </section>
 
         <section class="slide">
             <h1>Build Sprint Checklist</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Required Actions</h1>
-            <ul>
+            <p><strong>Required Actions</strong></p>
+<ul>
   <li>Add an item</li>
   <li>List items</li>
   <li>Search or view one item</li>
@@ -639,31 +606,20 @@ else:
 
         <section class="slide">
             <h1>Hour 47: Polish + Demo Readiness</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Learning Outcomes</h1>
-            <ul>
+            <p><strong>Learning Outcomes</strong></p>
+<ul>
   <li>Finalize capstone quality</li>
   <li>Prepare a short demo walkthrough</li>
   <li>Test from a fresh run</li>
 </ul>
-        </section>
-
-        <section class="slide">
-            <h1>Deliverable</h1>
-            <p>A project that runs cleanly from scratch and supports a demo flow in under 3 minutes.</p>
+<p><strong>Deliverable</strong></p>
+<p>A project that runs cleanly from scratch and supports a demo flow in under 3 minutes.</p>
         </section>
 
         <section class="slide">
             <h1>Polish Checklist</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Before Demo</h1>
-            <ul>
+            <p><strong>Before Demo</strong></p>
+<ul>
   <li>Prompts are clear</li>
   <li>Output is readable</li>
   <li>Invalid menu choices are handled</li>
@@ -680,12 +636,8 @@ else:
 
         <section class="slide">
             <h1>Demo Script</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Recommended Flow</h1>
-            <ol>
+            <p><strong>Recommended Flow</strong></p>
+<ol>
   <li>Start the program</li>
   <li>Add an item</li>
   <li>List items</li>
@@ -721,21 +673,14 @@ Features:
 
         <section class="slide">
             <h1>Hour 48: Final Assessment + Review</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Learning Outcomes</h1>
-            <ul>
+            <p><strong>Learning Outcomes</strong></p>
+<ul>
   <li>Demonstrate Basics competency end to end</li>
   <li>Explain project structure at a high level</li>
   <li>Identify next study targets</li>
 </ul>
-        </section>
-
-        <section class="slide">
-            <h1>Final Activities</h1>
-            <ul>
+<p><strong>Final Activities</strong></p>
+<ul>
   <li>Capstone demo + rubric scoring</li>
   <li>Short certification-style review</li>
   <li>Individual feedback</li>
@@ -778,12 +723,8 @@ Features:
 
         <section class="slide">
             <h1>Certification-Style Review Domains</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Review Agenda</h1>
-            <ul>
+            <p><strong>Review Agenda</strong></p>
+<ul>
   <li>Types + conversions</li>
   <li>Strings + formatting</li>
   <li>Data structures: list, tuple, set, dict</li>
@@ -796,12 +737,8 @@ Features:
 
         <section class="slide">
             <h1>Code Reading Practice</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Predict or Explain</h1>
-            <ul>
+            <p><strong>Predict or Explain</strong></p>
+<ul>
   <li>String slicing + <code>len()</code></li>
   <li>f-strings with numeric conversion</li>
   <li><code>range()</code> boundaries</li>
@@ -814,22 +751,15 @@ Features:
 
         <section class="slide">
             <h1>Final Exit Ticket</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Reflection Prompts</h1>
-            <ul>
+            <p><strong>Reflection Prompts</strong></p>
+<ul>
   <li>One concept I feel strong about is...</li>
   <li>One concept I should review is...</li>
   <li>One debugging habit I will keep using is...</li>
   <li>One improvement I would add to my capstone next is...</li>
 </ul>
-        </section>
-
-        <section class="slide">
-            <h1>Course Close</h1>
-            <p>You now have the full Basics toolkit for building small, useful Python programs.</p>
+<p><strong>Course Close</strong></p>
+<p>You now have the full Basics toolkit for building small, useful Python programs.</p>
         </section>
     </div>
 
@@ -947,17 +877,15 @@ Features:
             }
         }
 
-        // Load slide from URL hash
-        window.addEventListener('load', () => {
-            const hash = window.location.hash.slice(1);
-            if (hash) {
-                const slideNum = parseInt(hash) - 1;
-                if (!isNaN(slideNum)) {
-                    currentSlide = slideNum;
-                }
+        // Load slide from URL hash immediately and clamp invalid values.
+        const hash = window.location.hash.slice(1);
+        if (hash) {
+            const slideNum = parseInt(hash) - 1;
+            if (!isNaN(slideNum)) {
+                currentSlide = Math.max(0, Math.min(slideNum, totalSlides - 1));
             }
-            updateSlideDisplay(false);
-        });
+        }
+        updateSlideDisplay(false);
     </script>
 </body>
 </html>

--- a/Basics/lessons/slides/day-12/day-12-session-12.html
+++ b/Basics/lessons/slides/day-12/day-12-session-12.html
@@ -1,0 +1,963 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Basics Day 12 — Session 12 (Hours 45–48)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+
+        #nav-hint:hover {
+            opacity: 1;
+        }
+
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+
+            .slide h1 {
+                font-size: 2rem;
+            }
+
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+
+            p, li {
+                font-size: 1rem;
+            }
+        }
+
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+
+        em, i {
+            font-style: italic;
+        }
+
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+
+        <section class="slide title-slide">
+            <h1>Basics Day 12 — Session 12 (Hours 45–48)</h1>
+            <div class="subtitle">Python Programming (Basic) • Capstone Delivery and Final Review</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 12 Overview</h1>
+            <ul>
+  <li>Hour 45: Capstone kickoff — requirements + scaffolding</li>
+  <li>Hour 46: Capstone build sprint</li>
+  <li>Hour 47: Capstone polish + demo readiness</li>
+  <li>Hour 48: Final assessment + certification-style review</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day 12 Goal</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Finish With a Working Story</h1>
+            <ul>
+  <li>Build a small command-line capstone project</li>
+  <li>Save and load data with JSON in a <code>data/</code> folder</li>
+  <li>Organize code with functions, modules, and at least one class</li>
+  <li>Handle common input and file errors gracefully</li>
+  <li>Demo the project clearly in under 3 minutes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Capstone Theme Choices</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Choose One CLI Personal Organizer</h1>
+            <ul>
+  <li>Tasks</li>
+  <li>Contacts</li>
+  <li>Notes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Keep It Basics-Scope</h1>
+            <ul>
+  <li>No web frameworks</li>
+  <li>No databases</li>
+  <li>No GUI frameworks</li>
+  <li>No external packages required</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Required Capstone Features</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Minimum Requirements</h1>
+            <ul>
+  <li>Menu loop</li>
+  <li>Functions split into modules</li>
+  <li>At least one class</li>
+  <li>JSON persistence in a <code>data/</code> folder</li>
+  <li>Exception handling for input and file errors</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Today’s Rule</h1>
+            <p>Build the minimum viable product first, then polish.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 45: Kickoff + Scaffold</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Define capstone requirements</li>
+  <li>Plan the first build steps</li>
+  <li>Create the project skeleton</li>
+  <li>Make one action work end to end</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Deliverable</h1>
+            <p>Skeleton + load/save + one CRUD action working.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Suggested File Layout</h1>
+            <pre data-lang="text"><code>personal_organizer/
+├── main.py
+├── models.py
+├── storage.py
+├── actions.py
+├── data/
+│   └── organizer.json
+└── README.md</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Why This Layout Helps</h1>
+            <ul>
+  <li><code>main.py</code> owns the menu flow</li>
+  <li><code>storage.py</code> owns JSON load/save</li>
+  <li><code>models.py</code> owns the class</li>
+  <li><code>actions.py</code> owns add/list/search/update/delete behavior</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>First Working Flow</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Live Demo Target</h1>
+            <ol>
+  <li>Show the menu</li>
+  <li>Load existing data or start with defaults</li>
+  <li>Add one item</li>
+  <li>Save data</li>
+  <li>Restart and prove the item loads</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>MVP Question</h1>
+            <p>What is the smallest useful version of your organizer?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Load Safely When File Is Missing</h1>
+            <pre data-lang="python"><code>from pathlib import Path
+import json
+
+DATA_FILE = Path(&quot;data&quot;) / &quot;organizer.json&quot;
+
+def load_items():
+    try:
+        with DATA_FILE.open(&quot;r&quot;, encoding=&quot;utf-8&quot;) as file:
+            return json.load(file)
+    except FileNotFoundError:
+        return []
+    except json.JSONDecodeError:
+        print(&quot;Data file is damaged; starting with an empty list.&quot;)
+        return []</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Save After Changes</h1>
+            <pre data-lang="python"><code>def save_items(items):
+    DATA_FILE.parent.mkdir(exist_ok=True)
+    with DATA_FILE.open(&quot;w&quot;, encoding=&quot;utf-8&quot;) as file:
+        json.dump(items, file, indent=2)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfall</h1>
+            <p>If add/update/delete works during the run but disappears after restart, check whether <code>save_items()</code> was called.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 46: Build Sprint</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Complete the required CRUD feature set</li>
+  <li>Improve UX and robustness</li>
+  <li>Test features as they are added</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Build Order</h1>
+            <p>Add → list → search → update/delete → save/load retest</p>
+        </section>
+
+        <section class="slide">
+            <h1>Build Sprint Checklist</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Required Actions</h1>
+            <ul>
+  <li>Add an item</li>
+  <li>List items</li>
+  <li>Search or view one item</li>
+  <li>Update or mark an item complete</li>
+  <li>Delete an item</li>
+  <li>Save data after changes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quality Improvement</h1>
+            <p>Pick at least one: sorted output, confirmations, or input validation.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Input Validation Pattern</h1>
+            <pre data-lang="python"><code>choice = input(&quot;Choose an option: &quot;).strip()
+
+if choice == &quot;1&quot;:
+    add_item(items)
+elif choice == &quot;2&quot;:
+    list_items(items)
+elif choice == &quot;q&quot;:
+    print(&quot;Goodbye!&quot;)
+else:
+    print(&quot;Please choose a listed option.&quot;)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Keep It Clear</h1>
+            <p>Friendly messages are part of user experience.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Debug During the Sprint</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Spot-Check After Each Feature</h1>
+            <ul>
+  <li>Does the menu still appear?</li>
+  <li>Does the action change the right data?</li>
+  <li>Does the data save?</li>
+  <li>Does restart/load still work?</li>
+  <li>Does invalid input avoid a crash?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Exit Ticket</h1>
+            <p>What is one bug you fixed today, and how did you find it?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 47: Polish + Demo Readiness</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Finalize capstone quality</li>
+  <li>Prepare a short demo walkthrough</li>
+  <li>Test from a fresh run</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Deliverable</h1>
+            <p>A project that runs cleanly from scratch and supports a demo flow in under 3 minutes.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Polish Checklist</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Before Demo</h1>
+            <ul>
+  <li>Prompts are clear</li>
+  <li>Output is readable</li>
+  <li>Invalid menu choices are handled</li>
+  <li>Missing or damaged data files are handled</li>
+  <li>README explains how to run the project</li>
+  <li>Full demo flow has been rehearsed</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Avoid</h1>
+            <p>Last-minute refactors that break working code.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Script</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Recommended Flow</h1>
+            <ol>
+  <li>Start the program</li>
+  <li>Add an item</li>
+  <li>List items</li>
+  <li>Search or update an item</li>
+  <li>Save and quit</li>
+  <li>Restart and prove data persists</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Good Demo Habit</h1>
+            <p>Say what you are proving before you run the step.</p>
+        </section>
+
+        <section class="slide">
+            <h1>README Minimum</h1>
+            <pre data-lang="text"><code># Personal Organizer
+
+Run:
+python main.py
+
+Features:
+- Add items
+- List items
+- Search items
+- Save/load JSON data</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Why It Matters</h1>
+            <p>Run instructions make your project easier to grade, demo, and revisit.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 48: Final Assessment + Review</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Demonstrate Basics competency end to end</li>
+  <li>Explain project structure at a high level</li>
+  <li>Identify next study targets</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Final Activities</h1>
+            <ul>
+  <li>Capstone demo + rubric scoring</li>
+  <li>Short certification-style review</li>
+  <li>Individual feedback</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Capstone Rubric</h1>
+            <table>
+<thead>
+<tr>
+<th>Category</th>
+<th>What We Look For</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Requirements met</td>
+<td>Menu, modules, class, JSON, exceptions</td>
+</tr>
+<tr>
+<td>User experience</td>
+<td>Clear prompts and readable output</td>
+</tr>
+<tr>
+<td>Code organization</td>
+<td>Clear responsibilities</td>
+</tr>
+<tr>
+<td>Data persistence</td>
+<td>Save/load works across runs</td>
+</tr>
+<tr>
+<td>Demo &amp; explanation</td>
+<td>Clear walkthrough in under 3 minutes</td>
+</tr>
+</tbody>
+</table>
+        </section>
+
+        <section class="slide">
+            <h1>Certification-Style Review Domains</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Review Agenda</h1>
+            <ul>
+  <li>Types + conversions</li>
+  <li>Strings + formatting</li>
+  <li>Data structures: list, tuple, set, dict</li>
+  <li>Conditionals + loops</li>
+  <li>Functions + modules + basic classes</li>
+  <li>Files, JSON, paths, and directories</li>
+  <li>Exceptions: <code>ValueError</code>, <code>FileNotFoundError</code>, <code>JSONDecodeError</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Code Reading Practice</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Predict or Explain</h1>
+            <ul>
+  <li>String slicing + <code>len()</code></li>
+  <li>f-strings with numeric conversion</li>
+  <li><code>range()</code> boundaries</li>
+  <li>Guarding list indexes with <code>len()</code></li>
+  <li>Safe dictionary access with <code>in</code> or <code>.get()</code></li>
+  <li>Function <code>return</code> vs <code>print</code></li>
+  <li>JSON load recovery when a file is missing</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Final Exit Ticket</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Reflection Prompts</h1>
+            <ul>
+  <li>One concept I feel strong about is...</li>
+  <li>One concept I should review is...</li>
+  <li>One debugging habit I will keep using is...</li>
+  <li>One improvement I would add to my capstone next is...</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Course Close</h1>
+            <p>You now have the full Basics toolkit for building small, useful Python programs.</p>
+        </section>
+    </div>
+
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+
+        // Initialize
+        totalCounter.textContent = totalSlides;
+
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/Basics/lessons/slides/day-12/day-12-session-12.md
+++ b/Basics/lessons/slides/day-12/day-12-session-12.md
@@ -11,7 +11,8 @@ Python Programming (Basic) • Capstone Delivery and Final Review
 
 # Day 12 Goal
 
-## Finish With a Working Story
+**Finish With a Working Story**
+
 - Build a small command-line capstone project
 - Save and load data with JSON in a `data/` folder
 - Organize code with functions, modules, and at least one class
@@ -22,12 +23,14 @@ Python Programming (Basic) • Capstone Delivery and Final Review
 
 # Capstone Theme Choices
 
-## Choose One CLI Personal Organizer
+**Choose One CLI Personal Organizer**
+
 - Tasks
 - Contacts
 - Notes
 
-## Keep It Basics-Scope
+**Keep It Basics-Scope**
+
 - No web frameworks
 - No databases
 - No GUI frameworks
@@ -37,7 +40,8 @@ Python Programming (Basic) • Capstone Delivery and Final Review
 
 # Required Capstone Features
 
-## Minimum Requirements
+**Minimum Requirements**
+
 - Menu loop
 - Functions split into modules
 - At least one class
@@ -51,13 +55,15 @@ Build the minimum viable product first, then polish.
 
 # Hour 45: Kickoff + Scaffold
 
-## Learning Outcomes
+**Learning Outcomes**
+
 - Define capstone requirements
 - Plan the first build steps
 - Create the project skeleton
 - Make one action work end to end
 
-## Deliverable
+**Deliverable**
+
 Skeleton + load/save + one CRUD action working.
 
 ---
@@ -134,19 +140,22 @@ If add/update/delete works during the run but disappears after restart, check wh
 
 # Hour 46: Build Sprint
 
-## Learning Outcomes
+**Learning Outcomes**
+
 - Complete the required CRUD feature set
 - Improve UX and robustness
 - Test features as they are added
 
-## Build Order
+**Build Order**
+
 Add → list → search → update/delete → save/load retest
 
 ---
 
 # Build Sprint Checklist
 
-## Required Actions
+**Required Actions**
+
 - Add an item
 - List items
 - Search or view one item
@@ -195,19 +204,22 @@ What is one bug you fixed today, and how did you find it?
 
 # Hour 47: Polish + Demo Readiness
 
-## Learning Outcomes
+**Learning Outcomes**
+
 - Finalize capstone quality
 - Prepare a short demo walkthrough
 - Test from a fresh run
 
-## Deliverable
+**Deliverable**
+
 A project that runs cleanly from scratch and supports a demo flow in under 3 minutes.
 
 ---
 
 # Polish Checklist
 
-## Before Demo
+**Before Demo**
+
 - Prompts are clear
 - Output is readable
 - Invalid menu choices are handled
@@ -222,7 +234,8 @@ Last-minute refactors that break working code.
 
 # Demo Script
 
-## Recommended Flow
+**Recommended Flow**
+
 1. Start the program
 2. Add an item
 3. List items
@@ -257,12 +270,14 @@ Run instructions make your project easier to grade, demo, and revisit.
 
 # Hour 48: Final Assessment + Review
 
-## Learning Outcomes
+**Learning Outcomes**
+
 - Demonstrate Basics competency end to end
 - Explain project structure at a high level
 - Identify next study targets
 
-## Final Activities
+**Final Activities**
+
 - Capstone demo + rubric scoring
 - Short certification-style review
 - Individual feedback
@@ -283,7 +298,8 @@ Run instructions make your project easier to grade, demo, and revisit.
 
 # Certification-Style Review Domains
 
-## Review Agenda
+**Review Agenda**
+
 - Types + conversions
 - Strings + formatting
 - Data structures: list, tuple, set, dict
@@ -296,7 +312,8 @@ Run instructions make your project easier to grade, demo, and revisit.
 
 # Code Reading Practice
 
-## Predict or Explain
+**Predict or Explain**
+
 - String slicing + `len()`
 - f-strings with numeric conversion
 - `range()` boundaries
@@ -309,11 +326,13 @@ Run instructions make your project easier to grade, demo, and revisit.
 
 # Final Exit Ticket
 
-## Reflection Prompts
+**Reflection Prompts**
+
 - One concept I feel strong about is...
 - One concept I should review is...
 - One debugging habit I will keep using is...
 - One improvement I would add to my capstone next is...
 
-## Course Close
+**Course Close**
+
 You now have the full Basics toolkit for building small, useful Python programs.

--- a/Basics/lessons/slides/day-12/day-12-session-12.md
+++ b/Basics/lessons/slides/day-12/day-12-session-12.md
@@ -1,0 +1,319 @@
+# Basics Day 12 — Session 12 (Hours 45–48)
+Python Programming (Basic) • Capstone Delivery and Final Review
+
+## Session 12 Overview
+- Hour 45: Capstone kickoff — requirements + scaffolding
+- Hour 46: Capstone build sprint
+- Hour 47: Capstone polish + demo readiness
+- Hour 48: Final assessment + certification-style review
+
+---
+
+# Day 12 Goal
+
+## Finish With a Working Story
+- Build a small command-line capstone project
+- Save and load data with JSON in a `data/` folder
+- Organize code with functions, modules, and at least one class
+- Handle common input and file errors gracefully
+- Demo the project clearly in under 3 minutes
+
+---
+
+# Capstone Theme Choices
+
+## Choose One CLI Personal Organizer
+- Tasks
+- Contacts
+- Notes
+
+## Keep It Basics-Scope
+- No web frameworks
+- No databases
+- No GUI frameworks
+- No external packages required
+
+---
+
+# Required Capstone Features
+
+## Minimum Requirements
+- Menu loop
+- Functions split into modules
+- At least one class
+- JSON persistence in a `data/` folder
+- Exception handling for input and file errors
+
+## Today’s Rule
+Build the minimum viable product first, then polish.
+
+---
+
+# Hour 45: Kickoff + Scaffold
+
+## Learning Outcomes
+- Define capstone requirements
+- Plan the first build steps
+- Create the project skeleton
+- Make one action work end to end
+
+## Deliverable
+Skeleton + load/save + one CRUD action working.
+
+---
+
+# Suggested File Layout
+
+```text
+personal_organizer/
+├── main.py
+├── models.py
+├── storage.py
+├── actions.py
+├── data/
+│   └── organizer.json
+└── README.md
+```
+
+## Why This Layout Helps
+- `main.py` owns the menu flow
+- `storage.py` owns JSON load/save
+- `models.py` owns the class
+- `actions.py` owns add/list/search/update/delete behavior
+
+---
+
+# First Working Flow
+
+## Live Demo Target
+1. Show the menu
+2. Load existing data or start with defaults
+3. Add one item
+4. Save data
+5. Restart and prove the item loads
+
+## MVP Question
+What is the smallest useful version of your organizer?
+
+---
+
+# Load Safely When File Is Missing
+
+```python
+from pathlib import Path
+import json
+
+DATA_FILE = Path("data") / "organizer.json"
+
+def load_items():
+    try:
+        with DATA_FILE.open("r", encoding="utf-8") as file:
+            return json.load(file)
+    except FileNotFoundError:
+        return []
+    except json.JSONDecodeError:
+        print("Data file is damaged; starting with an empty list.")
+        return []
+```
+
+---
+
+# Save After Changes
+
+```python
+def save_items(items):
+    DATA_FILE.parent.mkdir(exist_ok=True)
+    with DATA_FILE.open("w", encoding="utf-8") as file:
+        json.dump(items, file, indent=2)
+```
+
+## Common Pitfall
+If add/update/delete works during the run but disappears after restart, check whether `save_items()` was called.
+
+---
+
+# Hour 46: Build Sprint
+
+## Learning Outcomes
+- Complete the required CRUD feature set
+- Improve UX and robustness
+- Test features as they are added
+
+## Build Order
+Add → list → search → update/delete → save/load retest
+
+---
+
+# Build Sprint Checklist
+
+## Required Actions
+- Add an item
+- List items
+- Search or view one item
+- Update or mark an item complete
+- Delete an item
+- Save data after changes
+
+## Quality Improvement
+Pick at least one: sorted output, confirmations, or input validation.
+
+---
+
+# Input Validation Pattern
+
+```python
+choice = input("Choose an option: ").strip()
+
+if choice == "1":
+    add_item(items)
+elif choice == "2":
+    list_items(items)
+elif choice == "q":
+    print("Goodbye!")
+else:
+    print("Please choose a listed option.")
+```
+
+## Keep It Clear
+Friendly messages are part of user experience.
+
+---
+
+# Debug During the Sprint
+
+## Spot-Check After Each Feature
+- Does the menu still appear?
+- Does the action change the right data?
+- Does the data save?
+- Does restart/load still work?
+- Does invalid input avoid a crash?
+
+## Exit Ticket
+What is one bug you fixed today, and how did you find it?
+
+---
+
+# Hour 47: Polish + Demo Readiness
+
+## Learning Outcomes
+- Finalize capstone quality
+- Prepare a short demo walkthrough
+- Test from a fresh run
+
+## Deliverable
+A project that runs cleanly from scratch and supports a demo flow in under 3 minutes.
+
+---
+
+# Polish Checklist
+
+## Before Demo
+- Prompts are clear
+- Output is readable
+- Invalid menu choices are handled
+- Missing or damaged data files are handled
+- README explains how to run the project
+- Full demo flow has been rehearsed
+
+## Avoid
+Last-minute refactors that break working code.
+
+---
+
+# Demo Script
+
+## Recommended Flow
+1. Start the program
+2. Add an item
+3. List items
+4. Search or update an item
+5. Save and quit
+6. Restart and prove data persists
+
+## Good Demo Habit
+Say what you are proving before you run the step.
+
+---
+
+# README Minimum
+
+```text
+# Personal Organizer
+
+Run:
+python main.py
+
+Features:
+- Add items
+- List items
+- Search items
+- Save/load JSON data
+```
+
+## Why It Matters
+Run instructions make your project easier to grade, demo, and revisit.
+
+---
+
+# Hour 48: Final Assessment + Review
+
+## Learning Outcomes
+- Demonstrate Basics competency end to end
+- Explain project structure at a high level
+- Identify next study targets
+
+## Final Activities
+- Capstone demo + rubric scoring
+- Short certification-style review
+- Individual feedback
+
+---
+
+# Capstone Rubric
+
+| Category | What We Look For |
+| --- | --- |
+| Requirements met | Menu, modules, class, JSON, exceptions |
+| User experience | Clear prompts and readable output |
+| Code organization | Clear responsibilities |
+| Data persistence | Save/load works across runs |
+| Demo & explanation | Clear walkthrough in under 3 minutes |
+
+---
+
+# Certification-Style Review Domains
+
+## Review Agenda
+- Types + conversions
+- Strings + formatting
+- Data structures: list, tuple, set, dict
+- Conditionals + loops
+- Functions + modules + basic classes
+- Files, JSON, paths, and directories
+- Exceptions: `ValueError`, `FileNotFoundError`, `JSONDecodeError`
+
+---
+
+# Code Reading Practice
+
+## Predict or Explain
+- String slicing + `len()`
+- f-strings with numeric conversion
+- `range()` boundaries
+- Guarding list indexes with `len()`
+- Safe dictionary access with `in` or `.get()`
+- Function `return` vs `print`
+- JSON load recovery when a file is missing
+
+---
+
+# Final Exit Ticket
+
+## Reflection Prompts
+- One concept I feel strong about is...
+- One concept I should review is...
+- One debugging habit I will keep using is...
+- One improvement I would add to my capstone next is...
+
+## Course Close
+You now have the full Basics toolkit for building small, useful Python programs.

--- a/slides/basics/day-12/README.md
+++ b/slides/basics/day-12/README.md
@@ -3,7 +3,7 @@
 **Course:** Python Programming (Basic)<br>
 **Day:** 12 · Session 12<br>
 **Hours covered:** 45–48<br>
-**Slides:** [`day-12-session-12.html`](day-12-session-12.html) &nbsp;(54 slides)
+**Slides:** [`day-12-session-12.html`](day-12-session-12.html) &nbsp;(35 slides)
 
 ---
 
@@ -63,7 +63,7 @@ By the end of Session 12, learners can:
 
 | File | Description |
 |------|-------------|
-| [`day-12-session-12.html`](day-12-session-12.html) | Self-contained HTML slide deck (54 slides) |
+| [`day-12-session-12.html`](day-12-session-12.html) | Self-contained HTML slide deck (35 slides) |
 | [`index.html`](index.html) | Session index / landing page |
 | [`README.md`](README.md) | This file |
 

--- a/slides/basics/day-12/README.md
+++ b/slides/basics/day-12/README.md
@@ -1,0 +1,110 @@
+# Day 12 — Session 12: Capstone Delivery and Final Review
+
+**Course:** Python Programming (Basic)<br>
+**Day:** 12 · Session 12<br>
+**Hours covered:** 45–48<br>
+**Slides:** [`day-12-session-12.html`](day-12-session-12.html) &nbsp;(54 slides)
+
+---
+
+## Session Overview
+
+| Hour | Topic | Key Concept |
+|------|-------|-------------|
+| 45 | Capstone kickoff: requirements + scaffolding | MVP planning, project skeleton, load/save, first CRUD action |
+| 46 | Capstone build sprint | CRUD completion, UX improvements, save/load retesting |
+| 47 | Capstone polish + demo readiness | README, fresh-run testing, demo script |
+| 48 | Final assessment + certification-style review | Capstone demo, rubric scoring, code-reading review |
+
+---
+
+## Learning Outcomes
+
+By the end of Session 12, learners can:
+
+### Hour 45 — Capstone kickoff
+- Define a small CLI personal organizer capstone scope
+- Create a project skeleton with `main.py`, modules, and a `data/` folder
+- Implement load/save behavior with JSON
+- Make one CRUD action work end to end
+
+### Hour 46 — Capstone build sprint
+- Complete the required feature set: add, list, search/view, update/delete
+- Save data after every state-changing action
+- Add at least one quality improvement such as confirmations or input validation
+- Test each feature as it is added
+
+### Hour 47 — Polish and demo readiness
+- Improve prompts, output readability, and error handling
+- Add basic run instructions in a README
+- Rehearse a short demo flow from a fresh program start
+- Avoid risky last-minute refactors
+
+### Hour 48 — Final assessment and review
+- Demonstrate end-to-end Basics competency through the capstone
+- Explain code organization at a high level
+- Review core Basics domains through certification-style code reading
+- Identify individual next-step study targets
+
+---
+
+## Labs
+
+| Hour | Lab | Timebox | Description |
+|------|-----|---------|-------------|
+| 45 | Capstone scaffold | 25–35 min | Choose tasks, contacts, or notes; create skeleton; implement load/save and one action |
+| 46 | Capstone build | 25–35 min | Complete CRUD behavior and add one quality improvement |
+| 47 | Capstone polish | 25–35 min | Add README, sample data if useful, and rehearse the demo flow |
+| 48 | Final assessment | 60–75 min | Present capstone, complete short review, and receive feedback |
+
+---
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [`day-12-session-12.html`](day-12-session-12.html) | Self-contained HTML slide deck (54 slides) |
+| [`index.html`](index.html) | Session index / landing page |
+| [`README.md`](README.md) | This file |
+
+---
+
+## Navigation
+
+Inside the slide deck, use:
+
+| Key | Action |
+|-----|--------|
+| `→` or `Space` | Next slide |
+| `←` | Previous slide |
+| `Home` | First slide |
+| `End` | Last slide |
+| Swipe left/right | Mobile navigation |
+
+---
+
+## Scope Guardrail
+
+This session stays within the **Basics** course scope.
+
+Topics covered in this session:
+- CLI capstone requirements and scaffolding
+- Functions, modules, and at least one basic class
+- JSON persistence in a `data/` folder
+- Input and file exception handling
+- Demo preparation and final Basics review
+
+Topics **excluded from full coverage** (covered in the Advanced course):
+
+| Topic | Why It Is Advanced |
+|-------|------------------|
+| Web frameworks and REST APIs | Requires HTTP/API architecture |
+| Databases and SQL | Requires persistence concepts beyond JSON files |
+| GUI frameworks | Adds event-driven UI structure |
+| pytest and coverage tooling | Advanced testing workflow |
+| Packaging and distribution | Advanced delivery workflow |
+| pandas/matplotlib/data science stack | Advanced analysis tooling |
+
+---
+
+*Generated from `Basics/lessons/slides/day-12/day-12-session-12.md`*

--- a/slides/basics/day-12/day-12-session-12.html
+++ b/slides/basics/day-12/day-12-session-12.html
@@ -403,12 +403,8 @@
 
         <section class="slide">
             <h1>Day 12 Goal</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Finish With a Working Story</h1>
-            <ul>
+            <p><strong>Finish With a Working Story</strong></p>
+<ul>
   <li>Build a small command-line capstone project</li>
   <li>Save and load data with JSON in a <code>data/</code> folder</li>
   <li>Organize code with functions, modules, and at least one class</li>
@@ -419,21 +415,14 @@
 
         <section class="slide">
             <h1>Capstone Theme Choices</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Choose One CLI Personal Organizer</h1>
-            <ul>
+            <p><strong>Choose One CLI Personal Organizer</strong></p>
+<ul>
   <li>Tasks</li>
   <li>Contacts</li>
   <li>Notes</li>
 </ul>
-        </section>
-
-        <section class="slide">
-            <h1>Keep It Basics-Scope</h1>
-            <ul>
+<p><strong>Keep It Basics-Scope</strong></p>
+<ul>
   <li>No web frameworks</li>
   <li>No databases</li>
   <li>No GUI frameworks</li>
@@ -443,12 +432,8 @@
 
         <section class="slide">
             <h1>Required Capstone Features</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Minimum Requirements</h1>
-            <ul>
+            <p><strong>Minimum Requirements</strong></p>
+<ul>
   <li>Menu loop</li>
   <li>Functions split into modules</li>
   <li>At least one class</li>
@@ -464,22 +449,15 @@
 
         <section class="slide">
             <h1>Hour 45: Kickoff + Scaffold</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Learning Outcomes</h1>
-            <ul>
+            <p><strong>Learning Outcomes</strong></p>
+<ul>
   <li>Define capstone requirements</li>
   <li>Plan the first build steps</li>
   <li>Create the project skeleton</li>
   <li>Make one action work end to end</li>
 </ul>
-        </section>
-
-        <section class="slide">
-            <h1>Deliverable</h1>
-            <p>Skeleton + load/save + one CRUD action working.</p>
+<p><strong>Deliverable</strong></p>
+<p>Skeleton + load/save + one CRUD action working.</p>
         </section>
 
         <section class="slide">
@@ -558,31 +536,20 @@ def load_items():
 
         <section class="slide">
             <h1>Hour 46: Build Sprint</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Learning Outcomes</h1>
-            <ul>
+            <p><strong>Learning Outcomes</strong></p>
+<ul>
   <li>Complete the required CRUD feature set</li>
   <li>Improve UX and robustness</li>
   <li>Test features as they are added</li>
 </ul>
-        </section>
-
-        <section class="slide">
-            <h1>Build Order</h1>
-            <p>Add → list → search → update/delete → save/load retest</p>
+<p><strong>Build Order</strong></p>
+<p>Add → list → search → update/delete → save/load retest</p>
         </section>
 
         <section class="slide">
             <h1>Build Sprint Checklist</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Required Actions</h1>
-            <ul>
+            <p><strong>Required Actions</strong></p>
+<ul>
   <li>Add an item</li>
   <li>List items</li>
   <li>Search or view one item</li>
@@ -639,31 +606,20 @@ else:
 
         <section class="slide">
             <h1>Hour 47: Polish + Demo Readiness</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Learning Outcomes</h1>
-            <ul>
+            <p><strong>Learning Outcomes</strong></p>
+<ul>
   <li>Finalize capstone quality</li>
   <li>Prepare a short demo walkthrough</li>
   <li>Test from a fresh run</li>
 </ul>
-        </section>
-
-        <section class="slide">
-            <h1>Deliverable</h1>
-            <p>A project that runs cleanly from scratch and supports a demo flow in under 3 minutes.</p>
+<p><strong>Deliverable</strong></p>
+<p>A project that runs cleanly from scratch and supports a demo flow in under 3 minutes.</p>
         </section>
 
         <section class="slide">
             <h1>Polish Checklist</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Before Demo</h1>
-            <ul>
+            <p><strong>Before Demo</strong></p>
+<ul>
   <li>Prompts are clear</li>
   <li>Output is readable</li>
   <li>Invalid menu choices are handled</li>
@@ -680,12 +636,8 @@ else:
 
         <section class="slide">
             <h1>Demo Script</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Recommended Flow</h1>
-            <ol>
+            <p><strong>Recommended Flow</strong></p>
+<ol>
   <li>Start the program</li>
   <li>Add an item</li>
   <li>List items</li>
@@ -721,21 +673,14 @@ Features:
 
         <section class="slide">
             <h1>Hour 48: Final Assessment + Review</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Learning Outcomes</h1>
-            <ul>
+            <p><strong>Learning Outcomes</strong></p>
+<ul>
   <li>Demonstrate Basics competency end to end</li>
   <li>Explain project structure at a high level</li>
   <li>Identify next study targets</li>
 </ul>
-        </section>
-
-        <section class="slide">
-            <h1>Final Activities</h1>
-            <ul>
+<p><strong>Final Activities</strong></p>
+<ul>
   <li>Capstone demo + rubric scoring</li>
   <li>Short certification-style review</li>
   <li>Individual feedback</li>
@@ -778,12 +723,8 @@ Features:
 
         <section class="slide">
             <h1>Certification-Style Review Domains</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Review Agenda</h1>
-            <ul>
+            <p><strong>Review Agenda</strong></p>
+<ul>
   <li>Types + conversions</li>
   <li>Strings + formatting</li>
   <li>Data structures: list, tuple, set, dict</li>
@@ -796,12 +737,8 @@ Features:
 
         <section class="slide">
             <h1>Code Reading Practice</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Predict or Explain</h1>
-            <ul>
+            <p><strong>Predict or Explain</strong></p>
+<ul>
   <li>String slicing + <code>len()</code></li>
   <li>f-strings with numeric conversion</li>
   <li><code>range()</code> boundaries</li>
@@ -814,22 +751,15 @@ Features:
 
         <section class="slide">
             <h1>Final Exit Ticket</h1>
-
-        </section>
-
-        <section class="slide">
-            <h1>Reflection Prompts</h1>
-            <ul>
+            <p><strong>Reflection Prompts</strong></p>
+<ul>
   <li>One concept I feel strong about is...</li>
   <li>One concept I should review is...</li>
   <li>One debugging habit I will keep using is...</li>
   <li>One improvement I would add to my capstone next is...</li>
 </ul>
-        </section>
-
-        <section class="slide">
-            <h1>Course Close</h1>
-            <p>You now have the full Basics toolkit for building small, useful Python programs.</p>
+<p><strong>Course Close</strong></p>
+<p>You now have the full Basics toolkit for building small, useful Python programs.</p>
         </section>
     </div>
 
@@ -947,17 +877,15 @@ Features:
             }
         }
 
-        // Load slide from URL hash
-        window.addEventListener('load', () => {
-            const hash = window.location.hash.slice(1);
-            if (hash) {
-                const slideNum = parseInt(hash) - 1;
-                if (!isNaN(slideNum)) {
-                    currentSlide = slideNum;
-                }
+        // Load slide from URL hash immediately and clamp invalid values.
+        const hash = window.location.hash.slice(1);
+        if (hash) {
+            const slideNum = parseInt(hash) - 1;
+            if (!isNaN(slideNum)) {
+                currentSlide = Math.max(0, Math.min(slideNum, totalSlides - 1));
             }
-            updateSlideDisplay(false);
-        });
+        }
+        updateSlideDisplay(false);
     </script>
 </body>
 </html>

--- a/slides/basics/day-12/day-12-session-12.html
+++ b/slides/basics/day-12/day-12-session-12.html
@@ -1,0 +1,963 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Basics Day 12 — Session 12 (Hours 45–48)</title>
+    <style>
+        /* ====================================
+           CSS VARIABLES - TWEAK GUIDE
+           ==================================== */
+        :root {
+            /* Colors - Swiss Modern Palette */
+            --bg: #f7f7f7;              /* Main background (light gray) */
+            --fg: #111111;              /* Main text color (near black) */
+            --accent: #0066ff;          /* Accent color (blue) */
+            --accent-light: #e6f0ff;    /* Light accent background */
+            --code-bg: #1e1e1e;         /* Code block background (dark) */
+            --code-fg: #f8f8f2;         /* Code text color (light) */
+            --border: #cccccc;          /* Border color */
+            --shadow: rgba(0, 0, 0, 0.1); /* Shadow color */
+
+            /* Typography */
+            --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+            --font-heading: "Inter", system-ui, -apple-system, sans-serif;
+            --font-code: "SF Mono", "Monaco", "Consolas", monospace;
+
+            /* Spacing */
+            --spacing: 24px;            /* Base spacing unit */
+            --slide-padding: 60px;      /* Padding inside slides */
+
+            /* Animation timing */
+            --transition-speed: 0.3s;   /* Slide transition duration */
+        }
+
+        /* ====================================
+           BASE STYLES
+           ==================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: var(--font-body);
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.6;
+            overflow: hidden;
+        }
+
+        /* ====================================
+           SLIDE CONTAINER
+           ==================================== */
+        #slides-container {
+            position: relative;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
+        }
+
+        /* ====================================
+           INDIVIDUAL SLIDES
+           ==================================== */
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            padding: var(--slide-padding);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: translateX(100%);
+            transition: opacity var(--transition-speed) ease,
+                        transform var(--transition-speed) ease;
+        }
+
+        .slide.active {
+            opacity: 1;
+            transform: translateX(0);
+            z-index: 10;
+        }
+
+        .slide.previous {
+            opacity: 0;
+            transform: translateX(-100%);
+        }
+
+        /* Title slide special styling */
+        .slide.title-slide {
+            background: linear-gradient(135deg, var(--accent) 0%, #0052cc 100%);
+            color: white;
+            text-align: center;
+            justify-content: center;
+        }
+
+        .slide.title-slide h1 {
+            font-size: 3.5rem;
+            font-weight: 700;
+            margin-bottom: calc(var(--spacing) * 2);
+            line-height: 1.2;
+        }
+
+        .slide.title-slide .subtitle {
+            font-size: 1.5rem;
+            opacity: 0.9;
+            font-weight: 300;
+        }
+
+        /* ====================================
+           TYPOGRAPHY
+           ==================================== */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: var(--spacing);
+        }
+
+        .slide:not(.title-slide) h1 {
+            font-size: 2.5rem;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: calc(var(--spacing) / 2);
+        }
+
+        .slide h2 {
+            font-size: 2rem;
+            margin-top: calc(var(--spacing) * 1.5);
+        }
+
+        .slide h3 {
+            font-size: 1.5rem;
+            margin-top: var(--spacing);
+        }
+
+        p {
+            margin-bottom: var(--spacing);
+            font-size: 1.2rem;
+            max-width: 900px;
+        }
+
+        /* ====================================
+           LISTS
+           ==================================== */
+        ul, ol {
+            margin-left: calc(var(--spacing) * 1.5);
+            margin-bottom: var(--spacing);
+            max-width: 900px;
+        }
+
+        li {
+            margin-bottom: calc(var(--spacing) / 2);
+            font-size: 1.2rem;
+            line-height: 1.6;
+        }
+
+        ul li {
+            list-style-type: none;
+            position: relative;
+            padding-left: calc(var(--spacing) * 1.5);
+        }
+
+        ul li::before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: var(--accent);
+            font-weight: bold;
+        }
+
+        /* Nested lists */
+        ul ul, ol ol {
+            margin-top: calc(var(--spacing) / 2);
+            margin-bottom: calc(var(--spacing) / 2);
+        }
+
+        /* ====================================
+           TABLES
+           ==================================== */
+        table {
+            border-collapse: collapse;
+            width: 100%;
+            max-width: 1000px;
+            margin-bottom: var(--spacing);
+            background: #fff;
+            box-shadow: 0 4px 6px var(--shadow);
+        }
+
+        th, td {
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            text-align: left;
+            vertical-align: top;
+            font-size: 1rem;
+        }
+
+        th {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+        }
+
+        td {
+            background: #fff;
+        }
+
+        /* ====================================
+           CODE BLOCKS
+           ==================================== */
+        pre {
+            background: var(--code-bg);
+            color: var(--code-fg);
+            padding: var(--spacing);
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: var(--spacing);
+            box-shadow: 0 4px 6px var(--shadow);
+            max-width: 1000px;
+        }
+
+        code {
+            font-family: var(--font-code);
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+
+        /* Inline code */
+        p code, li code {
+            background: var(--accent-light);
+            color: var(--accent);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 0.9em;
+        }
+
+        /* ====================================
+           BLOCKQUOTES
+           ==================================== */
+        blockquote {
+            border-left: 4px solid var(--accent);
+            padding-left: var(--spacing);
+            margin: var(--spacing) 0;
+            font-style: italic;
+            color: #555;
+            background: var(--accent-light);
+            padding: var(--spacing);
+            border-radius: 4px;
+        }
+
+        /* ====================================
+           IMAGES
+           ==================================== */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px var(--shadow);
+            margin: var(--spacing) 0;
+        }
+
+        /* ====================================
+           LINKS
+           ==================================== */
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.2s;
+        }
+
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+
+        /* ====================================
+           NAVIGATION CONTROLS
+           ==================================== */
+        #nav-hint {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 12px 20px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+            opacity: 0.8;
+            transition: opacity 0.3s;
+        }
+
+        #nav-hint:hover {
+            opacity: 1;
+        }
+
+        #progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 4px;
+            background: var(--accent);
+            z-index: 100;
+            transition: width 0.3s ease;
+        }
+
+        #slide-counter {
+            position: fixed;
+            bottom: 30px;
+            left: 30px;
+            background: rgba(0, 0, 0, 0.7);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            z-index: 100;
+        }
+
+        /* ====================================
+           RESPONSIVE DESIGN
+           ==================================== */
+        @media (max-width: 768px) {
+            .slide {
+                padding: 30px;
+            }
+
+            .slide.title-slide h1 {
+                font-size: 2.5rem;
+            }
+
+            .slide h1 {
+                font-size: 2rem;
+            }
+
+            .slide h2 {
+                font-size: 1.5rem;
+            }
+
+            p, li {
+                font-size: 1rem;
+            }
+        }
+
+        /* ====================================
+           SPECIAL ELEMENTS
+           ==================================== */
+        hr {
+            border: none;
+            border-top: 2px solid var(--border);
+            margin: calc(var(--spacing) * 2) 0;
+        }
+
+        strong, b {
+            font-weight: 600;
+            color: var(--accent);
+        }
+
+        em, i {
+            font-style: italic;
+        }
+
+        /* Checkmarks and X marks for task lists */
+        .check {
+            color: #22c55e;
+            font-weight: bold;
+        }
+
+        .cross {
+            color: #ef4444;
+            font-weight: bold;
+        }
+
+        /* Warning/Alert styling */
+        .warning {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: var(--spacing);
+            margin: var(--spacing) 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div id="slides-container">
+
+        <section class="slide title-slide">
+            <h1>Basics Day 12 — Session 12 (Hours 45–48)</h1>
+            <div class="subtitle">Python Programming (Basic) • Capstone Delivery and Final Review</div>
+        </section>
+
+        <section class="slide">
+            <h1>Session 12 Overview</h1>
+            <ul>
+  <li>Hour 45: Capstone kickoff — requirements + scaffolding</li>
+  <li>Hour 46: Capstone build sprint</li>
+  <li>Hour 47: Capstone polish + demo readiness</li>
+  <li>Hour 48: Final assessment + certification-style review</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Day 12 Goal</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Finish With a Working Story</h1>
+            <ul>
+  <li>Build a small command-line capstone project</li>
+  <li>Save and load data with JSON in a <code>data/</code> folder</li>
+  <li>Organize code with functions, modules, and at least one class</li>
+  <li>Handle common input and file errors gracefully</li>
+  <li>Demo the project clearly in under 3 minutes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Capstone Theme Choices</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Choose One CLI Personal Organizer</h1>
+            <ul>
+  <li>Tasks</li>
+  <li>Contacts</li>
+  <li>Notes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Keep It Basics-Scope</h1>
+            <ul>
+  <li>No web frameworks</li>
+  <li>No databases</li>
+  <li>No GUI frameworks</li>
+  <li>No external packages required</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Required Capstone Features</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Minimum Requirements</h1>
+            <ul>
+  <li>Menu loop</li>
+  <li>Functions split into modules</li>
+  <li>At least one class</li>
+  <li>JSON persistence in a <code>data/</code> folder</li>
+  <li>Exception handling for input and file errors</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Today’s Rule</h1>
+            <p>Build the minimum viable product first, then polish.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 45: Kickoff + Scaffold</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Define capstone requirements</li>
+  <li>Plan the first build steps</li>
+  <li>Create the project skeleton</li>
+  <li>Make one action work end to end</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Deliverable</h1>
+            <p>Skeleton + load/save + one CRUD action working.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Suggested File Layout</h1>
+            <pre data-lang="text"><code>personal_organizer/
+├── main.py
+├── models.py
+├── storage.py
+├── actions.py
+├── data/
+│   └── organizer.json
+└── README.md</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Why This Layout Helps</h1>
+            <ul>
+  <li><code>main.py</code> owns the menu flow</li>
+  <li><code>storage.py</code> owns JSON load/save</li>
+  <li><code>models.py</code> owns the class</li>
+  <li><code>actions.py</code> owns add/list/search/update/delete behavior</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>First Working Flow</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Live Demo Target</h1>
+            <ol>
+  <li>Show the menu</li>
+  <li>Load existing data or start with defaults</li>
+  <li>Add one item</li>
+  <li>Save data</li>
+  <li>Restart and prove the item loads</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>MVP Question</h1>
+            <p>What is the smallest useful version of your organizer?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Load Safely When File Is Missing</h1>
+            <pre data-lang="python"><code>from pathlib import Path
+import json
+
+DATA_FILE = Path(&quot;data&quot;) / &quot;organizer.json&quot;
+
+def load_items():
+    try:
+        with DATA_FILE.open(&quot;r&quot;, encoding=&quot;utf-8&quot;) as file:
+            return json.load(file)
+    except FileNotFoundError:
+        return []
+    except json.JSONDecodeError:
+        print(&quot;Data file is damaged; starting with an empty list.&quot;)
+        return []</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Save After Changes</h1>
+            <pre data-lang="python"><code>def save_items(items):
+    DATA_FILE.parent.mkdir(exist_ok=True)
+    with DATA_FILE.open(&quot;w&quot;, encoding=&quot;utf-8&quot;) as file:
+        json.dump(items, file, indent=2)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Common Pitfall</h1>
+            <p>If add/update/delete works during the run but disappears after restart, check whether <code>save_items()</code> was called.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 46: Build Sprint</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Complete the required CRUD feature set</li>
+  <li>Improve UX and robustness</li>
+  <li>Test features as they are added</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Build Order</h1>
+            <p>Add → list → search → update/delete → save/load retest</p>
+        </section>
+
+        <section class="slide">
+            <h1>Build Sprint Checklist</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Required Actions</h1>
+            <ul>
+  <li>Add an item</li>
+  <li>List items</li>
+  <li>Search or view one item</li>
+  <li>Update or mark an item complete</li>
+  <li>Delete an item</li>
+  <li>Save data after changes</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Quality Improvement</h1>
+            <p>Pick at least one: sorted output, confirmations, or input validation.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Input Validation Pattern</h1>
+            <pre data-lang="python"><code>choice = input(&quot;Choose an option: &quot;).strip()
+
+if choice == &quot;1&quot;:
+    add_item(items)
+elif choice == &quot;2&quot;:
+    list_items(items)
+elif choice == &quot;q&quot;:
+    print(&quot;Goodbye!&quot;)
+else:
+    print(&quot;Please choose a listed option.&quot;)</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Keep It Clear</h1>
+            <p>Friendly messages are part of user experience.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Debug During the Sprint</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Spot-Check After Each Feature</h1>
+            <ul>
+  <li>Does the menu still appear?</li>
+  <li>Does the action change the right data?</li>
+  <li>Does the data save?</li>
+  <li>Does restart/load still work?</li>
+  <li>Does invalid input avoid a crash?</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Exit Ticket</h1>
+            <p>What is one bug you fixed today, and how did you find it?</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 47: Polish + Demo Readiness</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Finalize capstone quality</li>
+  <li>Prepare a short demo walkthrough</li>
+  <li>Test from a fresh run</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Deliverable</h1>
+            <p>A project that runs cleanly from scratch and supports a demo flow in under 3 minutes.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Polish Checklist</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Before Demo</h1>
+            <ul>
+  <li>Prompts are clear</li>
+  <li>Output is readable</li>
+  <li>Invalid menu choices are handled</li>
+  <li>Missing or damaged data files are handled</li>
+  <li>README explains how to run the project</li>
+  <li>Full demo flow has been rehearsed</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Avoid</h1>
+            <p>Last-minute refactors that break working code.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Demo Script</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Recommended Flow</h1>
+            <ol>
+  <li>Start the program</li>
+  <li>Add an item</li>
+  <li>List items</li>
+  <li>Search or update an item</li>
+  <li>Save and quit</li>
+  <li>Restart and prove data persists</li>
+</ol>
+        </section>
+
+        <section class="slide">
+            <h1>Good Demo Habit</h1>
+            <p>Say what you are proving before you run the step.</p>
+        </section>
+
+        <section class="slide">
+            <h1>README Minimum</h1>
+            <pre data-lang="text"><code># Personal Organizer
+
+Run:
+python main.py
+
+Features:
+- Add items
+- List items
+- Search items
+- Save/load JSON data</code></pre>
+        </section>
+
+        <section class="slide">
+            <h1>Why It Matters</h1>
+            <p>Run instructions make your project easier to grade, demo, and revisit.</p>
+        </section>
+
+        <section class="slide">
+            <h1>Hour 48: Final Assessment + Review</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Learning Outcomes</h1>
+            <ul>
+  <li>Demonstrate Basics competency end to end</li>
+  <li>Explain project structure at a high level</li>
+  <li>Identify next study targets</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Final Activities</h1>
+            <ul>
+  <li>Capstone demo + rubric scoring</li>
+  <li>Short certification-style review</li>
+  <li>Individual feedback</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Capstone Rubric</h1>
+            <table>
+<thead>
+<tr>
+<th>Category</th>
+<th>What We Look For</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Requirements met</td>
+<td>Menu, modules, class, JSON, exceptions</td>
+</tr>
+<tr>
+<td>User experience</td>
+<td>Clear prompts and readable output</td>
+</tr>
+<tr>
+<td>Code organization</td>
+<td>Clear responsibilities</td>
+</tr>
+<tr>
+<td>Data persistence</td>
+<td>Save/load works across runs</td>
+</tr>
+<tr>
+<td>Demo &amp; explanation</td>
+<td>Clear walkthrough in under 3 minutes</td>
+</tr>
+</tbody>
+</table>
+        </section>
+
+        <section class="slide">
+            <h1>Certification-Style Review Domains</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Review Agenda</h1>
+            <ul>
+  <li>Types + conversions</li>
+  <li>Strings + formatting</li>
+  <li>Data structures: list, tuple, set, dict</li>
+  <li>Conditionals + loops</li>
+  <li>Functions + modules + basic classes</li>
+  <li>Files, JSON, paths, and directories</li>
+  <li>Exceptions: <code>ValueError</code>, <code>FileNotFoundError</code>, <code>JSONDecodeError</code></li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Code Reading Practice</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Predict or Explain</h1>
+            <ul>
+  <li>String slicing + <code>len()</code></li>
+  <li>f-strings with numeric conversion</li>
+  <li><code>range()</code> boundaries</li>
+  <li>Guarding list indexes with <code>len()</code></li>
+  <li>Safe dictionary access with <code>in</code> or <code>.get()</code></li>
+  <li>Function <code>return</code> vs <code>print</code></li>
+  <li>JSON load recovery when a file is missing</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Final Exit Ticket</h1>
+
+        </section>
+
+        <section class="slide">
+            <h1>Reflection Prompts</h1>
+            <ul>
+  <li>One concept I feel strong about is...</li>
+  <li>One concept I should review is...</li>
+  <li>One debugging habit I will keep using is...</li>
+  <li>One improvement I would add to my capstone next is...</li>
+</ul>
+        </section>
+
+        <section class="slide">
+            <h1>Course Close</h1>
+            <p>You now have the full Basics toolkit for building small, useful Python programs.</p>
+        </section>
+    </div>
+
+    <div id="progress-bar"></div>
+    <div id="slide-counter"><span id="current">1</span> / <span id="total">1</span></div>
+    <div id="nav-hint">← → or Space to navigate</div>
+
+    <script>
+        // ====================================
+        // SLIDE NAVIGATION
+        // ====================================
+        let currentSlide = 0;
+        const slides = document.querySelectorAll('.slide');
+        const totalSlides = slides.length;
+        const progressBar = document.getElementById('progress-bar');
+        const currentCounter = document.getElementById('current');
+        const totalCounter = document.getElementById('total');
+
+        // Initialize
+        totalCounter.textContent = totalSlides;
+
+        function updateSlideDisplay(updateHash = true) {
+            // Hide all slides
+            slides.forEach((slide, index) => {
+                slide.classList.remove('active', 'previous');
+                if (index < currentSlide) {
+                    slide.classList.add('previous');
+                }
+            });
+
+            // Show current slide
+            if (slides[currentSlide]) {
+                slides[currentSlide].classList.add('active');
+            }
+
+            // Update progress bar
+            const progress = ((currentSlide + 1) / totalSlides) * 100;
+            progressBar.style.width = progress + '%';
+
+            // Update counter
+            currentCounter.textContent = currentSlide + 1;
+
+            // Update URL hash (for bookmarking)
+            if (updateHash) {
+                window.location.hash = currentSlide + 1;
+            }
+        }
+
+        function nextSlide() {
+            if (currentSlide < totalSlides - 1) {
+                currentSlide++;
+                updateSlideDisplay();
+            }
+        }
+
+        function prevSlide() {
+            if (currentSlide > 0) {
+                currentSlide--;
+                updateSlideDisplay();
+            }
+        }
+
+        function goToSlide(index) {
+            if (index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateSlideDisplay();
+            }
+        }
+
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            switch(e.key) {
+                case 'ArrowRight':
+                case ' ':
+                case 'PageDown':
+                    e.preventDefault();
+                    nextSlide();
+                    break;
+                case 'ArrowLeft':
+                case 'PageUp':
+                    e.preventDefault();
+                    prevSlide();
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    goToSlide(0);
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    goToSlide(totalSlides - 1);
+                    break;
+            }
+        });
+
+        // Touch/swipe support for mobile
+        let touchStartX = 0;
+        let touchEndX = 0;
+
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        });
+
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            handleSwipe();
+        });
+
+        function handleSwipe() {
+            const swipeThreshold = 50;
+            if (touchEndX < touchStartX - swipeThreshold) {
+                nextSlide();
+            }
+            if (touchEndX > touchStartX + swipeThreshold) {
+                prevSlide();
+            }
+        }
+
+        // Load slide from URL hash
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash) {
+                const slideNum = parseInt(hash) - 1;
+                if (!isNaN(slideNum)) {
+                    currentSlide = slideNum;
+                }
+            }
+            updateSlideDisplay(false);
+        });
+    </script>
+</body>
+</html>

--- a/slides/basics/day-12/index.html
+++ b/slides/basics/day-12/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Day 12 — Basics Course Slides</title>
+    <style>
+        :root {
+            --bg: #f7f7f7;
+            --fg: #111;
+            --accent: #0066ff;
+            --accent-light: #e6f0ff;
+            --border: #ddd;
+            --font: system-ui, -apple-system, "Segoe UI", sans-serif;
+        }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: var(--font);
+            background: var(--bg);
+            color: var(--fg);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 40px 20px;
+        }
+        .card {
+            background: #fff;
+            border-radius: 12px;
+            box-shadow: 0 4px 24px rgba(0,0,0,0.10);
+            padding: 48px 56px;
+            max-width: 640px;
+            width: 100%;
+        }
+        .badge {
+            display: inline-block;
+            background: var(--accent);
+            color: #fff;
+            font-size: 0.75rem;
+            font-weight: 700;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            padding: 3px 10px;
+            border-radius: 20px;
+            margin-bottom: 18px;
+        }
+        h1 {
+            font-size: 1.9rem;
+            font-weight: 700;
+            line-height: 1.2;
+            margin-bottom: 8px;
+            color: var(--fg);
+        }
+        .subtitle {
+            color: #666;
+            font-size: 1rem;
+            margin-bottom: 32px;
+        }
+        .session-list {
+            list-style: none;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            overflow: hidden;
+            margin-bottom: 32px;
+        }
+        .session-list li {
+            border-bottom: 1px solid var(--border);
+        }
+        .session-list li:last-child { border-bottom: none; }
+        .session-list a {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            padding: 16px 20px;
+            text-decoration: none;
+            color: var(--fg);
+            transition: background 0.15s;
+        }
+        .session-list a:hover { background: var(--accent-light); }
+        .session-list .num {
+            background: var(--accent-light);
+            color: var(--accent);
+            font-weight: 700;
+            font-size: 0.82rem;
+            padding: 4px 10px;
+            border-radius: 20px;
+            white-space: nowrap;
+        }
+        .session-list .info { flex: 1; }
+        .session-list .info strong { display: block; font-size: 0.97rem; }
+        .session-list .info span { font-size: 0.82rem; color: #888; }
+        .session-list .arrow { color: var(--accent); font-size: 1.2rem; }
+        .meta {
+            font-size: 0.8rem;
+            color: #aaa;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+<div class="card">
+    <span class="badge">Python Basics · Day 12</span>
+    <h1>Day 12 — Session 12<br>Capstone Delivery and Final Review</h1>
+    <p class="subtitle">Hours 45–48 &nbsp;·&nbsp; Python Programming (Basic)</p>
+
+    <ul class="session-list">
+        <li>
+            <a href="day-12-session-12.html">
+                <span class="num">Session 12</span>
+                <span class="info">
+                    <strong>Capstone Delivery and Final Review</strong>
+                    <span>54 slides · Hours 45–48</span>
+                </span>
+                <span class="arrow">→</span>
+            </a>
+        </li>
+    </ul>
+
+    <p class="meta">
+        In the deck, press <kbd>←</kbd> <kbd>→</kbd> or <kbd>Space</kbd> to navigate slides
+    </p>
+</div>
+</body>
+</html>

--- a/slides/basics/day-12/index.html
+++ b/slides/basics/day-12/index.html
@@ -109,7 +109,7 @@
                 <span class="num">Session 12</span>
                 <span class="info">
                     <strong>Capstone Delivery and Final Review</strong>
-                    <span>54 slides · Hours 45–48</span>
+                    <span>35 slides · Hours 45–48</span>
                 </span>
                 <span class="arrow">→</span>
             </a>


### PR DESCRIPTION
## Summary
- Add the missing Basics Day 12 slide source deck for Session 12 / Hours 45-48.
- Generate source-adjacent standalone HTML under `Basics/lessons/slides/day-12/`.
- Add the public static mirror under `slides/basics/day-12/`, including `index.html` and `README.md` to match existing day-level conventions.
- Close stale slide/source issues #347, #349, and #350 after confirming the current tree already resolves them.

## Validation
- `bash validate_slides.sh Basics/lessons/slides/day-12`
- `bash validate_slides.sh slides/basics/day-12`
- `git diff --cached --check` before each commit
- Review-agent pass plus rubber-duck critique; added the missing public mirror `index.html` and `README.md` from that feedback.

Closes #348