### PR TITLE
Security: Pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/autograder.yml
+++ b/.github/workflows/autograder.yml
@@ -28,7 +28,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Prepare autograder configuration
         id: prepare_autograder
@@ -145,7 +145,7 @@ jobs:
       
       - name: Run autograder
         if: steps.prepare_autograder.outputs.any_submission_found == 'true'
-        uses: webtech-network/autograder@v1
+        uses: webtech-network/autograder@de364dd67c5f4dc04b77896ce695ff72db5529cc # v1
         with:
           template_preset: 'io'
           feedback-type: 'default'
@@ -577,7 +577,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Validate autograder source configuration
         run: |

--- a/.github/workflows/marp-action.yml
+++ b/.github/workflows/marp-action.yml
@@ -35,20 +35,20 @@ jobs:
       deployments: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
           
       - name: Convert Basics slide Markdown into HTML and PDF
-        uses: KoharaKazuya/marp-cli-action@v4
+        uses: KoharaKazuya/marp-cli-action@0810e250c2fcf4e81b17012e35cffacd1b9e976b # v4
         with:
           config-file: ./.marprc.yml
 
       - name: Convert Advanced slide Markdown into HTML and PDF
         if: ${{ hashFiles('Advanced/lessons/slides/day-*/**/*.md') != '' }}
-        uses: KoharaKazuya/marp-cli-action@v4
+        uses: KoharaKazuya/marp-cli-action@0810e250c2fcf4e81b17012e35cffacd1b9e976b # v4
         with:
           config-file: ./.marprc.yml
           args: --input-dir Advanced/lessons/slides --output _site/slides/advanced
@@ -169,7 +169,7 @@ jobs:
           fi
         
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: '_site'
 
@@ -191,5 +191,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         


### PR DESCRIPTION
Issue #161: Security & Supply Chain Risks - GitHub Actions Pinning

Pins all GitHub Actions to immutable commit SHAs instead of mutable version tags to prevent tag-spoofing attacks and ensure reproducible builds.

Changes:
- Autograder: Pinned checkout (v6) and webtech-network/autograder (v1)
- Marp/Pages: Pinned checkout, configure-pages, marp-cli-action, upload-artifact, deploy-pages

Resolves #161