### PR TITLE
Implement the Epic #419 course portal rollout

### DIFF
--- a/.github/workflows/marp-action.yml
+++ b/.github/workflows/marp-action.yml
@@ -8,6 +8,14 @@ on:
       - "Advanced/lessons/slides/day-*/**"
       - "Basics/lessons/slides/**"
       - "Advanced/lessons/slides/**"
+      - "Basics/lessons/lecture/**"
+      - "Advanced/lessons/lecture/**"
+      - "Basics/assignments/**"
+      - "Advanced/assignments/**"
+      - "Basics/quizzes/**"
+      - "Advanced/quizzes/**"
+      - "slides/**"
+      - "scripts/generate_portal_manifest.py"
       - ".marprc.yml"
       - ".github/workflows/marp-action.yml"
       - "_site/slides/**"
@@ -151,6 +159,38 @@ jobs:
             fi
           fi
 
+          mkdir -p _site/slides/shared/portal
+          if [ -d slides/shared/portal ]; then
+            cp -R slides/shared/portal/. _site/slides/shared/portal
+          fi
+
+          if [ -f Basics/lessons/slides/index.html ]; then
+            mkdir -p _site/slides/basics
+            cp Basics/lessons/slides/index.html _site/slides/basics/index.html
+          fi
+
+          if [ -f Advanced/lessons/slides/index.html ]; then
+            mkdir -p _site/slides/advanced
+            cp Advanced/lessons/slides/index.html _site/slides/advanced/index.html
+          fi
+
+          python scripts/generate_portal_manifest.py --repo-root . --site-root _site --output _site/slides/shared/portal/course-manifest.json
+
+          if [ -f slides/index.html ]; then
+            cp slides/index.html _site/index.html
+            FOUND_INDEX=1
+            echo "Copied slides/index.html as the root course entrypoint."
+          fi
+
+          if [ -f slides/printable-index.html ]; then
+            mkdir -p _site/slides
+            cp slides/printable-index.html _site/slides/printable-index.html
+          fi
+
+          if [ -f slides/404.html ]; then
+            cp slides/404.html _site/404.html
+          fi
+
           # mkdir -p _site/slides
           # mkdir -p _site/slides/advanced
           if [ "${FOUND_INDEX:-0}" -eq 0 ]; then
@@ -211,7 +251,10 @@ jobs:
           else
             echo "Using generated _site/index.html."
           fi
-        
+
+      - name: Validate portal publish contract
+        run: python scripts/check_portal_publish.py --repo-root . --site-root _site
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:

--- a/.github/workflows/marp-action.yml
+++ b/.github/workflows/marp-action.yml
@@ -16,6 +16,7 @@ on:
       - "Advanced/quizzes/**"
       - "slides/**"
       - "scripts/generate_portal_manifest.py"
+      - "scripts/check_portal_publish.py"
       - ".marprc.yml"
       - ".github/workflows/marp-action.yml"
       - "_site/slides/**"

--- a/Advanced/lessons/slides/index.html
+++ b/Advanced/lessons/slides/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Basics Module Portal</title>
+    <title>Advanced Module Portal</title>
     <style>
         body {
             margin: 0;
@@ -52,11 +52,6 @@
             color: #0066ff;
             font-weight: 700;
         }
-
-        .fallback-note {
-            color: #4f5b66;
-            font-size: 0.95rem;
-        }
     </style>
     <script>
         (function () {
@@ -94,28 +89,28 @@
         })();
     </script>
 </head>
-<body class="portal-page" data-portal-root="module" data-module-id="basics">
-    <a class="portal-skip-link" href="#main-content">Skip to Basics day grid</a>
+<body class="portal-page" data-portal-root="module" data-module-id="advanced">
+    <a class="portal-skip-link" href="#main-content">Skip to Advanced day grid</a>
     <main id="main-content" class="portal-shell fallback-shell" role="main">
         <nav class="portal-breadcrumbs fallback-panel" aria-label="Breadcrumb">
             <a href="../../index.html" data-source-href="slides/index.html">Course portal</a>
             <span class="portal-breadcrumb-separator" aria-hidden="true">/</span>
-            <span>Basics</span>
+            <span>Advanced</span>
         </nav>
 
         <header class="portal-header">
-            <section class="portal-hero fallback-panel" aria-labelledby="basics-portal-title">
-                <span class="portal-kicker">Module 1 · PCEP aligned</span>
-                <h1 id="basics-portal-title">Python Programming: Basic</h1>
+            <section class="portal-hero fallback-panel" aria-labelledby="advanced-portal-title">
+                <span class="portal-kicker">Module 2 · Applied project track</span>
+                <h1 id="advanced-portal-title">Python Programming: Advanced</h1>
                 <p class="subtitle">
-                    Interactive HTML slide decks for Python programming lessons. This module portal keeps the existing day-by-day content map while making the full 48-hour Basics sequence easier to browse by day and artifact.
+                    Interactive HTML slide decks for the project-focused half of the course. This portal organizes the Advanced track across object design, GUI development, sqlite, REST APIs, analytics, testing, and delivery.
                 </p>
                 <div class="portal-actions">
                     <a class="portal-button" data-variant="primary" href="day-01/day-01-session-1.html">Start with Day 1</a>
+                    <a class="portal-button" data-variant="secondary" href="day-12/day-12-session-12.html">Jump to final review</a>
                     <a class="portal-button" data-variant="secondary" href="../../index.html" data-source-href="slides/index.html">Back to course portal</a>
-                    <a class="portal-button" data-variant="secondary" href="../advanced/index.html" data-source-href="Advanced/lessons/slides/index.html">Continue to Advanced</a>
                 </div>
-                <div class="portal-stats-grid" aria-label="Basics module summary">
+                <div class="portal-stats-grid" aria-label="Advanced module summary">
                     <div class="portal-stat">
                         <strong data-module-total-days>12</strong>
                         <span>day decks</span>
@@ -135,7 +130,7 @@
                 </div>
             </section>
 
-            <aside class="portal-toolbar" aria-label="Basics portal tools">
+            <aside class="portal-toolbar" aria-label="Advanced portal tools">
                 <section class="portal-panel">
                     <h2>Theme</h2>
                     <div class="portal-theme-row">
@@ -150,16 +145,17 @@
                 <section class="portal-panel">
                     <h2>Module notes</h2>
                     <p class="portal-note">
-                        Day-deck links stay static and relative so this page works both from the source tree and from the published Basics portal path. Manifest data enhances badges and repository artifact links when JavaScript is available.
+                        Advanced keeps the same static-first portal structure as Basics, but frames the work as an applied build track. Need a fundamentals refresher? Reopen the
+                        <a href="../basics/index.html" data-source-href="Basics/lessons/slides/index.html">Basics module portal</a>.
                     </p>
                 </section>
             </aside>
         </header>
 
-        <section class="portal-section fallback-panel" aria-labelledby="basics-day-grid-title">
-            <h2 id="basics-day-grid-title">Basics day grid</h2>
+        <section class="portal-section fallback-panel" aria-labelledby="advanced-day-grid-title">
+            <h2 id="advanced-day-grid-title">Advanced day grid</h2>
             <p>
-                The day descriptions and lecture-file references below remain the core content map for the module. The shared portal layer adds theme persistence, repository artifact links, and manifest-backed badge status without replacing the direct deck links.
+                Each day card points directly to the session deck while preserving the runbook-aligned topic map. Manifest enhancement fills in artifact status and repository links without changing the published deck routes.
             </p>
 
             <div class="portal-day-grid fallback-grid">
@@ -168,17 +164,16 @@
                     <p class="portal-summary">
                         <a href="day-01/day-01-session-1.html">Open Presentation</a>
                         <br>
-                        Comprehensive basics covering environment setup, print(), variables, and operators
+                        Advanced kickoff, class design from requirements, invariants, custom exceptions, and composition vs inheritance
                     </p>
-                    <p class="portal-note">59-slide session deck</p>
                     <div class="portal-badge-row" data-day-badges="day-01">
-                        <span class="portal-badge">Slides ✓</span>
-                        <span class="portal-badge">Lecture ✓</span>
-                        <span class="portal-badge">Assignment ✓</span>
-                        <span class="portal-badge">Quiz ✓</span>
+                        <span class="portal-badge">Slides</span>
+                        <span class="portal-badge">Lecture</span>
+                        <span class="portal-badge">Assignment</span>
+                        <span class="portal-badge">Quiz</span>
                     </div>
                     <div class="portal-summary">
-                        <em>Per-hour lecture source files: <code>lecture/Day1_Hour1_Basics.md</code> through <code>lecture/Day1_Hour4_Basics.md</code></em>
+                        <em>Per-hour lecture source files: <code>lecture/Day1_Hour1_Advanced.md</code> through <code>lecture/Day1_Hour4_Advanced.md</code></em>
                     </div>
                     <div class="portal-chip-list portal-day-links" data-day-links="day-01">
                         <p class="portal-note">Repository artifact links load here when JavaScript is available.</p>
@@ -188,19 +183,18 @@
                 <article class="portal-card fallback-card" data-day-id="day-02">
                     <h3>Day 2 — Session 2 (Hours 5–8)</h3>
                     <p class="portal-summary">
-                        <a href="day-02/day-02-session-2.html">Open Full Session Presentation</a>
+                        <a href="day-02/day-02-session-2.html">Open Presentation</a>
                         <br>
-                        Strings (indexing, slicing, methods), Input/Output, Type conversion, and Checkpoint 1
+                        Factory and Strategy patterns, class ergonomics, type hints, and Checkpoint 1 for the domain plus service layer
                     </p>
-                    <p class="portal-note">74-slide session deck</p>
                     <div class="portal-badge-row" data-day-badges="day-02">
-                        <span class="portal-badge">Slides ✓</span>
-                        <span class="portal-badge">Lecture ✓</span>
-                        <span class="portal-badge">Assignment ✓</span>
-                        <span class="portal-badge">Quiz ✓</span>
+                        <span class="portal-badge">Slides</span>
+                        <span class="portal-badge">Lecture</span>
+                        <span class="portal-badge">Assignment</span>
+                        <span class="portal-badge">Quiz</span>
                     </div>
                     <div class="portal-summary">
-                        <em>Per-hour lecture source files: <code>lecture/Day2_Hour1_Basics.md</code> through <code>Day2_Hour4_Basics.md</code> (runbook Session 2 / course Hours 5–8; HTML deck covers full session)</em>
+                        <em>Per-hour lecture source files: <code>lecture/Day2_Hour1_Advanced.md</code> through <code>lecture/Day2_Hour4_Advanced.md</code></em>
                     </div>
                     <div class="portal-chip-list portal-day-links" data-day-links="day-02">
                         <p class="portal-note">Repository artifact links load here when JavaScript is available.</p>
@@ -210,19 +204,18 @@
                 <article class="portal-card fallback-card" data-day-id="day-03">
                     <h3>Day 3 — Session 3 (Hours 9–12)</h3>
                     <p class="portal-summary">
-                        <a href="day-03/day-03-session-3.html">Open Full Session Presentation</a>
+                        <a href="day-03/day-03-session-3.html">Open Presentation</a>
                         <br>
-                        Comparisons &amp; boolean logic, f-string formatting, split/join text processing, and debugging habits
+                        Project structure, packages, logging, safer file operations with context managers, and decorators for timing, validation, or authorization
                     </p>
-                    <p class="portal-note">48-slide session deck</p>
                     <div class="portal-badge-row" data-day-badges="day-03">
-                        <span class="portal-badge">Slides ✓</span>
-                        <span class="portal-badge">Lecture ✓</span>
-                        <span class="portal-badge">Assignment ✓</span>
-                        <span class="portal-badge">Quiz ✓</span>
+                        <span class="portal-badge">Slides</span>
+                        <span class="portal-badge">Lecture</span>
+                        <span class="portal-badge">Assignment</span>
+                        <span class="portal-badge">Quiz</span>
                     </div>
                     <div class="portal-summary">
-                        <em>Per-hour lecture source files: <code>lecture/Day3_Hour1_Basics.md</code> through <code>lecture/Day3_Hour4_Basics.md</code> (HTML deck covers full session)</em>
+                        <em>Per-hour lecture source files: <code>lecture/Day3_Hour1_Advanced.md</code> through <code>lecture/Day3_Hour4_Advanced.md</code></em>
                     </div>
                     <div class="portal-chip-list portal-day-links" data-day-links="day-03">
                         <p class="portal-note">Repository artifact links load here when JavaScript is available.</p>
@@ -232,19 +225,18 @@
                 <article class="portal-card fallback-card" data-day-id="day-04">
                     <h3>Day 4 — Session 4 (Hours 13–16)</h3>
                     <p class="portal-summary">
-                        <a href="day-04/day-04-session-4.html">Open Full Session Presentation</a>
+                        <a href="day-04/day-04-session-4.html">Open Presentation</a>
                         <br>
-                        Lists fundamentals, iterating lists with <code>for</code> loops, nested lists, and Checkpoint 2
+                        HTTP client work, security basics, capstone planning, and Checkpoint 2 for persistence-ready core plus JSON save/load
                     </p>
-                    <p class="portal-note">53-slide session deck</p>
                     <div class="portal-badge-row" data-day-badges="day-04">
-                        <span class="portal-badge">Slides ✓</span>
-                        <span class="portal-badge">Lecture ✓</span>
-                        <span class="portal-badge">Assignment ✓</span>
-                        <span class="portal-badge">Quiz ✓</span>
+                        <span class="portal-badge">Slides</span>
+                        <span class="portal-badge">Lecture</span>
+                        <span class="portal-badge">Assignment</span>
+                        <span class="portal-badge">Quiz</span>
                     </div>
                     <div class="portal-summary">
-                        <em>Per-hour lecture source files: <code>lecture/Day4_Hour1_Basics.md</code> through <code>lecture/Day4_Hour4_Basics.md</code> (HTML deck covers full session)</em>
+                        <em>Per-hour lecture source files: <code>lecture/Day4_Hour1_Advanced.md</code> through <code>lecture/Day4_Hour4_Advanced.md</code></em>
                     </div>
                     <div class="portal-chip-list portal-day-links" data-day-links="day-04">
                         <p class="portal-note">Repository artifact links load here when JavaScript is available.</p>
@@ -254,18 +246,18 @@
                 <article class="portal-card fallback-card" data-day-id="day-05">
                     <h3>Day 5 — Session 5 (Hours 17–20)</h3>
                     <p class="portal-summary">
-                        <a href="day-05/day-05-session-5.html">Open Full Session Presentation</a>
+                        <a href="day-05/day-05-session-5.html">Open Presentation</a>
                         <br>
-                        Tuples: immutability, packing/unpacking, use cases, and tuple vs list trade-offs
+                        GUI fundamentals with Tkinter and ttk, layout systems, validation feedback, and record list interfaces
                     </p>
                     <div class="portal-badge-row" data-day-badges="day-05">
-                        <span class="portal-badge">Slides ✓</span>
-                        <span class="portal-badge">Lecture ✓</span>
-                        <span class="portal-badge">Assignment ✓</span>
-                        <span class="portal-badge">Quiz ✓</span>
+                        <span class="portal-badge">Slides</span>
+                        <span class="portal-badge">Lecture</span>
+                        <span class="portal-badge">Assignment</span>
+                        <span class="portal-badge">Quiz</span>
                     </div>
                     <div class="portal-summary">
-                        <em>Per-hour lecture source files: <code>lecture/Day5_Hour1_Basics.md</code> through <code>lecture/Day5_Hour4_Basics.md</code></em>
+                        <em>Per-hour lecture source files: <code>lecture/Day5_Hour1_Advanced.md</code> through <code>lecture/Day5_Hour4_Advanced.md</code></em>
                     </div>
                     <div class="portal-chip-list portal-day-links" data-day-links="day-05">
                         <p class="portal-note">Repository artifact links load here when JavaScript is available.</p>
@@ -275,18 +267,18 @@
                 <article class="portal-card fallback-card" data-day-id="day-06">
                     <h3>Day 6 — Session 6 (Hours 21–24)</h3>
                     <p class="portal-summary">
-                        <a href="day-06/day-06-session-6.html">Open Full Session Presentation</a>
+                        <a href="day-06/day-06-session-6.html">Open Presentation</a>
                         <br>
-                        Sets and Dictionaries: creation, operations, comprehensions, and Checkpoint 3
+                        CRUD wiring in the GUI, controller separation, callback cleanup, mini-project polish, and Checkpoint 3
                     </p>
                     <div class="portal-badge-row" data-day-badges="day-06">
-                        <span class="portal-badge">Slides ✓</span>
-                        <span class="portal-badge">Lecture ✓</span>
-                        <span class="portal-badge">Assignment ✓</span>
-                        <span class="portal-badge">Quiz ✓</span>
+                        <span class="portal-badge">Slides</span>
+                        <span class="portal-badge">Lecture</span>
+                        <span class="portal-badge">Assignment</span>
+                        <span class="portal-badge">Quiz</span>
                     </div>
                     <div class="portal-summary">
-                        <em>Per-hour lecture source files: <code>lecture/Day6_Hour1_Basics.md</code> through <code>lecture/Day6_Hour4_Basics.md</code></em>
+                        <em>Per-hour lecture source files: <code>lecture/Day6_Hour1_Advanced.md</code> through <code>lecture/Day6_Hour4_Advanced.md</code></em>
                     </div>
                     <div class="portal-chip-list portal-day-links" data-day-links="day-06">
                         <p class="portal-note">Repository artifact links load here when JavaScript is available.</p>
@@ -296,18 +288,18 @@
                 <article class="portal-card fallback-card" data-day-id="day-07">
                     <h3>Day 7 — Session 7 (Hours 25–28)</h3>
                     <p class="portal-summary">
-                        <a href="day-07/day-07-session-7.html">Open Full Session Presentation</a>
+                        <a href="day-07/day-07-session-7.html">Open Presentation</a>
                         <br>
-                        Conditionals: if/elif/else logic, nested conditions, boolean operators, and match/case
+                        Schema thinking, sqlite CRUD, row mapping, transactions, and database initialization patterns
                     </p>
                     <div class="portal-badge-row" data-day-badges="day-07">
-                        <span class="portal-badge">Slides ✓</span>
-                        <span class="portal-badge">Lecture ✓</span>
-                        <span class="portal-badge">Assignment ✓</span>
-                        <span class="portal-badge">Quiz ✓</span>
+                        <span class="portal-badge">Slides</span>
+                        <span class="portal-badge">Lecture</span>
+                        <span class="portal-badge">Assignment</span>
+                        <span class="portal-badge">Quiz</span>
                     </div>
                     <div class="portal-summary">
-                        <em>Per-hour lecture source files: <code>lecture/Day7_Hour1_Basics.md</code> through <code>lecture/Day7_Hour4_Basics.md</code></em>
+                        <em>Per-hour lecture source files: <code>lecture/Day7_Hour1_Advanced.md</code> through <code>lecture/Day7_Hour4_Advanced.md</code></em>
                     </div>
                     <div class="portal-chip-list portal-day-links" data-day-links="day-07">
                         <p class="portal-note">Repository artifact links load here when JavaScript is available.</p>
@@ -317,18 +309,18 @@
                 <article class="portal-card fallback-card" data-day-id="day-08">
                     <h3>Day 8 — Session 8 (Hours 29–32)</h3>
                     <p class="portal-summary">
-                        <a href="day-08/day-08-session-8.html">Open Full Session Presentation</a>
+                        <a href="day-08/day-08-session-8.html">Open Presentation</a>
                         <br>
-                        Loops: while loops, break/continue/pass, input validation, and CLI mini-project
+                        SQLAlchemy or deeper SQL practice, database integration, search and pagination patterns, and Checkpoint 4
                     </p>
                     <div class="portal-badge-row" data-day-badges="day-08">
-                        <span class="portal-badge">Slides ✓</span>
-                        <span class="portal-badge">Lecture ✓</span>
-                        <span class="portal-badge">Assignment ✓</span>
-                        <span class="portal-badge">Quiz ✓</span>
+                        <span class="portal-badge">Slides</span>
+                        <span class="portal-badge">Lecture</span>
+                        <span class="portal-badge">Assignment</span>
+                        <span class="portal-badge">Quiz</span>
                     </div>
                     <div class="portal-summary">
-                        <em>Per-hour lecture source files: <code>lecture/Day8_Hour1_Basics.md</code> through <code>lecture/Day8_Hour4_Basics.md</code></em>
+                        <em>Per-hour lecture source files: <code>lecture/Day8_Hour1_Advanced.md</code> through <code>lecture/Day8_Hour4_Advanced.md</code></em>
                     </div>
                     <div class="portal-chip-list portal-day-links" data-day-links="day-08">
                         <p class="portal-note">Repository artifact links load here when JavaScript is available.</p>
@@ -338,18 +330,18 @@
                 <article class="portal-card fallback-card" data-day-id="day-09">
                     <h3>Day 9 — Session 9 (Hours 33–36)</h3>
                     <p class="portal-summary">
-                        <a href="day-09/day-09-session-9.html">Open Full Session Presentation</a>
+                        <a href="day-09/day-09-session-9.html">Open Presentation</a>
                         <br>
-                        Functions: def/parameters/return, scope, collections in functions, and modules
+                        REST fundamentals, Flask setup, CRUD endpoints, serialization, validation, and service wiring
                     </p>
                     <div class="portal-badge-row" data-day-badges="day-09">
-                        <span class="portal-badge">Slides ✓</span>
-                        <span class="portal-badge">Lecture ✓</span>
-                        <span class="portal-badge">Assignment ✓</span>
-                        <span class="portal-badge">Quiz ✓</span>
+                        <span class="portal-badge">Slides</span>
+                        <span class="portal-badge">Lecture</span>
+                        <span class="portal-badge">Assignment</span>
+                        <span class="portal-badge">Quiz</span>
                     </div>
                     <div class="portal-summary">
-                        <em>Per-hour lecture source files: <code>lecture/Day9_Hour1_Basics.md</code> through <code>lecture/Day9_Hour4_Basics.md</code></em>
+                        <em>Per-hour lecture source files: <code>lecture/Day9_Hour1_Advanced.md</code> through <code>lecture/Day9_Hour4_Advanced.md</code></em>
                     </div>
                     <div class="portal-chip-list portal-day-links" data-day-links="day-09">
                         <p class="portal-note">Repository artifact links load here when JavaScript is available.</p>
@@ -359,18 +351,18 @@
                 <article class="portal-card fallback-card" data-day-id="day-10">
                     <h3>Day 10 — Session 10 (Hours 37–40)</h3>
                     <p class="portal-summary">
-                        <a href="day-10/day-10-session-10.html">Open Full Session Presentation</a>
+                        <a href="day-10/day-10-session-10.html">Open Presentation</a>
                         <br>
-                        OOP and Classes: class definition, attributes/methods, inheritance, and Checkpoint 4
+                        API security basics, Python client functions, integration choices, and Checkpoint 5 for the API milestone
                     </p>
                     <div class="portal-badge-row" data-day-badges="day-10">
-                        <span class="portal-badge">Slides ✓</span>
-                        <span class="portal-badge">Lecture ✓</span>
-                        <span class="portal-badge">Assignment ✓</span>
-                        <span class="portal-badge">Quiz ✓</span>
+                        <span class="portal-badge">Slides</span>
+                        <span class="portal-badge">Lecture</span>
+                        <span class="portal-badge">Assignment</span>
+                        <span class="portal-badge">Quiz</span>
                     </div>
                     <div class="portal-summary">
-                        <em>Per-hour lecture source files: <code>lecture/Day10_Hour1_Basics.md</code> through <code>lecture/Day10_Hour4_Basics.md</code></em>
+                        <em>Per-hour lecture source files: <code>lecture/Day10_Hour1_Advanced.md</code> through <code>lecture/Day10_Hour4_Advanced.md</code></em>
                     </div>
                     <div class="portal-chip-list portal-day-links" data-day-links="day-10">
                         <p class="portal-note">Repository artifact links load here when JavaScript is available.</p>
@@ -380,18 +372,18 @@
                 <article class="portal-card fallback-card" data-day-id="day-11">
                     <h3>Day 11 — Session 11 (Hours 41–44)</h3>
                     <p class="portal-summary">
-                        <a href="day-11/day-11-session-11.html">Open Full Session Presentation</a>
+                        <a href="day-11/day-11-session-11.html">Open Presentation</a>
                         <br>
-                        File I/O and Exception Handling: read/write files, try/except, and error management
+                        Pandas essentials, matplotlib visualizations, a practical regression demo, and analytics integration for the capstone
                     </p>
                     <div class="portal-badge-row" data-day-badges="day-11">
-                        <span class="portal-badge">Slides ✓</span>
-                        <span class="portal-badge">Lecture ✓</span>
-                        <span class="portal-badge">Assignment ✓</span>
-                        <span class="portal-badge">Quiz ✓</span>
+                        <span class="portal-badge">Slides</span>
+                        <span class="portal-badge">Lecture</span>
+                        <span class="portal-badge">Assignment</span>
+                        <span class="portal-badge">Quiz</span>
                     </div>
                     <div class="portal-summary">
-                        <em>Per-hour lecture source files: <code>lecture/Day11_Hour1_Basics.md</code> through <code>lecture/Day11_Hour4_Basics.md</code></em>
+                        <em>Per-hour lecture source files: <code>lecture/Day11_Hour1_Advanced.md</code> through <code>lecture/Day11_Hour4_Advanced.md</code></em>
                     </div>
                     <div class="portal-chip-list portal-day-links" data-day-links="day-11">
                         <p class="portal-note">Repository artifact links load here when JavaScript is available.</p>
@@ -401,18 +393,18 @@
                 <article class="portal-card fallback-card" data-day-id="day-12">
                     <h3>Day 12 — Session 12 (Hours 45–48)</h3>
                     <p class="portal-summary">
-                        <a href="day-12/day-12-session-12.html">Open Full Session Presentation</a>
+                        <a href="day-12/day-12-session-12.html">Open Presentation</a>
                         <br>
-                        Capstone project, final review, PCEP exam prep, and course wrap-up
+                        pytest, coverage, packaging, runnable delivery, final capstone demo, and certification-style review
                     </p>
                     <div class="portal-badge-row" data-day-badges="day-12">
-                        <span class="portal-badge">Slides ✓</span>
-                        <span class="portal-badge">Lecture ✓</span>
-                        <span class="portal-badge">Assignment ✓</span>
-                        <span class="portal-badge">Quiz ✓</span>
+                        <span class="portal-badge">Slides</span>
+                        <span class="portal-badge">Lecture</span>
+                        <span class="portal-badge">Assignment</span>
+                        <span class="portal-badge">Quiz</span>
                     </div>
                     <div class="portal-summary">
-                        <em>Per-hour lecture source files: <code>lecture/Day12_Hour1_Basics.md</code> through <code>lecture/Day12_Hour4_Basics.md</code></em>
+                        <em>Per-hour lecture source files: <code>lecture/Day12_Hour1_Advanced.md</code> through <code>lecture/Day12_Hour4_Advanced.md</code></em>
                     </div>
                     <div class="portal-chip-list portal-day-links" data-day-links="day-12">
                         <p class="portal-note">Repository artifact links load here when JavaScript is available.</p>
@@ -421,23 +413,23 @@
             </div>
         </section>
 
-        <section class="portal-section fallback-panel" aria-labelledby="basics-portal-features">
-            <h2 id="basics-portal-features">Portal features</h2>
+        <section class="portal-section fallback-panel" aria-labelledby="advanced-portal-features">
+            <h2 id="advanced-portal-features">Portal features</h2>
             <p>
-                The Basics portal remains offline-friendly and dependency-free while adding theme persistence, repository artifact links, and clearer day-by-day wayfinding for all twelve sessions.
+                The Advanced portal keeps the same dependency-free delivery model as the rest of the site while surfacing the full applied track from object design through final delivery.
             </p>
             <div class="portal-badge-row">
-                <span class="portal-badge">Offline Ready</span>
-                <span class="portal-badge">Responsive Design</span>
-                <span class="portal-badge">No Dependencies</span>
+                <span class="portal-badge">GUI + API path</span>
+                <span class="portal-badge">SQLite + ORM</span>
+                <span class="portal-badge">Analytics</span>
+                <span class="portal-badge">pytest</span>
                 <span class="portal-badge">Theme Toggle</span>
-                <span class="portal-badge">Manifest-backed badges</span>
             </div>
         </section>
 
         <footer class="portal-footer">
             <p>
-                Module portal source: <code>Basics/lessons/slides/index.html</code>. Published module entrypoint: <code>_site/slides/basics/index.html</code>.
+                Module portal source: <code>Advanced/lessons/slides/index.html</code>. Published module entrypoint: <code>_site/slides/advanced/index.html</code>.
             </p>
         </footer>
     </main>

--- a/Advanced/lessons/slides/index.html
+++ b/Advanced/lessons/slides/index.html
@@ -55,14 +55,29 @@
     </style>
     <script>
         (function () {
-            const repoMarker = "/python_programming_courses/";
             const pathname = window.location.pathname;
-            const basePath = pathname.includes(repoMarker)
-                ? pathname.slice(0, pathname.indexOf(repoMarker) + repoMarker.length)
-                : "/";
+            const isSourcePreview = pathname.includes("/Basics/lessons/slides/") || pathname.includes("/Advanced/lessons/slides/");
+
+            function computeBasePath(siteRelativePath) {
+                const normalizedSitePath = siteRelativePath.replace(/^\/+/, "");
+                const suffix = `/${normalizedSitePath}`;
+                if (pathname === suffix) {
+                    return "/";
+                }
+                if (pathname.endsWith(suffix)) {
+                    return pathname.slice(0, -normalizedSitePath.length);
+                }
+                if (pathname.endsWith(normalizedSitePath)) {
+                    const base = pathname.slice(0, -normalizedSitePath.length);
+                    return base || "/";
+                }
+                return "/";
+            }
+
+            const basePath = isSourcePreview ? "/" : computeBasePath("slides/advanced/index.html");
             window.__PYC_BASE_PATH = basePath;
             // Treat source-tree slide paths as preview mode even when they are served from a local static server.
-            window.__PYC_SOURCE_PREVIEW = pathname.includes("/Basics/lessons/slides/") || pathname.includes("/Advanced/lessons/slides/");
+            window.__PYC_SOURCE_PREVIEW = isSourcePreview;
 
             document.addEventListener("DOMContentLoaded", function () {
                 if (!window.__PYC_SOURCE_PREVIEW) {

--- a/Advanced/themes/python-dark.css
+++ b/Advanced/themes/python-dark.css
@@ -1,12 +1,22 @@
 /* @theme python-dark */
 @import 'gaia';
 
+/* Portal pages consume slides/shared/portal/portal.css directly; keep shared semantic tokens
+   aligned here so Marp decks and portal surfaces do not drift. */
 :root {
   --bg: #0d1117;
   --fg: #e6edf3;
   --muted: #9da7b1;
   --accent: #2f81f7;
   --accent-contrast: #0d1117;
+  --border: #30363d;
+  --surface-1: rgba(22, 27, 34, 0.9);
+  --surface-2: rgba(15, 22, 34, 0.92);
+  --focus-ring: rgba(47, 129, 247, 0.4);
+  --shadow: 0 18px 40px rgba(0, 0, 0, 0.38);
+  --radius-md: 16px;
+  --radius-lg: 24px;
+  --space-base: 24px;
 
   --code-bg: #161b22;
   --code-fg: #c9d1d9;

--- a/Advanced/themes/python-light.css
+++ b/Advanced/themes/python-light.css
@@ -1,13 +1,23 @@
 /* @theme python-light */
 @import 'gaia';
 
-/* Color system */
+/* Color system
+   Portal pages consume slides/shared/portal/portal.css directly; keep shared semantic tokens
+   aligned here so Marp decks and portal surfaces do not drift. */
 :root {
   --bg: #ffffff;
   --fg: #1f2328;
   --muted: #57606a;
   --accent: #1f6feb;
   --accent-contrast: #ffffff;
+  --border: #d0d7de;
+  --surface-1: rgba(255, 255, 255, 0.92);
+  --surface-2: rgba(238, 242, 247, 0.92);
+  --focus-ring: rgba(31, 111, 235, 0.32);
+  --shadow: 0 18px 40px rgba(31, 35, 40, 0.12);
+  --radius-md: 16px;
+  --radius-lg: 24px;
+  --space-base: 24px;
 
   --code-bg: #f6f8fa;
   --code-fg: #0d1117;

--- a/Basics/lessons/slides/index.html
+++ b/Basics/lessons/slides/index.html
@@ -60,14 +60,29 @@
     </style>
     <script>
         (function () {
-            const repoMarker = "/python_programming_courses/";
             const pathname = window.location.pathname;
-            const basePath = pathname.includes(repoMarker)
-                ? pathname.slice(0, pathname.indexOf(repoMarker) + repoMarker.length)
-                : "/";
+            const isSourcePreview = pathname.includes("/Basics/lessons/slides/") || pathname.includes("/Advanced/lessons/slides/");
+
+            function computeBasePath(siteRelativePath) {
+                const normalizedSitePath = siteRelativePath.replace(/^\/+/, "");
+                const suffix = `/${normalizedSitePath}`;
+                if (pathname === suffix) {
+                    return "/";
+                }
+                if (pathname.endsWith(suffix)) {
+                    return pathname.slice(0, -normalizedSitePath.length);
+                }
+                if (pathname.endsWith(normalizedSitePath)) {
+                    const base = pathname.slice(0, -normalizedSitePath.length);
+                    return base || "/";
+                }
+                return "/";
+            }
+
+            const basePath = isSourcePreview ? "/" : computeBasePath("slides/basics/index.html");
             window.__PYC_BASE_PATH = basePath;
             // Treat source-tree slide paths as preview mode even when they are served from a local static server.
-            window.__PYC_SOURCE_PREVIEW = pathname.includes("/Basics/lessons/slides/") || pathname.includes("/Advanced/lessons/slides/");
+            window.__PYC_SOURCE_PREVIEW = isSourcePreview;
 
             document.addEventListener("DOMContentLoaded", function () {
                 if (!window.__PYC_SOURCE_PREVIEW) {

--- a/Basics/themes/python-dark.css
+++ b/Basics/themes/python-dark.css
@@ -1,12 +1,22 @@
 /* @theme python-dark */
 @import 'gaia';
 
+/* Portal pages consume slides/shared/portal/portal.css directly; keep shared semantic tokens
+   aligned here so Marp decks and portal surfaces do not drift. */
 :root {
   --bg: #0d1117;
   --fg: #e6edf3;
   --muted: #9da7b1;
   --accent: #2f81f7;
   --accent-contrast: #0d1117;
+  --border: #30363d;
+  --surface-1: rgba(22, 27, 34, 0.9);
+  --surface-2: rgba(15, 22, 34, 0.92);
+  --focus-ring: rgba(47, 129, 247, 0.4);
+  --shadow: 0 18px 40px rgba(0, 0, 0, 0.38);
+  --radius-md: 16px;
+  --radius-lg: 24px;
+  --space-base: 24px;
 
   --code-bg: #161b22;
   --code-fg: #c9d1d9;

--- a/Basics/themes/python-light.css
+++ b/Basics/themes/python-light.css
@@ -1,13 +1,23 @@
 /* @theme python-light */
 @import 'gaia';
 
-/* Color system */
+/* Color system
+   Portal pages consume slides/shared/portal/portal.css directly; keep shared semantic tokens
+   aligned here so Marp decks and portal surfaces do not drift. */
 :root {
   --bg: #ffffff;
   --fg: #1f2328;
   --muted: #57606a;
   --accent: #1f6feb;
   --accent-contrast: #ffffff;
+  --border: #d0d7de;
+  --surface-1: rgba(255, 255, 255, 0.92);
+  --surface-2: rgba(238, 242, 247, 0.92);
+  --focus-ring: rgba(31, 111, 235, 0.32);
+  --shadow: 0 18px 40px rgba(31, 35, 40, 0.12);
+  --radius-md: 16px;
+  --radius-lg: 24px;
+  --space-base: 24px;
 
   --code-bg: #f6f8fa;
   --code-fg: #0d1117;

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ No `package.json` — use `npx` directly.
 npx @marp-team/marp-cli -c .marprc.yml --input-dir Basics/lessons/slides --output _site/slides/basics
 
 # Build Advanced the same way the workflow does
-npx @marp-team/marp-cli -c .marprc.advanced.yml --no-config --input-dir Advanced/lessons/slides --output _site/slides/advanced
+npx @marp-team/marp-cli --config-file .marprc.advanced.yml --input-dir Advanced/lessons/slides --output _site/slides/advanced
 
 # Build and watch a single file during development
 npx @marp-team/marp-cli --no-config-file -w Basics/lessons/slides/day-01/day-01-session-1.md
@@ -110,7 +110,7 @@ npx @marp-team/marp-cli --no-config-file -w Basics/lessons/slides/day-01/day-01-
 npx @marp-team/marp-cli --no-config-file Basics/lessons/slides/day-01/day-01-session-1.md -o out.pdf --pdf
 ```
 
-Slides are published automatically to **GitHub Pages** on manual dispatch and on pushes to `main` that touch the workflow's configured path filters under `Basics/lessons/slides/**`, `Advanced/lessons/slides/**`, `.marprc.yml`, `.github/workflows/marp-action.yml`, or `_site/slides/**`.
+Slides are published automatically to **GitHub Pages** on manual dispatch and on pushes to `main` that touch the workflow's configured portal and slide paths, including `Basics/lessons/slides/**`, `Advanced/lessons/slides/**`, `Basics/lessons/lecture/**`, `Advanced/lessons/lecture/**`, assignment and quiz trees for both modules, `slides/**`, `scripts/generate_portal_manifest.py`, `.marprc.yml`, `.github/workflows/marp-action.yml`, or `_site/slides/**`.
 
 ### Lecture Scripts
 
@@ -234,10 +234,10 @@ python_programming_courses/
 
 | | |
 |---|---|
-| **Trigger** | `workflow_dispatch` and pushes to `main` touching `Basics/lessons/slides/**`, `Advanced/lessons/slides/**`, `.marprc.yml`, `.github/workflows/marp-action.yml`, or `_site/slides/**` |
+| **Trigger** | `workflow_dispatch` and pushes to `main` touching slide, portal, lecture, assignment, quiz, or workflow paths needed to rebuild the shared manifest and published artifact |
 | **Jobs** | `build` then `deploy`, with Pages concurrency so newer publish runs cancel older in-progress runs |
 | **Action** | Builds Basics and Advanced slide trees separately, stages a Pages artifact under `_site`, then deploys that artifact to GitHub Pages |
-| **Output** | `_site/index.html`, `_site/slides/basics/**`, and `_site/slides/advanced/**` published through the `github-pages` environment |
+| **Output** | `_site/index.html`, `_site/404.html`, `_site/slides/basics/**`, `_site/slides/advanced/**`, `_site/slides/printable-index.html`, and `_site/slides/shared/portal/**` published through the `github-pages` environment |
 
 #### `marp-action.yml` Behavior
 
@@ -245,8 +245,10 @@ python_programming_courses/
 2. **Build Advanced output** from `Advanced/lessons/slides` into `_site/slides/advanced` using `.marprc.advanced.yml`.
 3. **Remove top-level README artifacts** from generated output so the published module roots expose decks and indexes instead of root README files.
 4. **Verify published HTML exists** for both modules. If a generated module tree is missing usable HTML, the workflow falls back to copying the checked-in standalone slide site from `Basics/lessons/slides` or `Advanced/lessons/slides`.
-5. **Guarantee a GitHub Pages entrypoint**. If no generated root index is present, the workflow either copies `Basics/lessons/slides/index.html` to `_site/index.html` or writes a redirect page to the first safe published slide path it can discover.
-6. **Upload and deploy** the `_site` directory as the Pages artifact, then publish it through a separate deploy job targeting the `github-pages` environment.
+5. **Publish the shared portal foundation**. The workflow copies `slides/shared/portal/**` into the Pages artifact and generates the published manifest at `_site/slides/shared/portal/course-manifest.json`.
+6. **Publish supporting portal pages**. If present, `slides/printable-index.html` is copied to `_site/slides/printable-index.html` and `slides/404.html` is copied to `_site/404.html`.
+7. **Guarantee a GitHub Pages entrypoint**. If `slides/index.html` exists, the workflow copies it to `_site/index.html` as the dedicated root course entrypoint. If no root page exists, the fallback redirect logic still resolves the published site to the first safe slide path it can discover.
+8. **Upload and deploy** the `_site` directory as the Pages artifact, then publish it through a separate deploy job targeting the `github-pages` environment.
 
 #### Maintaining `marp-action.yml`
 
@@ -254,13 +256,15 @@ python_programming_courses/
 
   ```bash
   npx @marp-team/marp-cli -c .marprc.yml --input-dir Basics/lessons/slides --output _site/slides/basics
-  npx @marp-team/marp-cli -c .marprc.advanced.yml --no-config --input-dir Advanced/lessons/slides --output _site/slides/advanced
+  npx @marp-team/marp-cli --config-file .marprc.advanced.yml --input-dir Advanced/lessons/slides --output _site/slides/advanced
   ```
 
-- **Preserve trigger intent carefully.** Changes under `Basics/lessons/lecture/**` and `Advanced/lessons/lecture/**` do **not** currently trigger this workflow. Changes to `.marprc.advanced.yml` also do **not** currently appear in the workflow path filters even though that file is used during the Advanced build step.
+- **Preserve trigger intent carefully.** The workflow now watches the portal source tree plus lecture, assignment, and quiz paths so manifest-backed artifact badges stay current. Changes to `.marprc.advanced.yml` still do **not** currently appear in the workflow path filters even though that file is used during the Advanced build step.
 - **Keep config ownership explicit.** The workflow actively uses `.marprc.yml` for Basics and `.marprc.advanced.yml` for Advanced. A third file, `.marprc.basics.yml`, exists in the repository but is not referenced by the current workflow.
-- **Do not remove the fallback copy logic casually.** The checked-in `Basics/lessons/slides/index.html` currently serves as the most reliable static module landing page and is also part of the fallback story when generated output is incomplete.
-- **Protect the Pages root behavior.** `_site/index.html` is intentionally managed so the published site always resolves to slide content even when Marp does not emit a root landing page.
+- **Do not remove the fallback copy logic casually.** The checked-in `Basics/lessons/slides/index.html` still anchors the Basics module fallback, and `Advanced/lessons/slides/` still anchors the Advanced fallback, when generated output is incomplete.
+- **Protect the Pages root behavior.** `_site/index.html` is intentionally managed by `slides/index.html` first and by the redirect fallback second so the published site always resolves to course content.
+- **Keep supporting pages in the artifact contract.** `slides/printable-index.html` and `slides/404.html` are now first-class publish surfaces; if they exist in source, the workflow and validator are expected to stage them into `_site`.
+- **Regenerate the portal manifest whenever artifact coverage changes.** Use `python scripts/generate_portal_manifest.py` locally; CI regenerates the published manifest against `_site`.
 - **Review the pinned action SHAs and temporary runtime flags together.** The workflow opts JavaScript actions into Node 24 through `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`, and all referenced third-party actions are SHA-pinned. Update those deliberately rather than ad hoc.
 - **Treat `_site/slides/**` as a defensive trigger path.** `_site/` is build output and should not normally be committed, so edits there should usually prompt a workflow/config review rather than routine content work.
 - **Use the workflow specification for deeper changes.** See [`spec/spec-process-cicd-marp-action.md`](spec/spec-process-cicd-marp-action.md) before changing job flow, permissions, or entrypoint logic.
@@ -300,7 +304,11 @@ This index is intentionally **comprehensive but grouped**. It covers both module
 | Slide day folders | 12 folders | [`Basics/lessons/slides/`](Basics/lessons/slides/) + `day-01/` ... `day-12/` | Checked-in standalone slide tree grouped by day |
 | Slide Markdown sources | 13 files | `Basics/lessons/slides/**/*.md` | Includes day-based deck sources plus module-level slide docs such as the local README |
 | Standalone slide HTML | 22 files | `Basics/lessons/slides/**/*.html` | Includes `index.html`, day decks, and additional standalone HTML artifacts |
-| Module slide landing page | 1 file | [`Basics/lessons/slides/index.html`](Basics/lessons/slides/index.html) | Current Basics portal/landing page used directly and by workflow fallback logic |
+| Course root landing page | 1 file | [`slides/index.html`](slides/index.html) | Dedicated root portal source copied to `_site/index.html` by the workflow |
+| Supporting portal pages | 2 files | [`slides/printable-index.html`](slides/printable-index.html), [`slides/404.html`](slides/404.html) | Printable course index and custom 404 page staged by the workflow |
+| Shared portal asset kit | 3 files + generator | [`slides/shared/portal/`](slides/shared/portal/) and [`scripts/generate_portal_manifest.py`](scripts/generate_portal_manifest.py) | Shared CSS/JS/manifest foundation for the root dashboard and later module portals |
+| Module slide landing page | 1 file | [`Basics/lessons/slides/index.html`](Basics/lessons/slides/index.html) | Current Basics module landing page used directly and by the module fallback copy |
+| Module slide landing page | 1 file | [`Advanced/lessons/slides/index.html`](Advanced/lessons/slides/index.html) | Current Advanced module landing page used directly and by the module fallback copy |
 | Assignment templates | 12 files | `Basics/assignments/Basics_DayX_homework.ipynb` | Blank day-level learner notebooks |
 | Assignment config directories | 12 folders | `Basics/assignments/Basics_DayX_homework/` | Each contains grading config plus a `submissions/` folder |
 | Quiz HTML files | 12 files | `Basics/quizzes/Basics_DayX_Quiz.html` | Day-based learner quiz UIs |

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ No `package.json` — use `npx` directly.
 # Build Basics the same way the workflow does
 npx @marp-team/marp-cli -c .marprc.yml --input-dir Basics/lessons/slides --output _site/slides/basics
 
-# Build Advanced the same way the workflow does
+# Build Advanced locally with the repository's Advanced Marp config
 npx @marp-team/marp-cli --config-file .marprc.advanced.yml --input-dir Advanced/lessons/slides --output _site/slides/advanced
 
 # Build and watch a single file during development
@@ -110,7 +110,7 @@ npx @marp-team/marp-cli --no-config-file -w Basics/lessons/slides/day-01/day-01-
 npx @marp-team/marp-cli --no-config-file Basics/lessons/slides/day-01/day-01-session-1.md -o out.pdf --pdf
 ```
 
-Slides are published automatically to **GitHub Pages** on manual dispatch and on pushes to `main` that touch the workflow's configured portal and slide paths, including `Basics/lessons/slides/**`, `Advanced/lessons/slides/**`, `Basics/lessons/lecture/**`, `Advanced/lessons/lecture/**`, assignment and quiz trees for both modules, `slides/**`, `scripts/generate_portal_manifest.py`, `.marprc.yml`, `.github/workflows/marp-action.yml`, or `_site/slides/**`.
+Slides are published automatically to **GitHub Pages** on manual dispatch and on pushes to `main` that touch the workflow's configured portal and slide paths, including `Basics/lessons/slides/**`, `Advanced/lessons/slides/**`, `Basics/lessons/lecture/**`, `Advanced/lessons/lecture/**`, assignment and quiz trees for both modules, `slides/**`, `scripts/generate_portal_manifest.py`, `scripts/check_portal_publish.py`, `.marprc.yml`, `.github/workflows/marp-action.yml`, or `_site/slides/**`.
 
 ### Lecture Scripts
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,3 +33,7 @@ Project-specific directory that should be inspected before large changes.
 - Keep third-party AI assets pinned, attributable, and license-checked before vendoring.
 - Use the smallest relevant validation commands before merging automation changes.
 <!-- repo-agent-bootstrap:managed:end -->
+
+## Portal architecture
+
+Epic #419 and issue #420 define the static portal information architecture, manifest contract, and Pages entrypoint rules in [`portal-architecture.md`](portal-architecture.md). Read that document together with [`../spec/spec-process-cicd-marp-action.md`](../spec/spec-process-cicd-marp-action.md) before changing module portals or GitHub Pages root behavior.

--- a/docs/portal-architecture.md
+++ b/docs/portal-architecture.md
@@ -1,0 +1,316 @@
+# Portal Architecture Contract
+
+**Epic:** #419  
+**Issue:** #420  
+**Status:** Approved architecture target for issues #421-#425
+
+## 1. Authority and relationship to other docs
+
+This document is the authoritative contract for:
+
+- portal information architecture and page inventory
+- published route and path semantics
+- manifest ownership and schema
+- root and module entrypoint ownership
+- rollout gates between issues #421-#425
+
+`spec/spec-process-cicd-marp-action.md` remains the authoritative reference for workflow job shape, permissions, artifact staging, and deployment flow.
+
+If portal entrypoint or fallback behavior changes, this document, `spec/spec-process-cicd-marp-action.md`, and `.github/workflows/marp-action.yml` must be updated together in the same pull request.
+
+## 2. Goals and non-goals
+
+### Goals
+
+- deliver a static, GitHub Pages-compatible course portal with a stable root page and two module landing pages
+- define a manifest rich enough that downstream pages do not hardcode day ordering, breadcrumbs, or artifact badges
+- preserve fallback safety while the portal is rolled out incrementally
+- keep the implementation zero-CDN, zero-framework, and offline-friendly
+
+### Non-goals for this epic
+
+- introducing a frontend framework, bundler, remote fonts, or analytics
+- requiring day-level overview pages as a separate page type in this rollout
+- publishing lecture notebooks, assignments, or quizzes into Pages unless a later issue adds explicit workflow support
+- changing portal copy beyond small implementation-driven wording fixes
+
+## 3. Current-state constraints
+
+| Area | Current reality | Why it matters |
+| --- | --- | --- |
+| Basics module root | `Basics/lessons/slides/index.html` is both the current Basics landing page and a fallback input to the Pages root entrypoint logic. | Rebuilding Basics without decoupling root ownership could silently replace `/`. |
+| Advanced module root | `Advanced/lessons/slides/` has day folders but no module `index.html`. | #423 must add the first Advanced landing page. |
+| Workflow fallback | `marp-action.yml` has three distinct behaviors: Basics module fallback copy, Advanced module fallback copy, and root `_site/index.html` synthesis. | The contract must address all three behaviors, not only Basics. |
+| Published artifact scope | The Pages artifact currently guarantees slide trees under `_site/slides/**`. Lecture Markdown, assignments, and quizzes are not copied into the artifact. | Artifact badges and links must distinguish between Pages-hosted assets and repository-hosted assets. |
+| Ordering signal | Module day folders already use zero-padded `day-01` through `day-12` names. | The manifest can use numeric day order instead of guessing from titles. |
+| Theme sources | `Basics/themes/python-light.css` and `python-dark.css` define the current semantic token names, while `Basics/lessons/slides/day-01/day-01-session-1.html` establishes the requested visual language. | #421 needs a shared portal token layer that preserves dark/light parity and reflects the day-01 aesthetic. |
+
+## 4. Target sitemap and page inventory
+
+The finished portal for this epic uses a small set of stable pages.
+
+| Surface | Source path | Staged artifact path | Published URL | Notes |
+| --- | --- | --- | --- | --- |
+| Course root dashboard | `slides/index.html` | `_site/index.html` | `${BASE_PATH}` | Introduced as a dedicated root entrypoint in #421, then upgraded in #424. |
+| Basics module landing page | `Basics/lessons/slides/index.html` | `_site/slides/basics/index.html` | `${BASE_PATH}slides/basics/` | Rebuilt in #422. |
+| Advanced module landing page | `Advanced/lessons/slides/index.html` | `_site/slides/advanced/index.html` | `${BASE_PATH}slides/advanced/` | Created in #423. |
+| Shared portal asset kit | `slides/shared/portal/**` | `_site/slides/shared/portal/**` | `${BASE_PATH}slides/shared/portal/**` | Added in #421. |
+| Printable full-course index | `slides/printable-index.html` | `_site/slides/printable-index.html` | `${BASE_PATH}slides/printable-index.html` | Implemented in #424 as the compact full-course deck index. |
+| Custom 404 page | `slides/404.html` | `_site/404.html` | `${BASE_PATH}404.html` | Implemented in #424 as the course-portal recovery page. |
+
+The following are explicitly **not** required as separate page types in this epic:
+
+- dedicated search-results pages
+- dedicated day overview pages
+- lecture/assignment/quiz render pages inside the Pages artifact
+
+Search is an enhancement inside the root or module pages. Day navigation is owned by module landing pages through cards or lists driven by the manifest.
+
+## 5. URL and path contract
+
+### 5.1 Base path
+
+Portal pages must treat the site root as a runtime variable named `BASE_PATH`.
+
+- On GitHub Pages project-site deploys, `BASE_PATH` is the repository path prefix ending in `/python_programming_courses/`.
+- On local preview served from the repository root with a static HTTP server, `BASE_PATH` is `/`.
+- On staged artifact preview served from `_site`, `BASE_PATH` is `/`.
+- Raw `file://` preview is unsupported for manifest-driven portal pages.
+
+### 5.2 Path rules
+
+1. Manifest paths are stored without a leading slash and are relative to `BASE_PATH`.
+2. Same-tree links inside module slide folders may remain relative when they stay within the copied module tree, for example `day-01/day-01-session-1.html`.
+3. Cross-module links, shared-asset links, root-dashboard links, and download links must resolve through `BASE_PATH` rather than `../` arithmetic.
+4. Portal pages may use a tiny inline bootstrap script to resolve `BASE_PATH` before attaching shared CSS or JS URLs.
+5. Local preview for manifest-driven pages must use a static server such as `python -m http.server`; direct file opening is not part of the contract.
+
+### 5.3 Delivery modes for links
+
+Each artifact link must declare one of these delivery modes:
+
+- `pages` - asset is published in the Pages artifact and opens under `BASE_PATH`
+- `repo` - asset is discovered in the repository and should open via a GitHub repository URL
+- `none` - asset is absent and should render as unavailable
+
+This distinction prevents the portal from pretending that every artifact is already part of the Pages artifact.
+
+## 6. Shared asset and deployment contract
+
+### 6.1 Canonical shared asset location
+
+The canonical shared portal asset source is:
+
+- `slides/shared/portal/portal.css`
+- `slides/shared/portal/portal.js`
+- `slides/shared/portal/course-manifest.json`
+
+This location is shared by the root dashboard and both module landing pages. Shared assets are reusable by design and must not be copied manually into Basics or Advanced pages.
+
+### 6.2 Workflow implications
+
+Issue #421 must update workflow behavior to make the shared asset contract real:
+
+1. add trigger coverage for `slides/index.html`, `slides/shared/portal/**`, and any approved supporting pages under `slides/`
+2. copy `slides/shared/portal/**` into `_site/slides/shared/portal/**`
+3. copy `slides/index.html` into `_site/index.html` once the dedicated root entrypoint exists
+4. copy `slides/printable-index.html` into `_site/slides/printable-index.html` if the printable index is implemented
+5. copy `slides/404.html` to `_site/404.html` if the custom 404 page is implemented
+6. preserve the existing module fallback copies unless a later workflow change intentionally replaces them
+
+Until #421 lands, no page may depend on the shared asset kit.
+
+## 7. Manifest contract
+
+### 7.1 Canonical file
+
+The canonical navigation and artifact manifest is `slides/shared/portal/course-manifest.json`.
+
+### 7.2 Ordering authority
+
+Ordering is defined as follows:
+
+1. module order is `basics`, then `advanced`
+2. day order comes from the numeric `day-01` through `day-12` directory names, not from alphabetical title sorting
+3. artifact display order is `slides`, `lecture`, `assignment`, `quiz`, `syllabus`, then `downloads`
+
+Portal pages must never infer order from rendered text.
+
+### 7.3 Required schema
+
+```json
+{
+  "version": 1,
+  "repository": {
+    "owner": "dhar174",
+    "name": "python_programming_courses",
+    "defaultBranch": "main"
+  },
+  "supportingPages": {
+    "root": "index.html",
+    "printableIndex": "slides/printable-index.html",
+    "notFound": "404.html"
+  },
+  "modules": [
+    {
+      "id": "basics",
+      "title": "Python Programming: Basic",
+      "order": 1,
+      "sourceRoot": "Basics/lessons/slides",
+      "publishedRoot": "slides/basics/",
+      "theme": "portal",
+      "days": [
+        {
+          "id": "day-01",
+          "dayNumber": 1,
+          "title": "Day 1 - Session 1 (Hours 1-4)",
+          "order": 1,
+          "primaryHref": "slides/basics/day-01/day-01-session-1.html",
+          "breadcrumbs": [
+            { "label": "Course", "href": "index.html" },
+            { "label": "Basics", "href": "slides/basics/" },
+            { "label": "Day 1", "href": "slides/basics/" }
+          ],
+          "prev": null,
+          "next": {
+            "label": "Day 2",
+            "href": "slides/basics/day-02/day-02-session-2.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/basics/day-01/day-01-session-1.html",
+              "downloads": {
+                "html": "slides/basics/day-01/day-01-session-1.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/lessons/lecture/Day1_Hour1_Basics.md",
+              "href": null
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/assignments/Basics_Day1_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/quizzes/Basics_Day1_Quiz.html",
+              "href": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 7.4 Schema rules
+
+- `supportingPages` values are published paths relative to `BASE_PATH`, not source-repository paths.
+- `href` is required only for `pages` delivery.
+- `repoPath` is required only for `repo` delivery.
+- `present` drives badge visibility and no-JS fallback text.
+- `downloads` may include only paths that actually exist; no guessed file names.
+- `breadcrumbs`, `prev`, and `next` are authored or generated into the manifest, not hardcoded in page templates.
+- Titles are manifest data, not runtime filename parsing.
+
+## 8. Theme contract
+
+### 8.1 Source of visual direction
+
+Portal visuals must clearly descend from `Basics/lessons/slides/day-01/day-01-session-1.html`, especially its:
+
+- Swiss Modern light palette
+- system-ui and Segoe UI body typography with an Inter-like heading feel
+- generous spacing rhythm centered on `24px`
+- bold blue accent treatment
+- restrained `0.3s` motion tone
+
+### 8.2 Semantic token contract
+
+`Basics/themes/python-light.css` and `python-dark.css` remain the semantic token reference for:
+
+- `--bg`
+- `--fg`
+- `--muted`
+- `--accent`
+- `--accent-contrast`
+- `--code-bg`
+- `--code-fg`
+- `--code-border`
+- `--table-border`
+- `--blockquote-bg`
+- `--blockquote-border`
+
+Issue #421 must create a portal-specific token layer under `slides/shared/portal/portal.css` that:
+
+- reuses the same semantic token names for parity
+- adds portal-only tokens only when both light and dark variants are defined
+- does not import the Marp theme files directly into portal pages
+- preserves dark/light parity while translating the day-01 visual language into portal-safe styles
+
+Portal text content should remain substantively the same unless a later issue explicitly expands copy scope.
+
+## 9. Fallback and entrypoint contract
+
+The workflow currently has three independent entrypoint decisions. The portal architecture adopts these rules:
+
+| Behavior | Current source | Target contract |
+| --- | --- | --- |
+| Basics module fallback copy | `Basics/lessons/slides/. -> _site/slides/basics/` | Remains valid. The rebuilt Basics portal continues to own the Basics module landing page. |
+| Advanced module fallback copy | `Advanced/lessons/slides/. -> _site/slides/advanced/` | Remains valid once `Advanced/lessons/slides/index.html` exists. |
+| Root `_site/index.html` synthesis | Currently prefers `Basics/lessons/slides/index.html` | Must be reassigned to the dedicated root source `slides/index.html` in #421 before #422 merges. |
+
+### Explicit decision
+
+`Basics/lessons/slides/index.html` must **stop** serving as the fallback input for the live site root before or during issue #421.
+
+As a result:
+
+- issue #421 is responsible for introducing a dedicated root source page or stub at `slides/index.html`
+- issue #422 must not merge while the workflow still copies `Basics/lessons/slides/index.html` to `_site/index.html`
+- issue #424 may replace the root stub with the full course dashboard without changing module ownership
+
+If the root dashboard is temporarily incomplete, the dedicated root source may be a minimal student-safe landing page or redirect, but it must not be the Basics module page.
+
+## 10. Rollout contract for issues #421-#425
+
+| Issue | Required contract from this document |
+| --- | --- |
+| #421 | establish `BASE_PATH`, publish shared assets, implement the manifest file, and decouple root ownership from the Basics portal |
+| #422 | consume the shared kit and manifest, preserve the Basics module fallback contract, and avoid any root-entrypoint regression |
+| #423 | reuse the same shared kit and manifest contract without introducing Advanced-only path rules |
+| #424 | replace the dedicated root stub with the final course dashboard and add only the supporting pages approved here |
+| #425 | verify that workflow, preview, accessibility, navigation, and docs still match this contract |
+
+## 11. Validation and preview contract
+
+Before portal-affecting pull requests merge, the implementation must prove:
+
+- `_site/index.html`, `_site/slides/basics/index.html`, `_site/slides/advanced/index.html`, and `_site/slides/shared/portal/course-manifest.json` all exist when their owning issue has landed
+- module fallback copies still produce valid module roots
+- the published root entrypoint no longer matches `Basics/lessons/slides/index.html`
+- no-JS rendering leaves root and module pages readable
+- local preview works through a static HTTP server, not only inside GitHub Pages
+- artifact badges do not link to nonexistent Pages outputs
+
+## 12. Decision log
+
+- **D-001:** The root course dashboard owns `/`; module portals own `/slides/basics/` and `/slides/advanced/`.
+- **D-002:** The shared portal asset kit lives under `slides/shared/portal/**`.
+- **D-003:** The canonical manifest file is `slides/shared/portal/course-manifest.json`.
+- **D-004:** Root ownership must be decoupled from `Basics/lessons/slides/index.html` in #421 before the Basics portal rebuild in #422.
+- **D-005:** Day ordering is numeric and runbook-aligned through the zero-padded `day-NN` directory names.
+- **D-006:** Lecture, assignment, and quiz artifacts may be discovered as `repo` delivery targets until workflow support publishes them to Pages.
+- **D-007:** Search is an inline enhancement, not a separate approved page type for this epic.
+- **D-008:** Per-day overview pages are out of scope for this rollout; day cards on module portals are the canonical day navigation surface.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -45,3 +45,13 @@ The repository is now in a maintenance state. All lecture scripts, slides, and C
 3. Update `README.md` badges/links if the Pages URL is confirmed working.
 <!-- repo-agent-bootstrap:managed:end -->
 
+## Portal architecture update
+
+- [2026-05-16] Issue #420 architecture contract added in `docs/portal-architecture.md`.
+- Root ownership is now specified to move to `slides/index.html` in #421 before the Basics portal rebuild in #422.
+- Shared portal assets and the canonical manifest path are reserved as `slides/shared/portal/**`.
+- [2026-05-16] Issue #421 shared portal foundation implemented in the working tree: `slides/index.html` now owns the course root, shared portal CSS/JS live under `slides/shared/portal/`, and publish validation is codified in `scripts/check_portal_publish.py`.
+- [2026-05-16] Issue #422 Basics portal rebuild is now implemented in the working tree. `Basics/lessons/slides/index.html` is a static-first module portal with root breadcrumbs, theme controls, preserved day descriptions, static relative deck links, and manifest-enhanced repository artifact chips.
+- [2026-05-16] Issue #423 Advanced portal is now implemented in the working tree. `Advanced/lessons/slides/index.html` now exists as the Advanced module landing page, and the Basics portal now routes its "Continue to Advanced" CTA to the new module page.
+- [2026-05-16] Issue #424 root dashboard/supporting pages are now implemented in the working tree. `slides/index.html` reflects both live module portals, `slides/printable-index.html` provides the approved full-course deck index, and `slides/404.html` provides the approved recovery page.
+- [2026-05-16] Current active portal objective: finish issue #425 by aligning docs and remaining workflow/QA notes with the now-complete root + module portal surfaces.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -34,3 +34,10 @@
 [2026-05-14] All content complete; Pages root 404 fix applied and pushed
 <!-- repo-agent-bootstrap:managed:end -->
 
+## Portal rollout milestone
+
+- [2026-05-16] Issue #420 architecture contract drafted in `docs/portal-architecture.md`, including sitemap, route rules, manifest schema, shared asset location, and the root-decoupling requirement ahead of #422.
+- [2026-05-16] Issue #421 shared portal foundation implemented: root portal source added at `slides/index.html`, manifest generation/validation scripts added, shared portal assets added under `slides/shared/portal/`, and the Pages workflow updated to publish and validate the new root-entrypoint contract.
+- [2026-05-16] Issue #422 Basics portal rebuilt as a production module portal in `Basics/lessons/slides/index.html`, with manifest-backed badges/repository artifact links, source-preview bootstrap logic, and validated published/source preview behavior.
+- [2026-05-16] Issue #423 Advanced portal added at `Advanced/lessons/slides/index.html`, validated in source and published previews, and cross-module navigation from the Basics portal now targets the new Advanced landing page.
+- [2026-05-16] Issue #424 root dashboard upgraded and supporting pages added: `slides/index.html` now points at both module portals plus course-material categories, `slides/printable-index.html` provides the approved full-course deck index, and `slides/404.html` is now part of the published portal contract.

--- a/scripts/check_portal_publish.py
+++ b/scripts/check_portal_publish.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Validate the published portal artifact and root-entrypoint contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    script_path = Path(__file__).resolve()
+    repo_root = script_path.parent.parent
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=str(repo_root))
+    parser.add_argument("--site-root", default=str(repo_root / "_site"))
+    return parser.parse_args()
+
+
+def add_error(errors: list[str], message: str) -> None:
+    errors.append(message)
+
+
+def require_file(path: Path, label: str, errors: list[str]) -> None:
+    if not path.is_file():
+        add_error(errors, f"Missing {label}: {path}")
+
+
+def validate_repo_artifact(repo_root: Path, artifact: dict[str, object], label: str, errors: list[str]) -> None:
+    if artifact.get("delivery") != "repo":
+        return
+    repo_path = artifact.get("repoPath")
+    if repo_path and not (repo_root / str(repo_path)).is_file():
+        add_error(errors, f"Missing repo artifact for {label}: {repo_root / str(repo_path)}")
+    repo_paths = artifact.get("repoPaths") or []
+    for item in repo_paths:
+        if not (repo_root / str(item)).is_file():
+            add_error(errors, f"Missing repo artifact for {label}: {repo_root / str(item)}")
+
+
+def validate_pages_artifact(site_root: Path, artifact: dict[str, object], label: str, errors: list[str]) -> None:
+    if artifact.get("delivery") != "pages":
+        return
+    href = artifact.get("href")
+    if href and not (site_root / str(href)).is_file():
+        add_error(errors, f"Missing published artifact for {label}: {site_root / str(href)}")
+    downloads = artifact.get("downloads") or {}
+    for format_name, relative_path in downloads.items():
+        if relative_path and not (site_root / str(relative_path)).is_file():
+            add_error(errors, f"Missing published {format_name} download for {label}: {site_root / str(relative_path)}")
+
+
+def validate_manifest(repo_root: Path, site_root: Path, errors: list[str]) -> None:
+    manifest_path = site_root / "slides" / "shared" / "portal" / "course-manifest.json"
+    require_file(manifest_path, "published portal manifest", errors)
+    if errors:
+        return
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    support_root = manifest.get("supportingPages", {}).get("root")
+    if support_root != "index.html":
+        add_error(errors, f"Unexpected supportingPages.root value: {support_root!r}")
+    printable_index = manifest.get("supportingPages", {}).get("printableIndex")
+    if printable_index:
+        require_file(site_root / str(printable_index), "published printable index", errors)
+    not_found = manifest.get("supportingPages", {}).get("notFound")
+    if not_found:
+        require_file(site_root / str(not_found), "published 404 page", errors)
+
+    modules = manifest.get("modules", [])
+    if not modules:
+        add_error(errors, "Manifest contains no modules.")
+        return
+
+    for module in modules:
+        landing_page = module.get("landingPage")
+        if landing_page and not (site_root / str(landing_page)).is_file():
+            add_error(errors, f"Missing module landing page for {module.get('id')}: {site_root / str(landing_page)}")
+
+        primary_href = module.get("primaryHref")
+        if primary_href and not (site_root / str(primary_href)).is_file():
+            add_error(errors, f"Missing module primary href for {module.get('id')}: {site_root / str(primary_href)}")
+
+        for day in module.get("days", []):
+            validate_pages_artifact(site_root, day["artifacts"]["slides"], f"{module['id']} {day['id']} slides", errors)
+            validate_repo_artifact(repo_root, day["artifacts"]["lecture"], f"{module['id']} {day['id']} lecture", errors)
+            validate_repo_artifact(repo_root, day["artifacts"]["assignment"], f"{module['id']} {day['id']} assignment", errors)
+            validate_repo_artifact(repo_root, day["artifacts"]["quiz"], f"{module['id']} {day['id']} quiz", errors)
+
+
+def validate_root_decoupling(repo_root: Path, site_root: Path, errors: list[str]) -> None:
+    published_root = site_root / "index.html"
+    require_file(published_root, "published root entrypoint", errors)
+    if errors:
+        return
+
+    root_html = published_root.read_text(encoding="utf-8")
+    if 'data-portal-root="course"' not in root_html:
+        add_error(errors, "Published root entrypoint is missing the portal root marker.")
+    if "slides/shared/portal/portal.css" not in root_html:
+        add_error(errors, "Published root entrypoint does not reference the shared portal asset kit.")
+    if "Python Course Slides - Index" in root_html:
+        add_error(errors, "Published root entrypoint still exposes the legacy Basics landing heading.")
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    site_root = Path(args.site_root).resolve()
+
+    errors: list[str] = []
+    require_file(site_root / "slides" / "shared" / "portal" / "portal.css", "published portal CSS", errors)
+    require_file(site_root / "slides" / "shared" / "portal" / "portal.js", "published portal JS", errors)
+    validate_manifest(repo_root, site_root, errors)
+    validate_root_decoupling(repo_root, site_root, errors)
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("Portal publish checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_portal_publish.py
+++ b/scripts/check_portal_publish.py
@@ -97,11 +97,14 @@ def validate_root_decoupling(repo_root: Path, site_root: Path, errors: list[str]
         return
 
     root_html = published_root.read_text(encoding="utf-8")
-    if 'data-portal-root="course"' not in root_html:
-        add_error(errors, "Published root entrypoint is missing the portal root marker.")
-    if "slides/shared/portal/portal.css" not in root_html:
+    is_portal_root = 'data-portal-root="course"' in root_html
+    is_redirect_fallback = 'http-equiv="refresh"' in root_html and "Redirecting to slides" in root_html and 'href="./' in root_html
+
+    if not is_portal_root and not is_redirect_fallback:
+        add_error(errors, "Published root entrypoint is neither the dedicated portal root nor the validated redirect fallback.")
+    if is_portal_root and "slides/shared/portal/portal.css" not in root_html:
         add_error(errors, "Published root entrypoint does not reference the shared portal asset kit.")
-    if "Python Course Slides - Index" in root_html:
+    if is_portal_root and "Python Course Slides - Index" in root_html:
         add_error(errors, "Published root entrypoint still exposes the legacy Basics landing heading.")
 
 

--- a/scripts/generate_portal_manifest.py
+++ b/scripts/generate_portal_manifest.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Generate the static portal manifest for the course site."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+REPOSITORY = {
+    "owner": "dhar174",
+    "name": "python_programming_courses",
+    "defaultBranch": "main",
+}
+
+MODULES = (
+    {
+        "id": "basics",
+        "title": "Python Programming: Basic",
+        "source_root": "Basics/lessons/slides",
+        "lecture_pattern": "Basics/lessons/lecture/Day{day}_Hour*_Basics.md",
+        "assignment_path": "Basics/assignments/Basics_Day{day}_homework.ipynb",
+        "quiz_path": "Basics/quizzes/Basics_Day{day}_Quiz.html",
+    },
+    {
+        "id": "advanced",
+        "title": "Python Programming: Advanced",
+        "source_root": "Advanced/lessons/slides",
+        "lecture_pattern": "Advanced/lessons/lecture/Day{day}_Hour*_Advanced.md",
+        "assignment_path": "Advanced/assignments/Advanced_Day{day}_homework.ipynb",
+        "quiz_path": "Advanced/quizzes/Advanced_Day{day}_Quiz.html",
+    },
+)
+
+DOWNLOAD_SUFFIXES = {
+    "html": ".html",
+    "pdf": ".pdf",
+    "pptx": ".pptx",
+    "png": ".png",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    script_path = Path(__file__).resolve()
+    repo_root = script_path.parent.parent
+    default_output = repo_root / "slides" / "shared" / "portal" / "course-manifest.json"
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=str(repo_root))
+    parser.add_argument("--site-root", help="Optional _site directory for published artifact discovery.")
+    parser.add_argument("--output", default=str(default_output))
+    return parser.parse_args()
+
+
+def find_primary_html(day_dir: Path) -> Path | None:
+    html_files = sorted(
+        path
+        for path in day_dir.glob("*.html")
+        if path.name.lower() not in {"index.html", "readme.html"}
+    )
+    return html_files[0] if html_files else None
+
+
+def build_downloads(
+    *,
+    published_dir: str,
+    stem: str,
+    site_root: Path | None,
+) -> dict[str, str | None]:
+    downloads: dict[str, str | None] = {}
+    for format_name, suffix in DOWNLOAD_SUFFIXES.items():
+        relative_path = f"{published_dir}{stem}{suffix}"
+        if format_name == "html":
+            downloads[format_name] = relative_path
+            continue
+        if site_root and (site_root / relative_path).is_file():
+            downloads[format_name] = relative_path
+        else:
+            downloads[format_name] = None
+    return downloads
+
+
+def build_repo_artifact(
+    *,
+    present: bool,
+    repo_path: str | None,
+    repo_paths: list[str] | None = None,
+) -> dict[str, object]:
+    artifact: dict[str, object] = {
+        "present": present,
+        "delivery": "repo" if present else "none",
+        "repoPath": repo_path if present else None,
+        "href": None,
+    }
+    if repo_paths:
+        artifact["repoPaths"] = repo_paths
+        artifact["count"] = len(repo_paths)
+    return artifact
+
+
+def build_pages_artifact(
+    *,
+    published_href: str | None,
+    source_path: str | None,
+    site_root: Path | None,
+) -> dict[str, object]:
+    present = published_href is not None
+    downloads = {
+        format_name: None for format_name in DOWNLOAD_SUFFIXES
+    }
+    if present and published_href:
+        published_path = Path(published_href)
+        downloads = build_downloads(
+            published_dir=f"{published_path.parent.as_posix()}/",
+            stem=published_path.stem,
+            site_root=site_root,
+        )
+    return {
+        "present": present,
+        "delivery": "pages" if present else "none",
+        "href": published_href,
+        "sourcePath": source_path,
+        "downloads": downloads,
+    }
+
+
+def build_day(
+    *,
+    repo_root: Path,
+    site_root: Path | None,
+    module: dict[str, str],
+    day_number: int,
+    total_days: int,
+) -> dict[str, object]:
+    day_id = f"day-{day_number:02d}"
+    source_day_dir = repo_root / module["source_root"] / day_id
+    primary_html = find_primary_html(source_day_dir) if source_day_dir.is_dir() else None
+    published_dir = f"slides/{module['id']}/{day_id}/"
+    primary_href = f"{published_dir}{primary_html.name}" if primary_html else None
+    source_primary_href = primary_html.relative_to(repo_root).as_posix() if primary_html else None
+
+    lecture_paths = sorted(
+        path.relative_to(repo_root).as_posix()
+        for path in repo_root.glob(module["lecture_pattern"].format(day=day_number))
+    )
+    assignment_path = module["assignment_path"].format(day=day_number)
+    quiz_path = module["quiz_path"].format(day=day_number)
+    assignment_present = (repo_root / assignment_path).is_file()
+    quiz_present = (repo_root / quiz_path).is_file()
+
+    day_entry: dict[str, object] = {
+        "id": day_id,
+        "dayNumber": day_number,
+        "title": f"Day {day_number}",
+        "order": day_number,
+        "primaryHref": primary_href,
+        "sourcePrimaryHref": source_primary_href,
+        "breadcrumbs": [
+            {"label": "Course", "href": "index.html"},
+            {"label": module["title"], "href": f"slides/{module['id']}/index.html"},
+            {"label": f"Day {day_number}", "href": primary_href},
+        ],
+        "prev": None,
+        "next": None,
+        "artifacts": {
+            "slides": build_pages_artifact(
+                published_href=primary_href,
+                source_path=source_primary_href,
+                site_root=site_root,
+            ),
+            "lecture": build_repo_artifact(
+                present=bool(lecture_paths),
+                repo_path=lecture_paths[0] if lecture_paths else None,
+                repo_paths=lecture_paths or None,
+            ),
+            "assignment": build_repo_artifact(
+                present=assignment_present,
+                repo_path=assignment_path if assignment_present else None,
+            ),
+            "quiz": build_repo_artifact(
+                present=quiz_present,
+                repo_path=quiz_path if quiz_present else None,
+            ),
+        },
+    }
+
+    if day_number > 1:
+        prev_id = f"day-{day_number - 1:02d}"
+        day_entry["prev"] = {
+            "label": f"Day {day_number - 1}",
+            "href": f"slides/{module['id']}/{prev_id}/",
+        }
+    if day_number < total_days:
+        next_id = f"day-{day_number + 1:02d}"
+        day_entry["next"] = {
+            "label": f"Day {day_number + 1}",
+            "href": f"slides/{module['id']}/{next_id}/",
+        }
+
+    return day_entry
+
+
+def fill_navigation(days: list[dict[str, object]]) -> None:
+    for index, day in enumerate(days):
+        primary_href = day.get("primaryHref")
+        if index > 0:
+            prev_day = days[index - 1]
+            day["prev"] = {
+                "label": f"Day {prev_day['dayNumber']}",
+                "href": prev_day.get("primaryHref") or prev_day["breadcrumbs"][-1]["href"],
+            }
+        if index < len(days) - 1:
+            next_day = days[index + 1]
+            day["next"] = {
+                "label": f"Day {next_day['dayNumber']}",
+                "href": next_day.get("primaryHref") or next_day["breadcrumbs"][-1]["href"],
+            }
+        day["breadcrumbs"][-1]["href"] = primary_href
+
+
+def build_module(
+    *,
+    repo_root: Path,
+    site_root: Path | None,
+    module: dict[str, str],
+    order: int,
+) -> dict[str, object]:
+    source_root = repo_root / module["source_root"]
+    days = [
+        build_day(
+            repo_root=repo_root,
+            site_root=site_root,
+            module=module,
+            day_number=day_number,
+            total_days=12,
+        )
+        for day_number in range(1, 13)
+    ]
+    fill_navigation(days)
+
+    module_index = source_root / "index.html"
+    landing_page = f"slides/{module['id']}/index.html" if module_index.is_file() else None
+    source_landing_page = module_index.relative_to(repo_root).as_posix() if module_index.is_file() else None
+    primary_href = landing_page or next(
+        (day["primaryHref"] for day in days if day.get("primaryHref")),
+        None,
+    )
+    source_primary_href = source_landing_page or next(
+        (day["sourcePrimaryHref"] for day in days if day.get("sourcePrimaryHref")),
+        None,
+    )
+
+    return {
+        "id": module["id"],
+        "title": module["title"],
+        "order": order,
+        "sourceRoot": module["source_root"],
+        "publishedRoot": f"slides/{module['id']}/",
+        "landingPage": landing_page,
+        "primaryHref": primary_href,
+        "sourceLandingPage": source_landing_page,
+        "sourcePrimaryHref": source_primary_href,
+        "theme": "portal",
+        "stats": {
+            "days": len(days),
+            "slides": sum(1 for day in days if day["artifacts"]["slides"]["present"]),
+            "lectures": sum(1 for day in days if day["artifacts"]["lecture"]["present"]),
+            "assignments": sum(1 for day in days if day["artifacts"]["assignment"]["present"]),
+            "quizzes": sum(1 for day in days if day["artifacts"]["quiz"]["present"]),
+        },
+        "days": days,
+    }
+
+
+def build_manifest(repo_root: Path, site_root: Path | None) -> dict[str, object]:
+    modules = [
+        build_module(
+            repo_root=repo_root,
+            site_root=site_root,
+            module=module,
+            order=index,
+        )
+        for index, module in enumerate(MODULES, start=1)
+    ]
+
+    return {
+        "version": 1,
+        "repository": REPOSITORY,
+        "supportingPages": {
+            "root": "index.html",
+            "printableIndex": "slides/printable-index.html",
+            "notFound": "404.html",
+        },
+        "stats": {
+            "modules": len(modules),
+            "days": sum(module["stats"]["days"] for module in modules),
+            "slides": sum(module["stats"]["slides"] for module in modules),
+            "lectures": sum(module["stats"]["lectures"] for module in modules),
+            "assignments": sum(module["stats"]["assignments"] for module in modules),
+            "quizzes": sum(module["stats"]["quizzes"] for module in modules),
+        },
+        "modules": modules,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    site_root = Path(args.site_root).resolve() if args.site_root else None
+    output_path = Path(args.output).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    manifest = build_manifest(repo_root=repo_root, site_root=site_root)
+    output_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_portal_manifest.py
+++ b/scripts/generate_portal_manifest.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
+import re
+import subprocess
 
 
-REPOSITORY = {
+DEFAULT_REPOSITORY = {
     "owner": "dhar174",
     "name": "python_programming_courses",
     "defaultBranch": "main",
@@ -39,6 +42,56 @@ DOWNLOAD_SUFFIXES = {
     "pptx": ".pptx",
     "png": ".png",
 }
+
+
+def run_command(repo_root: Path, *args: str) -> str | None:
+    completed = subprocess.run(
+        args,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip() or None
+
+
+def parse_github_remote(remote_url: str) -> tuple[str | None, str | None]:
+    match = re.search(r"github\.com[:/](?P<owner>[^/]+)/(?P<name>[^/]+?)(?:\.git)?$", remote_url.strip())
+    if not match:
+        return None, None
+    return match.group("owner"), match.group("name")
+
+
+def discover_repository(repo_root: Path) -> dict[str, str]:
+    owner: str | None = None
+    name: str | None = None
+    default_branch = os.getenv("PORTAL_DEFAULT_BRANCH") or os.getenv("GITHUB_DEFAULT_BRANCH")
+
+    env_repo = os.getenv("PORTAL_GITHUB_REPOSITORY") or os.getenv("GITHUB_REPOSITORY")
+    if env_repo and "/" in env_repo:
+        owner, name = env_repo.split("/", 1)
+
+    if not owner or not name:
+        remote_url = run_command(repo_root, "git", "remote", "get-url", "origin")
+        if remote_url:
+            remote_owner, remote_name = parse_github_remote(remote_url)
+            owner = owner or remote_owner
+            name = name or remote_name
+
+    if not default_branch:
+        remote_head = run_command(repo_root, "git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+        if remote_head and "/" in remote_head:
+            default_branch = remote_head.split("/", 1)[1]
+
+    return {
+        "owner": owner or DEFAULT_REPOSITORY["owner"],
+        "name": name or repo_root.name or DEFAULT_REPOSITORY["name"],
+        "defaultBranch": default_branch or DEFAULT_REPOSITORY["defaultBranch"],
+    }
 
 
 def parse_args() -> argparse.Namespace:
@@ -286,7 +339,7 @@ def build_manifest(repo_root: Path, site_root: Path | None) -> dict[str, object]
 
     return {
         "version": 1,
-        "repository": REPOSITORY,
+        "repository": discover_repository(repo_root),
         "supportingPages": {
             "root": "index.html",
             "printableIndex": "slides/printable-index.html",

--- a/slides/404.html
+++ b/slides/404.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page not found</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+            background: #f7f7f7;
+            color: #111111;
+            line-height: 1.6;
+        }
+
+        .fallback-shell {
+            width: min(960px, calc(100% - 32px));
+            margin: 0 auto;
+            padding: 24px 0 48px;
+        }
+
+        .fallback-panel {
+            background: #ffffff;
+            border: 1px solid #d0d7de;
+            border-radius: 20px;
+            box-shadow: 0 16px 40px rgba(17, 17, 17, 0.08);
+            padding: 28px;
+        }
+    </style>
+    <script>
+        (function () {
+            const repoMarker = "/python_programming_courses/";
+            const pathname = window.location.pathname;
+            const basePath = pathname.includes(repoMarker)
+                ? pathname.slice(0, pathname.indexOf(repoMarker) + repoMarker.length)
+                : "/";
+            window.__PYC_BASE_PATH = basePath;
+            window.__PYC_SOURCE_PREVIEW = false;
+
+            const stylesheet = document.createElement("link");
+            stylesheet.rel = "stylesheet";
+            stylesheet.href = basePath + "slides/shared/portal/portal.css";
+            document.head.appendChild(stylesheet);
+
+            const script = document.createElement("script");
+            script.src = basePath + "slides/shared/portal/portal.js";
+            script.defer = true;
+            document.head.appendChild(script);
+        })();
+    </script>
+</head>
+<body class="portal-page">
+    <main class="portal-shell fallback-shell" role="main">
+        <section class="portal-hero fallback-panel" aria-labelledby="not-found-title">
+            <span class="portal-kicker">Custom 404</span>
+            <h1 id="not-found-title">That page is not part of the course portal.</h1>
+            <p>
+                Use the course dashboard or one of the module portals to get back to a valid day deck, printable index, or repository-backed course document.
+            </p>
+            <div class="portal-actions">
+                <a class="portal-button" data-variant="primary" href="./index.html">Open course portal</a>
+                <a class="portal-button" data-variant="secondary" href="./slides/basics/">Basics portal</a>
+                <a class="portal-button" data-variant="secondary" href="./slides/advanced/">Advanced portal</a>
+                <a class="portal-button" data-variant="secondary" href="./slides/printable-index.html">Printable index</a>
+            </div>
+        </section>
+    </main>
+</body>
+</html>

--- a/slides/404.html
+++ b/slides/404.html
@@ -29,13 +29,49 @@
     </style>
     <script>
         (function () {
-            const repoMarker = "/python_programming_courses/";
             const pathname = window.location.pathname;
-            const basePath = pathname.includes(repoMarker)
-                ? pathname.slice(0, pathname.indexOf(repoMarker) + repoMarker.length)
-                : "/";
+            function computeBasePath(siteRelativePath) {
+                const normalizedSitePath = siteRelativePath.replace(/^\/+/, "");
+                const suffix = `/${normalizedSitePath}`;
+                if (pathname === suffix) {
+                    return "/";
+                }
+                if (pathname.endsWith(suffix)) {
+                    return pathname.slice(0, -normalizedSitePath.length);
+                }
+                if (pathname.endsWith(normalizedSitePath)) {
+                    const base = pathname.slice(0, -normalizedSitePath.length);
+                    return base || "/";
+                }
+                return "/";
+            }
+
+            function computeFallbackProjectBasePath() {
+                const segments = pathname.split("/").filter(Boolean);
+                if (window.location.hostname.endsWith(".github.io") && segments.length > 1) {
+                    return `/${segments[0]}/`;
+                }
+                return "/";
+            }
+
+            const isSourcePreview = pathname.startsWith("/slides/");
+            const publishedBasePath = computeBasePath("404.html");
+            const basePath = isSourcePreview
+                ? "/"
+                : (publishedBasePath !== "/" || pathname.endsWith("/404.html")
+                    ? publishedBasePath
+                    : computeFallbackProjectBasePath());
             window.__PYC_BASE_PATH = basePath;
-            window.__PYC_SOURCE_PREVIEW = false;
+            window.__PYC_SOURCE_PREVIEW = isSourcePreview;
+
+            document.addEventListener("DOMContentLoaded", function () {
+                document.querySelectorAll("[data-relative-href]").forEach(function (node) {
+                    const relativeHref = node.getAttribute("data-relative-href");
+                    if (relativeHref) {
+                        node.setAttribute("href", basePath + relativeHref.replace(/^\/+/, ""));
+                    }
+                });
+            }, { once: true });
 
             const stylesheet = document.createElement("link");
             stylesheet.rel = "stylesheet";
@@ -58,10 +94,10 @@
                 Use the course dashboard or one of the module portals to get back to a valid day deck, printable index, or repository-backed course document.
             </p>
             <div class="portal-actions">
-                <a class="portal-button" data-variant="primary" href="./index.html">Open course portal</a>
-                <a class="portal-button" data-variant="secondary" href="./slides/basics/">Basics portal</a>
-                <a class="portal-button" data-variant="secondary" href="./slides/advanced/">Advanced portal</a>
-                <a class="portal-button" data-variant="secondary" href="./slides/printable-index.html">Printable index</a>
+                <a class="portal-button" data-variant="primary" href="/" data-relative-href="index.html">Open course portal</a>
+                <a class="portal-button" data-variant="secondary" href="/slides/basics/" data-relative-href="slides/basics/">Basics portal</a>
+                <a class="portal-button" data-variant="secondary" href="/slides/advanced/" data-relative-href="slides/advanced/">Advanced portal</a>
+                <a class="portal-button" data-variant="secondary" href="/slides/printable-index.html" data-relative-href="slides/printable-index.html">Printable index</a>
             </div>
         </section>
     </main>

--- a/slides/index.html
+++ b/slides/index.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Python Programming Course Portal</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+            background: #f7f7f7;
+            color: #111111;
+            line-height: 1.6;
+        }
+
+        .fallback-shell {
+            width: min(1120px, calc(100% - 32px));
+            margin: 0 auto;
+            padding: 24px 0 48px;
+        }
+
+        .fallback-panel,
+        .fallback-card {
+            background: #ffffff;
+            border: 1px solid #d0d7de;
+            border-radius: 20px;
+            box-shadow: 0 16px 40px rgba(17, 17, 17, 0.08);
+        }
+
+        .fallback-panel {
+            padding: 28px;
+        }
+
+        .fallback-grid {
+            display: grid;
+            gap: 24px;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            margin-top: 24px;
+        }
+
+        .fallback-card {
+            padding: 24px;
+        }
+
+        .fallback-card h2,
+        .fallback-panel h1 {
+            margin-top: 0;
+        }
+
+        .fallback-card a,
+        .fallback-panel a {
+            color: #0066ff;
+            font-weight: 700;
+        }
+
+        .fallback-chip-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            padding: 0;
+            list-style: none;
+        }
+
+        .fallback-chip-list li {
+            padding: 8px 12px;
+            border-radius: 999px;
+            background: #e6f0ff;
+            color: #0066ff;
+            font-size: 0.95rem;
+        }
+
+        .fallback-meta {
+            color: #4f5b66;
+            font-size: 0.95rem;
+        }
+    </style>
+    <script>
+        (function () {
+            const repoMarker = "/python_programming_courses/";
+            const pathname = window.location.pathname;
+            const basePath = pathname.includes(repoMarker)
+                ? pathname.slice(0, pathname.indexOf(repoMarker) + repoMarker.length)
+                : "/";
+            window.__PYC_BASE_PATH = basePath;
+            window.__PYC_SOURCE_PREVIEW = pathname.startsWith("/slides/") && !pathname.includes(repoMarker);
+
+            document.addEventListener("DOMContentLoaded", function () {
+                if (!window.__PYC_SOURCE_PREVIEW) {
+                    return;
+                }
+
+                document.querySelectorAll("[data-source-href]").forEach(function (node) {
+                    const sourceHref = node.getAttribute("data-source-href");
+                    if (sourceHref) {
+                        node.setAttribute("href", basePath + sourceHref.replace(/^\/+/, ""));
+                    }
+                });
+            }, { once: true });
+
+            const stylesheet = document.createElement("link");
+            stylesheet.rel = "stylesheet";
+            stylesheet.href = basePath + "slides/shared/portal/portal.css";
+            document.head.appendChild(stylesheet);
+
+            const script = document.createElement("script");
+            script.src = basePath + "slides/shared/portal/portal.js";
+            script.defer = true;
+            document.head.appendChild(script);
+        })();
+    </script>
+</head>
+<body class="portal-page" data-portal-root="course">
+    <a class="portal-skip-link" href="#main-content">Skip to course overview</a>
+    <main id="main-content" class="portal-shell fallback-shell" role="main">
+        <header class="portal-header">
+            <section class="portal-hero fallback-panel" aria-labelledby="portal-title">
+                <span class="portal-kicker">GitHub Pages portal</span>
+                <h1 id="portal-title">Python Programming course portal</h1>
+                <p>
+                    Explore the full 96-hour curriculum across Basics and Advanced.
+                    The root dashboard now connects both module portals, the printable course index, and the repository-backed teaching materials without replacing the live homepage during rollout.
+                </p>
+                <div class="portal-actions">
+                    <a class="portal-button" data-variant="primary" href="./slides/basics/" data-source-href="Basics/lessons/slides/index.html">Open Basics portal</a>
+                    <a class="portal-button" data-variant="secondary" href="./slides/advanced/" data-source-href="Advanced/lessons/slides/index.html">Open Advanced portal</a>
+                    <a class="portal-button" data-variant="secondary" href="./slides/printable-index.html" data-source-href="slides/printable-index.html">Open printable index</a>
+                </div>
+                <div class="portal-stats-grid" aria-label="Course summary">
+                    <div class="portal-stat">
+                        <strong data-course-modules>2</strong>
+                        <span>modules</span>
+                    </div>
+                    <div class="portal-stat">
+                        <strong data-course-days>24</strong>
+                        <span>instruction days</span>
+                    </div>
+                    <div class="portal-stat">
+                        <strong data-course-slides>24</strong>
+                        <span>standalone day decks</span>
+                    </div>
+                    <div class="portal-stat">
+                        <strong data-course-artifacts>72</strong>
+                        <span>lecture, quiz, and assignment artifacts</span>
+                    </div>
+                </div>
+            </section>
+
+            <aside class="portal-toolbar" aria-label="Portal tools">
+                <section class="portal-panel">
+                    <h2>Theme</h2>
+                    <div class="portal-theme-row">
+                        <label for="theme-select">Appearance</label>
+                        <select id="theme-select" data-theme-toggle>
+                            <option value="auto">Auto</option>
+                            <option value="light">Light</option>
+                            <option value="dark">Dark</option>
+                        </select>
+                    </div>
+                </section>
+                <section class="portal-panel">
+                    <h2>Manifest status</h2>
+                    <p class="portal-note" data-manifest-status>
+                        Manifest-driven summaries will load automatically when the shared portal assets are available.
+                    </p>
+                </section>
+            </aside>
+        </header>
+
+        <section class="portal-section fallback-panel" aria-labelledby="module-section-title">
+            <h2 id="module-section-title">Choose a module</h2>
+            <p>
+                Both module portals now exist on the shared portal system. Start with the Basics or Advanced landing page, then move into day decks, lecture materials, assignments, and quizzes from there.
+            </p>
+            <div class="portal-module-grid fallback-grid">
+                <article class="portal-card fallback-card">
+                    <div class="portal-card-header">
+                        <h2>Basics</h2>
+                        <div class="portal-badge-row">
+                            <span class="portal-badge">PCEP aligned</span>
+                            <span class="portal-badge">48 hours</span>
+                        </div>
+                    </div>
+                    <p>
+                        Start with Python fundamentals, core data structures, file handling, and introductory object-oriented programming.
+                    </p>
+                    <div class="portal-card-meta">
+                        <div class="portal-meta-item">
+                            <strong data-module-days="basics">12</strong>
+                            <span>day decks</span>
+                        </div>
+                        <div class="portal-meta-item">
+                            <strong data-module-slides="basics">12</strong>
+                            <span>slide portals</span>
+                        </div>
+                        <div class="portal-meta-item">
+                            <strong data-module-lectures="basics">12</strong>
+                            <span>lecture sets</span>
+                        </div>
+                        <div class="portal-meta-item">
+                            <strong data-module-assignments="basics">12</strong>
+                            <span>homework notebooks</span>
+                        </div>
+                    </div>
+                    <div class="portal-actions">
+                        <a class="portal-button" data-variant="primary" data-module-link="basics" href="./slides/basics/" data-source-href="Basics/lessons/slides/index.html">Open Basics portal</a>
+                    </div>
+                    <div class="portal-chip-list" data-module-repo-links="basics"></div>
+                </article>
+
+                <article class="portal-card fallback-card">
+                    <div class="portal-card-header">
+                        <h2>Advanced</h2>
+                        <div class="portal-badge-row">
+                            <span class="portal-badge">PCAP aligned</span>
+                            <span class="portal-badge">48 hours</span>
+                        </div>
+                    </div>
+                    <p>
+                        Continue into advanced object-oriented design, databases, APIs, testing, and data-oriented Python workflows.
+                    </p>
+                    <div class="portal-card-meta">
+                        <div class="portal-meta-item">
+                            <strong data-module-days="advanced">12</strong>
+                            <span>day decks</span>
+                        </div>
+                        <div class="portal-meta-item">
+                            <strong data-module-slides="advanced">12</strong>
+                            <span>slide portals</span>
+                        </div>
+                        <div class="portal-meta-item">
+                            <strong data-module-lectures="advanced">12</strong>
+                            <span>lecture sets</span>
+                        </div>
+                        <div class="portal-meta-item">
+                            <strong data-module-quizzes="advanced">12</strong>
+                            <span>quizzes</span>
+                        </div>
+                    </div>
+                    <div class="portal-actions">
+                        <a class="portal-button" data-variant="primary" data-module-link="advanced" href="./slides/advanced/" data-source-href="Advanced/lessons/slides/index.html">Open Advanced portal</a>
+                    </div>
+                    <div class="portal-chip-list" data-module-repo-links="advanced"></div>
+                </article>
+            </div>
+        </section>
+
+        <section class="portal-section fallback-panel" aria-labelledby="course-docs-title">
+            <h2 id="course-docs-title">Course documents and material categories</h2>
+            <p>
+                Use the module portals for day-by-day navigation, then jump directly into repository-backed teaching materials or overview documents from these quick paths.
+            </p>
+            <div class="portal-module-grid fallback-grid">
+                <article class="portal-card fallback-card">
+                    <h2>Lecture materials</h2>
+                    <p>Browse the instructor-facing lecture scripts that support every four-hour session in both modules.</p>
+                    <div class="portal-chip-list">
+                        <a class="portal-link-chip" href="https://github.com/dhar174/python_programming_courses/tree/main/Basics/lessons/lecture">Basics lecture scripts</a>
+                        <a class="portal-link-chip" href="https://github.com/dhar174/python_programming_courses/tree/main/Advanced/lessons/lecture">Advanced lecture scripts</a>
+                    </div>
+                </article>
+                <article class="portal-card fallback-card">
+                    <h2>Assignments and quizzes</h2>
+                    <p>Open the notebook assignments and HTML quizzes that align with each module day.</p>
+                    <div class="portal-chip-list">
+                        <a class="portal-link-chip" href="https://github.com/dhar174/python_programming_courses/tree/main/Basics/assignments">Basics assignments</a>
+                        <a class="portal-link-chip" href="https://github.com/dhar174/python_programming_courses/tree/main/Advanced/assignments">Advanced assignments</a>
+                        <a class="portal-link-chip" href="https://github.com/dhar174/python_programming_courses/tree/main/Basics/quizzes">Basics quizzes</a>
+                        <a class="portal-link-chip" href="https://github.com/dhar174/python_programming_courses/tree/main/Advanced/quizzes">Advanced quizzes</a>
+                    </div>
+                </article>
+                <article class="portal-card fallback-card">
+                    <h2>Syllabi and overview docs</h2>
+                    <p>Reference the published course overviews and module syllabus documents that frame the full training package.</p>
+                    <div class="portal-chip-list">
+                        <a class="portal-link-chip" href="https://github.com/dhar174/python_programming_courses/blob/main/README.md">README</a>
+                        <a class="portal-link-chip" href="https://github.com/dhar174/python_programming_courses/blob/main/Basics/python_basics_48_h_syllabus_12_x_4_h_pcep_pcap_aligned.md">Basics syllabus</a>
+                        <a class="portal-link-chip" href="https://github.com/dhar174/python_programming_courses/blob/main/Advanced/python_advanced_48_h_syllabus_12_x_4_h_pcap_path_to_pcpp_1.md">Advanced syllabus</a>
+                        <a class="portal-link-chip" href="https://github.com/dhar174/python_programming_courses/blob/main/Python%20GIT%20Training%20Course%20Package.md">Training package</a>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section class="portal-section fallback-panel" aria-labelledby="featured-days-title">
+            <h2 id="featured-days-title">Start here</h2>
+            <p>
+                The shared manifest keeps the root experience aligned with the real day ordering so the dashboard, printable index, and module portals all point at the same sequence of decks.
+            </p>
+            <ul class="portal-chip-list fallback-chip-list" data-featured-days>
+                <li><a href="./slides/basics/day-01/day-01-session-1.html" data-source-href="Basics/lessons/slides/day-01/day-01-session-1.html">Basics · Day 1</a></li>
+                <li><a href="./slides/basics/day-02/day-02-session-2.html" data-source-href="Basics/lessons/slides/day-02/day-02-session-2.html">Basics · Day 2</a></li>
+                <li><a href="./slides/advanced/day-01/day-01-session-1.html" data-source-href="Advanced/lessons/slides/day-01/day-01-session-1.html">Advanced · Day 1</a></li>
+            </ul>
+        </section>
+
+        <footer class="portal-footer">
+            <p>
+                Shared portal assets live under <code>slides/shared/portal/</code>. The root page is intentionally static-first so it remains readable even if JavaScript enhancements are unavailable, and the printable index lives at <a href="./slides/printable-index.html" data-source-href="slides/printable-index.html">/slides/printable-index.html</a>.
+            </p>
+        </footer>
+    </main>
+</body>
+</html>

--- a/slides/index.html
+++ b/slides/index.html
@@ -76,13 +76,28 @@
     </style>
     <script>
         (function () {
-            const repoMarker = "/python_programming_courses/";
             const pathname = window.location.pathname;
-            const basePath = pathname.includes(repoMarker)
-                ? pathname.slice(0, pathname.indexOf(repoMarker) + repoMarker.length)
-                : "/";
+            const isSourcePreview = pathname.startsWith("/slides/");
+
+            function computeBasePath(siteRelativePath) {
+                const normalizedSitePath = siteRelativePath.replace(/^\/+/, "");
+                const suffix = `/${normalizedSitePath}`;
+                if (pathname === suffix) {
+                    return "/";
+                }
+                if (pathname.endsWith(suffix)) {
+                    return pathname.slice(0, -normalizedSitePath.length);
+                }
+                if (pathname.endsWith(normalizedSitePath)) {
+                    const base = pathname.slice(0, -normalizedSitePath.length);
+                    return base || "/";
+                }
+                return "/";
+            }
+
+            const basePath = isSourcePreview ? "/" : computeBasePath("index.html");
             window.__PYC_BASE_PATH = basePath;
-            window.__PYC_SOURCE_PREVIEW = pathname.startsWith("/slides/") && !pathname.includes(repoMarker);
+            window.__PYC_SOURCE_PREVIEW = isSourcePreview;
 
             document.addEventListener("DOMContentLoaded", function () {
                 if (!window.__PYC_SOURCE_PREVIEW) {

--- a/slides/printable-index.html
+++ b/slides/printable-index.html
@@ -55,13 +55,28 @@
     </style>
     <script>
         (function () {
-            const repoMarker = "/python_programming_courses/";
             const pathname = window.location.pathname;
-            const basePath = pathname.includes(repoMarker)
-                ? pathname.slice(0, pathname.indexOf(repoMarker) + repoMarker.length)
-                : "/";
+            const isSourcePreview = pathname.startsWith("/slides/");
+
+            function computeBasePath(siteRelativePath) {
+                const normalizedSitePath = siteRelativePath.replace(/^\/+/, "");
+                const suffix = `/${normalizedSitePath}`;
+                if (pathname === suffix) {
+                    return "/";
+                }
+                if (pathname.endsWith(suffix)) {
+                    return pathname.slice(0, -normalizedSitePath.length);
+                }
+                if (pathname.endsWith(normalizedSitePath)) {
+                    const base = pathname.slice(0, -normalizedSitePath.length);
+                    return base || "/";
+                }
+                return "/";
+            }
+
+            const basePath = isSourcePreview ? "/" : computeBasePath("slides/printable-index.html");
             window.__PYC_BASE_PATH = basePath;
-            window.__PYC_SOURCE_PREVIEW = pathname.startsWith("/slides/") && !pathname.includes(repoMarker);
+            window.__PYC_SOURCE_PREVIEW = isSourcePreview;
 
             document.addEventListener("DOMContentLoaded", function () {
                 if (!window.__PYC_SOURCE_PREVIEW) {

--- a/slides/printable-index.html
+++ b/slides/printable-index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Printable Course Index</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+            background: #f7f7f7;
+            color: #111111;
+            line-height: 1.6;
+        }
+
+        .fallback-shell {
+            width: min(1180px, calc(100% - 32px));
+            margin: 0 auto;
+            padding: 24px 0 48px;
+        }
+
+        .fallback-panel,
+        .fallback-card {
+            background: #ffffff;
+            border: 1px solid #d0d7de;
+            border-radius: 20px;
+            box-shadow: 0 16px 40px rgba(17, 17, 17, 0.08);
+        }
+
+        .fallback-panel {
+            padding: 24px;
+        }
+
+        .fallback-grid {
+            display: grid;
+            gap: 18px;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        }
+
+        .fallback-card {
+            padding: 20px;
+        }
+
+        .fallback-card h3,
+        .fallback-panel h1,
+        .fallback-panel h2 {
+            margin-top: 0;
+        }
+
+        .fallback-card a,
+        .fallback-panel a {
+            color: #0066ff;
+            font-weight: 700;
+        }
+    </style>
+    <script>
+        (function () {
+            const repoMarker = "/python_programming_courses/";
+            const pathname = window.location.pathname;
+            const basePath = pathname.includes(repoMarker)
+                ? pathname.slice(0, pathname.indexOf(repoMarker) + repoMarker.length)
+                : "/";
+            window.__PYC_BASE_PATH = basePath;
+            window.__PYC_SOURCE_PREVIEW = pathname.startsWith("/slides/") && !pathname.includes(repoMarker);
+
+            document.addEventListener("DOMContentLoaded", function () {
+                if (!window.__PYC_SOURCE_PREVIEW) {
+                    return;
+                }
+
+                document.querySelectorAll("[data-source-href]").forEach(function (node) {
+                    const sourceHref = node.getAttribute("data-source-href");
+                    if (sourceHref) {
+                        node.setAttribute("href", basePath + sourceHref.replace(/^\/+/, ""));
+                    }
+                });
+            }, { once: true });
+
+            const stylesheet = document.createElement("link");
+            stylesheet.rel = "stylesheet";
+            stylesheet.href = basePath + "slides/shared/portal/portal.css";
+            document.head.appendChild(stylesheet);
+
+            const script = document.createElement("script");
+            script.src = basePath + "slides/shared/portal/portal.js";
+            script.defer = true;
+            document.head.appendChild(script);
+        })();
+    </script>
+</head>
+<body class="portal-page">
+    <a class="portal-skip-link" href="#main-content">Skip to printable index</a>
+    <main id="main-content" class="portal-shell fallback-shell" role="main">
+        <nav class="portal-breadcrumbs fallback-panel" aria-label="Breadcrumb">
+            <a href="../index.html" data-source-href="slides/index.html">Course portal</a>
+            <span class="portal-breadcrumb-separator" aria-hidden="true">/</span>
+            <span>Printable index</span>
+        </nav>
+
+        <header class="portal-section fallback-panel" aria-labelledby="printable-index-title">
+            <span class="portal-kicker">Supporting page</span>
+            <h1 id="printable-index-title">Printable full-course index</h1>
+            <p>
+                This page collects the day-deck entrypoints for both modules in one printable-friendly overview. Use the module portals for richer artifact links and theme-aware browsing.
+            </p>
+            <div class="portal-actions">
+                <a class="portal-button" data-variant="primary" href="../index.html" data-source-href="slides/index.html">Back to course portal</a>
+                <a class="portal-button" data-variant="secondary" href="./basics/" data-source-href="Basics/lessons/slides/index.html">Open Basics portal</a>
+                <a class="portal-button" data-variant="secondary" href="./advanced/" data-source-href="Advanced/lessons/slides/index.html">Open Advanced portal</a>
+            </div>
+        </header>
+
+        <section class="portal-section fallback-panel" aria-labelledby="printable-notes-title">
+            <h2 id="printable-notes-title">Reference notes</h2>
+            <div class="portal-badge-row">
+                <span class="portal-badge">24 day decks</span>
+                <span class="portal-badge">2 module portals</span>
+                <span class="portal-badge">Static-first layout</span>
+            </div>
+            <p class="portal-note">
+                For lecture scripts, assignments, quizzes, and syllabus documents, use the root dashboard or the individual module portals. This page is optimized for a compact full-course deck index.
+            </p>
+        </section>
+
+        <section class="portal-section fallback-panel" aria-labelledby="basics-printable-title">
+            <div class="portal-card-header">
+                <h2 id="basics-printable-title">Basics module index</h2>
+                <a class="portal-link-chip" href="./basics/" data-source-href="Basics/lessons/slides/index.html">Basics portal</a>
+            </div>
+            <div class="portal-day-grid fallback-grid">
+                <article class="portal-card fallback-card"><h3>Basics Day 1</h3><p><a href="./basics/day-01/day-01-session-1.html" data-source-href="Basics/lessons/slides/day-01/day-01-session-1.html">Day 1 deck</a><br>Environment setup, print(), variables, and operators</p></article>
+                <article class="portal-card fallback-card"><h3>Basics Day 2</h3><p><a href="./basics/day-02/day-02-session-2.html" data-source-href="Basics/lessons/slides/day-02/day-02-session-2.html">Day 2 deck</a><br>Strings, input/output, type conversion, and Checkpoint 1</p></article>
+                <article class="portal-card fallback-card"><h3>Basics Day 3</h3><p><a href="./basics/day-03/day-03-session-3.html" data-source-href="Basics/lessons/slides/day-03/day-03-session-3.html">Day 3 deck</a><br>Comparisons, boolean logic, f-strings, and debugging habits</p></article>
+                <article class="portal-card fallback-card"><h3>Basics Day 4</h3><p><a href="./basics/day-04/day-04-session-4.html" data-source-href="Basics/lessons/slides/day-04/day-04-session-4.html">Day 4 deck</a><br>Lists, looping, nested lists, and Checkpoint 2</p></article>
+                <article class="portal-card fallback-card"><h3>Basics Day 5</h3><p><a href="./basics/day-05/day-05-session-5.html" data-source-href="Basics/lessons/slides/day-05/day-05-session-5.html">Day 5 deck</a><br>Tuples, immutability, packing/unpacking, and list trade-offs</p></article>
+                <article class="portal-card fallback-card"><h3>Basics Day 6</h3><p><a href="./basics/day-06/day-06-session-6.html" data-source-href="Basics/lessons/slides/day-06/day-06-session-6.html">Day 6 deck</a><br>Sets, dictionaries, comprehensions, and Checkpoint 3</p></article>
+                <article class="portal-card fallback-card"><h3>Basics Day 7</h3><p><a href="./basics/day-07/day-07-session-7.html" data-source-href="Basics/lessons/slides/day-07/day-07-session-7.html">Day 7 deck</a><br>Conditionals, boolean operators, and match/case</p></article>
+                <article class="portal-card fallback-card"><h3>Basics Day 8</h3><p><a href="./basics/day-08/day-08-session-8.html" data-source-href="Basics/lessons/slides/day-08/day-08-session-8.html">Day 8 deck</a><br>Loops, input validation, and a CLI mini-project</p></article>
+                <article class="portal-card fallback-card"><h3>Basics Day 9</h3><p><a href="./basics/day-09/day-09-session-9.html" data-source-href="Basics/lessons/slides/day-09/day-09-session-9.html">Day 9 deck</a><br>Functions, scope, collections in functions, and modules</p></article>
+                <article class="portal-card fallback-card"><h3>Basics Day 10</h3><p><a href="./basics/day-10/day-10-session-10.html" data-source-href="Basics/lessons/slides/day-10/day-10-session-10.html">Day 10 deck</a><br>Classes, attributes, methods, inheritance, and Checkpoint 4</p></article>
+                <article class="portal-card fallback-card"><h3>Basics Day 11</h3><p><a href="./basics/day-11/day-11-session-11.html" data-source-href="Basics/lessons/slides/day-11/day-11-session-11.html">Day 11 deck</a><br>File I/O, try/except, and error management</p></article>
+                <article class="portal-card fallback-card"><h3>Basics Day 12</h3><p><a href="./basics/day-12/day-12-session-12.html" data-source-href="Basics/lessons/slides/day-12/day-12-session-12.html">Day 12 deck</a><br>Capstone project, final review, PCEP prep, and wrap-up</p></article>
+            </div>
+        </section>
+
+        <section class="portal-section fallback-panel" aria-labelledby="advanced-printable-title">
+            <div class="portal-card-header">
+                <h2 id="advanced-printable-title">Advanced module index</h2>
+                <a class="portal-link-chip" href="./advanced/" data-source-href="Advanced/lessons/slides/index.html">Advanced portal</a>
+            </div>
+            <div class="portal-day-grid fallback-grid">
+                <article class="portal-card fallback-card"><h3>Advanced Day 1</h3><p><a href="./advanced/day-01/day-01-session-1.html" data-source-href="Advanced/lessons/slides/day-01/day-01-session-1.html">Day 1 deck</a><br>Kickoff, class design, invariants, exceptions, and polymorphism</p></article>
+                <article class="portal-card fallback-card"><h3>Advanced Day 2</h3><p><a href="./advanced/day-02/day-02-session-2.html" data-source-href="Advanced/lessons/slides/day-02/day-02-session-2.html">Day 2 deck</a><br>Factory and Strategy patterns, ergonomics, and Checkpoint 1</p></article>
+                <article class="portal-card fallback-card"><h3>Advanced Day 3</h3><p><a href="./advanced/day-03/day-03-session-3.html" data-source-href="Advanced/lessons/slides/day-03/day-03-session-3.html">Day 3 deck</a><br>Project structure, logging, context managers, and decorators</p></article>
+                <article class="portal-card fallback-card"><h3>Advanced Day 4</h3><p><a href="./advanced/day-04/day-04-session-4.html" data-source-href="Advanced/lessons/slides/day-04/day-04-session-4.html">Day 4 deck</a><br>HTTP clients, security basics, capstone planning, and Checkpoint 2</p></article>
+                <article class="portal-card fallback-card"><h3>Advanced Day 5</h3><p><a href="./advanced/day-05/day-05-session-5.html" data-source-href="Advanced/lessons/slides/day-05/day-05-session-5.html">Day 5 deck</a><br>GUI fundamentals, layout, forms, and list interfaces</p></article>
+                <article class="portal-card fallback-card"><h3>Advanced Day 6</h3><p><a href="./advanced/day-06/day-06-session-6.html" data-source-href="Advanced/lessons/slides/day-06/day-06-session-6.html">Day 6 deck</a><br>GUI CRUD workflows, architecture, polish, and Checkpoint 3</p></article>
+                <article class="portal-card fallback-card"><h3>Advanced Day 7</h3><p><a href="./advanced/day-07/day-07-session-7.html" data-source-href="Advanced/lessons/slides/day-07/day-07-session-7.html">Day 7 deck</a><br>Schema thinking, sqlite CRUD, row mapping, and transactions</p></article>
+                <article class="portal-card fallback-card"><h3>Advanced Day 8</h3><p><a href="./advanced/day-08/day-08-session-8.html" data-source-href="Advanced/lessons/slides/day-08/day-08-session-8.html">Day 8 deck</a><br>ORM/deeper SQL, DB integration, search, pagination, and Checkpoint 4</p></article>
+                <article class="portal-card fallback-card"><h3>Advanced Day 9</h3><p><a href="./advanced/day-09/day-09-session-9.html" data-source-href="Advanced/lessons/slides/day-09/day-09-session-9.html">Day 9 deck</a><br>REST fundamentals, CRUD endpoints, validation, and app structure</p></article>
+                <article class="portal-card fallback-card"><h3>Advanced Day 10</h3><p><a href="./advanced/day-10/day-10-session-10.html" data-source-href="Advanced/lessons/slides/day-10/day-10-session-10.html">Day 10 deck</a><br>API security, Python clients, integration choices, and Checkpoint 5</p></article>
+                <article class="portal-card fallback-card"><h3>Advanced Day 11</h3><p><a href="./advanced/day-11/day-11-session-11.html" data-source-href="Advanced/lessons/slides/day-11/day-11-session-11.html">Day 11 deck</a><br>Pandas, matplotlib, regression, and analytics integration</p></article>
+                <article class="portal-card fallback-card"><h3>Advanced Day 12</h3><p><a href="./advanced/day-12/day-12-session-12.html" data-source-href="Advanced/lessons/slides/day-12/day-12-session-12.html">Day 12 deck</a><br>pytest, coverage, packaging, final demo, and review</p></article>
+            </div>
+        </section>
+    </main>
+</body>
+</html>

--- a/slides/shared/portal/course-manifest.json
+++ b/slides/shared/portal/course-manifest.json
@@ -1,0 +1,1709 @@
+{
+  "version": 1,
+  "repository": {
+    "owner": "dhar174",
+    "name": "python_programming_courses",
+    "defaultBranch": "main"
+  },
+  "supportingPages": {
+    "root": "index.html",
+    "printableIndex": "slides/printable-index.html",
+    "notFound": "404.html"
+  },
+  "stats": {
+    "modules": 2,
+    "days": 24,
+    "slides": 24,
+    "lectures": 24,
+    "assignments": 24,
+    "quizzes": 24
+  },
+  "modules": [
+    {
+      "id": "basics",
+      "title": "Python Programming: Basic",
+      "order": 1,
+      "sourceRoot": "Basics/lessons/slides",
+      "publishedRoot": "slides/basics/",
+      "landingPage": "slides/basics/index.html",
+      "primaryHref": "slides/basics/index.html",
+      "sourceLandingPage": "Basics/lessons/slides/index.html",
+      "sourcePrimaryHref": "Basics/lessons/slides/index.html",
+      "theme": "portal",
+      "stats": {
+        "days": 12,
+        "slides": 12,
+        "lectures": 12,
+        "assignments": 12,
+        "quizzes": 12
+      },
+      "days": [
+        {
+          "id": "day-01",
+          "dayNumber": 1,
+          "title": "Day 1",
+          "order": 1,
+          "primaryHref": "slides/basics/day-01/day-01-session-1.html",
+          "sourcePrimaryHref": "Basics/lessons/slides/day-01/day-01-session-1.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Basic",
+              "href": "slides/basics/index.html"
+            },
+            {
+              "label": "Day 1",
+              "href": "slides/basics/day-01/day-01-session-1.html"
+            }
+          ],
+          "prev": null,
+          "next": {
+            "label": "Day 2",
+            "href": "slides/basics/day-02/day-02-session-2.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/basics/day-01/day-01-session-1.html",
+              "sourcePath": "Basics/lessons/slides/day-01/day-01-session-1.html",
+              "downloads": {
+                "html": "slides/basics/day-01/day-01-session-1.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/lessons/lecture/Day1_Hour1_Basics.md",
+              "href": null,
+              "repoPaths": [
+                "Basics/lessons/lecture/Day1_Hour1_Basics.md",
+                "Basics/lessons/lecture/Day1_Hour2_Basics.md",
+                "Basics/lessons/lecture/Day1_Hour3_Basics.md",
+                "Basics/lessons/lecture/Day1_Hour4_Basics.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/assignments/Basics_Day1_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/quizzes/Basics_Day1_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-02",
+          "dayNumber": 2,
+          "title": "Day 2",
+          "order": 2,
+          "primaryHref": "slides/basics/day-02/day-02-session-2.html",
+          "sourcePrimaryHref": "Basics/lessons/slides/day-02/day-02-session-2.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Basic",
+              "href": "slides/basics/index.html"
+            },
+            {
+              "label": "Day 2",
+              "href": "slides/basics/day-02/day-02-session-2.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 1",
+            "href": "slides/basics/day-01/day-01-session-1.html"
+          },
+          "next": {
+            "label": "Day 3",
+            "href": "slides/basics/day-03/day-03-session-3.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/basics/day-02/day-02-session-2.html",
+              "sourcePath": "Basics/lessons/slides/day-02/day-02-session-2.html",
+              "downloads": {
+                "html": "slides/basics/day-02/day-02-session-2.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/lessons/lecture/Day2_Hour1_Basics.md",
+              "href": null,
+              "repoPaths": [
+                "Basics/lessons/lecture/Day2_Hour1_Basics.md",
+                "Basics/lessons/lecture/Day2_Hour2_Basics.md",
+                "Basics/lessons/lecture/Day2_Hour3_Basics.md",
+                "Basics/lessons/lecture/Day2_Hour4_Basics.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/assignments/Basics_Day2_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/quizzes/Basics_Day2_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-03",
+          "dayNumber": 3,
+          "title": "Day 3",
+          "order": 3,
+          "primaryHref": "slides/basics/day-03/day-03-session-3.html",
+          "sourcePrimaryHref": "Basics/lessons/slides/day-03/day-03-session-3.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Basic",
+              "href": "slides/basics/index.html"
+            },
+            {
+              "label": "Day 3",
+              "href": "slides/basics/day-03/day-03-session-3.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 2",
+            "href": "slides/basics/day-02/day-02-session-2.html"
+          },
+          "next": {
+            "label": "Day 4",
+            "href": "slides/basics/day-04/day-04-session-4.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/basics/day-03/day-03-session-3.html",
+              "sourcePath": "Basics/lessons/slides/day-03/day-03-session-3.html",
+              "downloads": {
+                "html": "slides/basics/day-03/day-03-session-3.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/lessons/lecture/Day3_Hour1_Basics.md",
+              "href": null,
+              "repoPaths": [
+                "Basics/lessons/lecture/Day3_Hour1_Basics.md",
+                "Basics/lessons/lecture/Day3_Hour2_Basics.md",
+                "Basics/lessons/lecture/Day3_Hour3_Basics.md",
+                "Basics/lessons/lecture/Day3_Hour4_Basics.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/assignments/Basics_Day3_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/quizzes/Basics_Day3_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-04",
+          "dayNumber": 4,
+          "title": "Day 4",
+          "order": 4,
+          "primaryHref": "slides/basics/day-04/day-04-session-4.html",
+          "sourcePrimaryHref": "Basics/lessons/slides/day-04/day-04-session-4.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Basic",
+              "href": "slides/basics/index.html"
+            },
+            {
+              "label": "Day 4",
+              "href": "slides/basics/day-04/day-04-session-4.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 3",
+            "href": "slides/basics/day-03/day-03-session-3.html"
+          },
+          "next": {
+            "label": "Day 5",
+            "href": "slides/basics/day-05/day-05-session-5.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/basics/day-04/day-04-session-4.html",
+              "sourcePath": "Basics/lessons/slides/day-04/day-04-session-4.html",
+              "downloads": {
+                "html": "slides/basics/day-04/day-04-session-4.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/lessons/lecture/Day4_Hour1_Basics.md",
+              "href": null,
+              "repoPaths": [
+                "Basics/lessons/lecture/Day4_Hour1_Basics.md",
+                "Basics/lessons/lecture/Day4_Hour2_Basics.md",
+                "Basics/lessons/lecture/Day4_Hour3_Basics.md",
+                "Basics/lessons/lecture/Day4_Hour4_Basics.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/assignments/Basics_Day4_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/quizzes/Basics_Day4_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-05",
+          "dayNumber": 5,
+          "title": "Day 5",
+          "order": 5,
+          "primaryHref": "slides/basics/day-05/day-05-session-5.html",
+          "sourcePrimaryHref": "Basics/lessons/slides/day-05/day-05-session-5.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Basic",
+              "href": "slides/basics/index.html"
+            },
+            {
+              "label": "Day 5",
+              "href": "slides/basics/day-05/day-05-session-5.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 4",
+            "href": "slides/basics/day-04/day-04-session-4.html"
+          },
+          "next": {
+            "label": "Day 6",
+            "href": "slides/basics/day-06/day-06-session-6.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/basics/day-05/day-05-session-5.html",
+              "sourcePath": "Basics/lessons/slides/day-05/day-05-session-5.html",
+              "downloads": {
+                "html": "slides/basics/day-05/day-05-session-5.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/lessons/lecture/Day5_Hour1_Basics.md",
+              "href": null,
+              "repoPaths": [
+                "Basics/lessons/lecture/Day5_Hour1_Basics.md",
+                "Basics/lessons/lecture/Day5_Hour2_Basics.md",
+                "Basics/lessons/lecture/Day5_Hour3_Basics.md",
+                "Basics/lessons/lecture/Day5_Hour4_Basics.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/assignments/Basics_Day5_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/quizzes/Basics_Day5_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-06",
+          "dayNumber": 6,
+          "title": "Day 6",
+          "order": 6,
+          "primaryHref": "slides/basics/day-06/day-06-session-6.html",
+          "sourcePrimaryHref": "Basics/lessons/slides/day-06/day-06-session-6.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Basic",
+              "href": "slides/basics/index.html"
+            },
+            {
+              "label": "Day 6",
+              "href": "slides/basics/day-06/day-06-session-6.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 5",
+            "href": "slides/basics/day-05/day-05-session-5.html"
+          },
+          "next": {
+            "label": "Day 7",
+            "href": "slides/basics/day-07/day-07-session-7.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/basics/day-06/day-06-session-6.html",
+              "sourcePath": "Basics/lessons/slides/day-06/day-06-session-6.html",
+              "downloads": {
+                "html": "slides/basics/day-06/day-06-session-6.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/lessons/lecture/Day6_Hour1_Basics.md",
+              "href": null,
+              "repoPaths": [
+                "Basics/lessons/lecture/Day6_Hour1_Basics.md",
+                "Basics/lessons/lecture/Day6_Hour2_Basics.md",
+                "Basics/lessons/lecture/Day6_Hour3_Basics.md",
+                "Basics/lessons/lecture/Day6_Hour4_Basics.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/assignments/Basics_Day6_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/quizzes/Basics_Day6_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-07",
+          "dayNumber": 7,
+          "title": "Day 7",
+          "order": 7,
+          "primaryHref": "slides/basics/day-07/day-07-session-7.html",
+          "sourcePrimaryHref": "Basics/lessons/slides/day-07/day-07-session-7.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Basic",
+              "href": "slides/basics/index.html"
+            },
+            {
+              "label": "Day 7",
+              "href": "slides/basics/day-07/day-07-session-7.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 6",
+            "href": "slides/basics/day-06/day-06-session-6.html"
+          },
+          "next": {
+            "label": "Day 8",
+            "href": "slides/basics/day-08/day-08-session-8.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/basics/day-07/day-07-session-7.html",
+              "sourcePath": "Basics/lessons/slides/day-07/day-07-session-7.html",
+              "downloads": {
+                "html": "slides/basics/day-07/day-07-session-7.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/lessons/lecture/Day7_Hour1_Basics.md",
+              "href": null,
+              "repoPaths": [
+                "Basics/lessons/lecture/Day7_Hour1_Basics.md",
+                "Basics/lessons/lecture/Day7_Hour2_Basics.md",
+                "Basics/lessons/lecture/Day7_Hour3_Basics.md",
+                "Basics/lessons/lecture/Day7_Hour4_Basics.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/assignments/Basics_Day7_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/quizzes/Basics_Day7_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-08",
+          "dayNumber": 8,
+          "title": "Day 8",
+          "order": 8,
+          "primaryHref": "slides/basics/day-08/day-08-session-8.html",
+          "sourcePrimaryHref": "Basics/lessons/slides/day-08/day-08-session-8.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Basic",
+              "href": "slides/basics/index.html"
+            },
+            {
+              "label": "Day 8",
+              "href": "slides/basics/day-08/day-08-session-8.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 7",
+            "href": "slides/basics/day-07/day-07-session-7.html"
+          },
+          "next": {
+            "label": "Day 9",
+            "href": "slides/basics/day-09/day-09-session-9.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/basics/day-08/day-08-session-8.html",
+              "sourcePath": "Basics/lessons/slides/day-08/day-08-session-8.html",
+              "downloads": {
+                "html": "slides/basics/day-08/day-08-session-8.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/lessons/lecture/Day8_Hour1_Basics.md",
+              "href": null,
+              "repoPaths": [
+                "Basics/lessons/lecture/Day8_Hour1_Basics.md",
+                "Basics/lessons/lecture/Day8_Hour2_Basics.md",
+                "Basics/lessons/lecture/Day8_Hour3_Basics.md",
+                "Basics/lessons/lecture/Day8_Hour4_Basics.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/assignments/Basics_Day8_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/quizzes/Basics_Day8_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-09",
+          "dayNumber": 9,
+          "title": "Day 9",
+          "order": 9,
+          "primaryHref": "slides/basics/day-09/day-09-session-9.html",
+          "sourcePrimaryHref": "Basics/lessons/slides/day-09/day-09-session-9.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Basic",
+              "href": "slides/basics/index.html"
+            },
+            {
+              "label": "Day 9",
+              "href": "slides/basics/day-09/day-09-session-9.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 8",
+            "href": "slides/basics/day-08/day-08-session-8.html"
+          },
+          "next": {
+            "label": "Day 10",
+            "href": "slides/basics/day-10/day-10-session-10.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/basics/day-09/day-09-session-9.html",
+              "sourcePath": "Basics/lessons/slides/day-09/day-09-session-9.html",
+              "downloads": {
+                "html": "slides/basics/day-09/day-09-session-9.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/lessons/lecture/Day9_Hour1_Basics.md",
+              "href": null,
+              "repoPaths": [
+                "Basics/lessons/lecture/Day9_Hour1_Basics.md",
+                "Basics/lessons/lecture/Day9_Hour2_Basics.md",
+                "Basics/lessons/lecture/Day9_Hour3_Basics.md",
+                "Basics/lessons/lecture/Day9_Hour4_Basics.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/assignments/Basics_Day9_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/quizzes/Basics_Day9_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-10",
+          "dayNumber": 10,
+          "title": "Day 10",
+          "order": 10,
+          "primaryHref": "slides/basics/day-10/day-10-session-10.html",
+          "sourcePrimaryHref": "Basics/lessons/slides/day-10/day-10-session-10.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Basic",
+              "href": "slides/basics/index.html"
+            },
+            {
+              "label": "Day 10",
+              "href": "slides/basics/day-10/day-10-session-10.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 9",
+            "href": "slides/basics/day-09/day-09-session-9.html"
+          },
+          "next": {
+            "label": "Day 11",
+            "href": "slides/basics/day-11/day-11-session-11.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/basics/day-10/day-10-session-10.html",
+              "sourcePath": "Basics/lessons/slides/day-10/day-10-session-10.html",
+              "downloads": {
+                "html": "slides/basics/day-10/day-10-session-10.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/lessons/lecture/Day10_Hour1_Basics.md",
+              "href": null,
+              "repoPaths": [
+                "Basics/lessons/lecture/Day10_Hour1_Basics.md",
+                "Basics/lessons/lecture/Day10_Hour2_Basics.md",
+                "Basics/lessons/lecture/Day10_Hour3_Basics.md",
+                "Basics/lessons/lecture/Day10_Hour4_Basics.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/assignments/Basics_Day10_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/quizzes/Basics_Day10_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-11",
+          "dayNumber": 11,
+          "title": "Day 11",
+          "order": 11,
+          "primaryHref": "slides/basics/day-11/day-11-session-11.html",
+          "sourcePrimaryHref": "Basics/lessons/slides/day-11/day-11-session-11.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Basic",
+              "href": "slides/basics/index.html"
+            },
+            {
+              "label": "Day 11",
+              "href": "slides/basics/day-11/day-11-session-11.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 10",
+            "href": "slides/basics/day-10/day-10-session-10.html"
+          },
+          "next": {
+            "label": "Day 12",
+            "href": "slides/basics/day-12/day-12-session-12.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/basics/day-11/day-11-session-11.html",
+              "sourcePath": "Basics/lessons/slides/day-11/day-11-session-11.html",
+              "downloads": {
+                "html": "slides/basics/day-11/day-11-session-11.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/lessons/lecture/Day11_Hour1_Basics.md",
+              "href": null,
+              "repoPaths": [
+                "Basics/lessons/lecture/Day11_Hour1_Basics.md",
+                "Basics/lessons/lecture/Day11_Hour2_Basics.md",
+                "Basics/lessons/lecture/Day11_Hour3_Basics.md",
+                "Basics/lessons/lecture/Day11_Hour4_Basics.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/assignments/Basics_Day11_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/quizzes/Basics_Day11_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-12",
+          "dayNumber": 12,
+          "title": "Day 12",
+          "order": 12,
+          "primaryHref": "slides/basics/day-12/day-12-session-12.html",
+          "sourcePrimaryHref": "Basics/lessons/slides/day-12/day-12-session-12.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Basic",
+              "href": "slides/basics/index.html"
+            },
+            {
+              "label": "Day 12",
+              "href": "slides/basics/day-12/day-12-session-12.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 11",
+            "href": "slides/basics/day-11/day-11-session-11.html"
+          },
+          "next": null,
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/basics/day-12/day-12-session-12.html",
+              "sourcePath": "Basics/lessons/slides/day-12/day-12-session-12.html",
+              "downloads": {
+                "html": "slides/basics/day-12/day-12-session-12.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/lessons/lecture/Day12_Hour1_Basics.md",
+              "href": null,
+              "repoPaths": [
+                "Basics/lessons/lecture/Day12_Hour1_Basics.md",
+                "Basics/lessons/lecture/Day12_Hour2_Basics.md",
+                "Basics/lessons/lecture/Day12_Hour3_Basics.md",
+                "Basics/lessons/lecture/Day12_Hour4_Basics.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/assignments/Basics_Day12_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Basics/quizzes/Basics_Day12_Quiz.html",
+              "href": null
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "advanced",
+      "title": "Python Programming: Advanced",
+      "order": 2,
+      "sourceRoot": "Advanced/lessons/slides",
+      "publishedRoot": "slides/advanced/",
+      "landingPage": "slides/advanced/index.html",
+      "primaryHref": "slides/advanced/index.html",
+      "sourceLandingPage": "Advanced/lessons/slides/index.html",
+      "sourcePrimaryHref": "Advanced/lessons/slides/index.html",
+      "theme": "portal",
+      "stats": {
+        "days": 12,
+        "slides": 12,
+        "lectures": 12,
+        "assignments": 12,
+        "quizzes": 12
+      },
+      "days": [
+        {
+          "id": "day-01",
+          "dayNumber": 1,
+          "title": "Day 1",
+          "order": 1,
+          "primaryHref": "slides/advanced/day-01/day-01-session-1.html",
+          "sourcePrimaryHref": "Advanced/lessons/slides/day-01/day-01-session-1.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Advanced",
+              "href": "slides/advanced/index.html"
+            },
+            {
+              "label": "Day 1",
+              "href": "slides/advanced/day-01/day-01-session-1.html"
+            }
+          ],
+          "prev": null,
+          "next": {
+            "label": "Day 2",
+            "href": "slides/advanced/day-02/day-02-session-2.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/advanced/day-01/day-01-session-1.html",
+              "sourcePath": "Advanced/lessons/slides/day-01/day-01-session-1.html",
+              "downloads": {
+                "html": "slides/advanced/day-01/day-01-session-1.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/lessons/lecture/Day1_Hour1_Advanced.md",
+              "href": null,
+              "repoPaths": [
+                "Advanced/lessons/lecture/Day1_Hour1_Advanced.md",
+                "Advanced/lessons/lecture/Day1_Hour2_Advanced.md",
+                "Advanced/lessons/lecture/Day1_Hour3_Advanced.md",
+                "Advanced/lessons/lecture/Day1_Hour4_Advanced.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/assignments/Advanced_Day1_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/quizzes/Advanced_Day1_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-02",
+          "dayNumber": 2,
+          "title": "Day 2",
+          "order": 2,
+          "primaryHref": "slides/advanced/day-02/day-02-session-2.html",
+          "sourcePrimaryHref": "Advanced/lessons/slides/day-02/day-02-session-2.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Advanced",
+              "href": "slides/advanced/index.html"
+            },
+            {
+              "label": "Day 2",
+              "href": "slides/advanced/day-02/day-02-session-2.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 1",
+            "href": "slides/advanced/day-01/day-01-session-1.html"
+          },
+          "next": {
+            "label": "Day 3",
+            "href": "slides/advanced/day-03/day-03-session-3.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/advanced/day-02/day-02-session-2.html",
+              "sourcePath": "Advanced/lessons/slides/day-02/day-02-session-2.html",
+              "downloads": {
+                "html": "slides/advanced/day-02/day-02-session-2.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/lessons/lecture/Day2_Hour1_Advanced.md",
+              "href": null,
+              "repoPaths": [
+                "Advanced/lessons/lecture/Day2_Hour1_Advanced.md",
+                "Advanced/lessons/lecture/Day2_Hour2_Advanced.md",
+                "Advanced/lessons/lecture/Day2_Hour3_Advanced.md",
+                "Advanced/lessons/lecture/Day2_Hour4_Advanced.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/assignments/Advanced_Day2_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/quizzes/Advanced_Day2_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-03",
+          "dayNumber": 3,
+          "title": "Day 3",
+          "order": 3,
+          "primaryHref": "slides/advanced/day-03/day-03-session-3.html",
+          "sourcePrimaryHref": "Advanced/lessons/slides/day-03/day-03-session-3.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Advanced",
+              "href": "slides/advanced/index.html"
+            },
+            {
+              "label": "Day 3",
+              "href": "slides/advanced/day-03/day-03-session-3.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 2",
+            "href": "slides/advanced/day-02/day-02-session-2.html"
+          },
+          "next": {
+            "label": "Day 4",
+            "href": "slides/advanced/day-04/day-04-session-4.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/advanced/day-03/day-03-session-3.html",
+              "sourcePath": "Advanced/lessons/slides/day-03/day-03-session-3.html",
+              "downloads": {
+                "html": "slides/advanced/day-03/day-03-session-3.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/lessons/lecture/Day3_Hour1_Advanced.md",
+              "href": null,
+              "repoPaths": [
+                "Advanced/lessons/lecture/Day3_Hour1_Advanced.md",
+                "Advanced/lessons/lecture/Day3_Hour2_Advanced.md",
+                "Advanced/lessons/lecture/Day3_Hour3_Advanced.md",
+                "Advanced/lessons/lecture/Day3_Hour4_Advanced.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/assignments/Advanced_Day3_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/quizzes/Advanced_Day3_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-04",
+          "dayNumber": 4,
+          "title": "Day 4",
+          "order": 4,
+          "primaryHref": "slides/advanced/day-04/day-04-session-4.html",
+          "sourcePrimaryHref": "Advanced/lessons/slides/day-04/day-04-session-4.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Advanced",
+              "href": "slides/advanced/index.html"
+            },
+            {
+              "label": "Day 4",
+              "href": "slides/advanced/day-04/day-04-session-4.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 3",
+            "href": "slides/advanced/day-03/day-03-session-3.html"
+          },
+          "next": {
+            "label": "Day 5",
+            "href": "slides/advanced/day-05/day-05-session-5.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/advanced/day-04/day-04-session-4.html",
+              "sourcePath": "Advanced/lessons/slides/day-04/day-04-session-4.html",
+              "downloads": {
+                "html": "slides/advanced/day-04/day-04-session-4.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/lessons/lecture/Day4_Hour1_Advanced.md",
+              "href": null,
+              "repoPaths": [
+                "Advanced/lessons/lecture/Day4_Hour1_Advanced.md",
+                "Advanced/lessons/lecture/Day4_Hour2_Advanced.md",
+                "Advanced/lessons/lecture/Day4_Hour3_Advanced.md",
+                "Advanced/lessons/lecture/Day4_Hour4_Advanced.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/assignments/Advanced_Day4_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/quizzes/Advanced_Day4_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-05",
+          "dayNumber": 5,
+          "title": "Day 5",
+          "order": 5,
+          "primaryHref": "slides/advanced/day-05/day-05-session-5.html",
+          "sourcePrimaryHref": "Advanced/lessons/slides/day-05/day-05-session-5.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Advanced",
+              "href": "slides/advanced/index.html"
+            },
+            {
+              "label": "Day 5",
+              "href": "slides/advanced/day-05/day-05-session-5.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 4",
+            "href": "slides/advanced/day-04/day-04-session-4.html"
+          },
+          "next": {
+            "label": "Day 6",
+            "href": "slides/advanced/day-06/day-06-session-6.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/advanced/day-05/day-05-session-5.html",
+              "sourcePath": "Advanced/lessons/slides/day-05/day-05-session-5.html",
+              "downloads": {
+                "html": "slides/advanced/day-05/day-05-session-5.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/lessons/lecture/Day5_Hour1_Advanced.md",
+              "href": null,
+              "repoPaths": [
+                "Advanced/lessons/lecture/Day5_Hour1_Advanced.md",
+                "Advanced/lessons/lecture/Day5_Hour2_Advanced.md",
+                "Advanced/lessons/lecture/Day5_Hour3_Advanced.md",
+                "Advanced/lessons/lecture/Day5_Hour4_Advanced.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/assignments/Advanced_Day5_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/quizzes/Advanced_Day5_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-06",
+          "dayNumber": 6,
+          "title": "Day 6",
+          "order": 6,
+          "primaryHref": "slides/advanced/day-06/day-06-session-6.html",
+          "sourcePrimaryHref": "Advanced/lessons/slides/day-06/day-06-session-6.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Advanced",
+              "href": "slides/advanced/index.html"
+            },
+            {
+              "label": "Day 6",
+              "href": "slides/advanced/day-06/day-06-session-6.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 5",
+            "href": "slides/advanced/day-05/day-05-session-5.html"
+          },
+          "next": {
+            "label": "Day 7",
+            "href": "slides/advanced/day-07/day-07-session-7.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/advanced/day-06/day-06-session-6.html",
+              "sourcePath": "Advanced/lessons/slides/day-06/day-06-session-6.html",
+              "downloads": {
+                "html": "slides/advanced/day-06/day-06-session-6.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/lessons/lecture/Day6_Hour1_Advanced.md",
+              "href": null,
+              "repoPaths": [
+                "Advanced/lessons/lecture/Day6_Hour1_Advanced.md",
+                "Advanced/lessons/lecture/Day6_Hour2_Advanced.md",
+                "Advanced/lessons/lecture/Day6_Hour3_Advanced.md",
+                "Advanced/lessons/lecture/Day6_Hour4_Advanced.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/assignments/Advanced_Day6_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/quizzes/Advanced_Day6_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-07",
+          "dayNumber": 7,
+          "title": "Day 7",
+          "order": 7,
+          "primaryHref": "slides/advanced/day-07/day-07-session-7.html",
+          "sourcePrimaryHref": "Advanced/lessons/slides/day-07/day-07-session-7.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Advanced",
+              "href": "slides/advanced/index.html"
+            },
+            {
+              "label": "Day 7",
+              "href": "slides/advanced/day-07/day-07-session-7.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 6",
+            "href": "slides/advanced/day-06/day-06-session-6.html"
+          },
+          "next": {
+            "label": "Day 8",
+            "href": "slides/advanced/day-08/day-08-session-8.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/advanced/day-07/day-07-session-7.html",
+              "sourcePath": "Advanced/lessons/slides/day-07/day-07-session-7.html",
+              "downloads": {
+                "html": "slides/advanced/day-07/day-07-session-7.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/lessons/lecture/Day7_Hour1_Advanced.md",
+              "href": null,
+              "repoPaths": [
+                "Advanced/lessons/lecture/Day7_Hour1_Advanced.md",
+                "Advanced/lessons/lecture/Day7_Hour2_Advanced.md",
+                "Advanced/lessons/lecture/Day7_Hour3_Advanced.md",
+                "Advanced/lessons/lecture/Day7_Hour4_Advanced.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/assignments/Advanced_Day7_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/quizzes/Advanced_Day7_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-08",
+          "dayNumber": 8,
+          "title": "Day 8",
+          "order": 8,
+          "primaryHref": "slides/advanced/day-08/day-08-session-8.html",
+          "sourcePrimaryHref": "Advanced/lessons/slides/day-08/day-08-session-8.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Advanced",
+              "href": "slides/advanced/index.html"
+            },
+            {
+              "label": "Day 8",
+              "href": "slides/advanced/day-08/day-08-session-8.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 7",
+            "href": "slides/advanced/day-07/day-07-session-7.html"
+          },
+          "next": {
+            "label": "Day 9",
+            "href": "slides/advanced/day-09/day-09-session-9.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/advanced/day-08/day-08-session-8.html",
+              "sourcePath": "Advanced/lessons/slides/day-08/day-08-session-8.html",
+              "downloads": {
+                "html": "slides/advanced/day-08/day-08-session-8.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/lessons/lecture/Day8_Hour1_Advanced.md",
+              "href": null,
+              "repoPaths": [
+                "Advanced/lessons/lecture/Day8_Hour1_Advanced.md",
+                "Advanced/lessons/lecture/Day8_Hour2_Advanced.md",
+                "Advanced/lessons/lecture/Day8_Hour3_Advanced.md",
+                "Advanced/lessons/lecture/Day8_Hour4_Advanced.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/assignments/Advanced_Day8_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/quizzes/Advanced_Day8_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-09",
+          "dayNumber": 9,
+          "title": "Day 9",
+          "order": 9,
+          "primaryHref": "slides/advanced/day-09/day-09-session-9.html",
+          "sourcePrimaryHref": "Advanced/lessons/slides/day-09/day-09-session-9.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Advanced",
+              "href": "slides/advanced/index.html"
+            },
+            {
+              "label": "Day 9",
+              "href": "slides/advanced/day-09/day-09-session-9.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 8",
+            "href": "slides/advanced/day-08/day-08-session-8.html"
+          },
+          "next": {
+            "label": "Day 10",
+            "href": "slides/advanced/day-10/day-10-session-10.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/advanced/day-09/day-09-session-9.html",
+              "sourcePath": "Advanced/lessons/slides/day-09/day-09-session-9.html",
+              "downloads": {
+                "html": "slides/advanced/day-09/day-09-session-9.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/lessons/lecture/Day9_Hour1_Advanced.md",
+              "href": null,
+              "repoPaths": [
+                "Advanced/lessons/lecture/Day9_Hour1_Advanced.md",
+                "Advanced/lessons/lecture/Day9_Hour2_Advanced.md",
+                "Advanced/lessons/lecture/Day9_Hour3_Advanced.md",
+                "Advanced/lessons/lecture/Day9_Hour4_Advanced.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/assignments/Advanced_Day9_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/quizzes/Advanced_Day9_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-10",
+          "dayNumber": 10,
+          "title": "Day 10",
+          "order": 10,
+          "primaryHref": "slides/advanced/day-10/day-10-session-10.html",
+          "sourcePrimaryHref": "Advanced/lessons/slides/day-10/day-10-session-10.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Advanced",
+              "href": "slides/advanced/index.html"
+            },
+            {
+              "label": "Day 10",
+              "href": "slides/advanced/day-10/day-10-session-10.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 9",
+            "href": "slides/advanced/day-09/day-09-session-9.html"
+          },
+          "next": {
+            "label": "Day 11",
+            "href": "slides/advanced/day-11/day-11-session-11.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/advanced/day-10/day-10-session-10.html",
+              "sourcePath": "Advanced/lessons/slides/day-10/day-10-session-10.html",
+              "downloads": {
+                "html": "slides/advanced/day-10/day-10-session-10.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/lessons/lecture/Day10_Hour1_Advanced.md",
+              "href": null,
+              "repoPaths": [
+                "Advanced/lessons/lecture/Day10_Hour1_Advanced.md",
+                "Advanced/lessons/lecture/Day10_Hour2_Advanced.md",
+                "Advanced/lessons/lecture/Day10_Hour3_Advanced.md",
+                "Advanced/lessons/lecture/Day10_Hour4_Advanced.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/assignments/Advanced_Day10_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/quizzes/Advanced_Day10_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-11",
+          "dayNumber": 11,
+          "title": "Day 11",
+          "order": 11,
+          "primaryHref": "slides/advanced/day-11/day-11-session-11.html",
+          "sourcePrimaryHref": "Advanced/lessons/slides/day-11/day-11-session-11.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Advanced",
+              "href": "slides/advanced/index.html"
+            },
+            {
+              "label": "Day 11",
+              "href": "slides/advanced/day-11/day-11-session-11.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 10",
+            "href": "slides/advanced/day-10/day-10-session-10.html"
+          },
+          "next": {
+            "label": "Day 12",
+            "href": "slides/advanced/day-12/day-12-session-12.html"
+          },
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/advanced/day-11/day-11-session-11.html",
+              "sourcePath": "Advanced/lessons/slides/day-11/day-11-session-11.html",
+              "downloads": {
+                "html": "slides/advanced/day-11/day-11-session-11.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/lessons/lecture/Day11_Hour1_Advanced.md",
+              "href": null,
+              "repoPaths": [
+                "Advanced/lessons/lecture/Day11_Hour1_Advanced.md",
+                "Advanced/lessons/lecture/Day11_Hour2_Advanced.md",
+                "Advanced/lessons/lecture/Day11_Hour3_Advanced.md",
+                "Advanced/lessons/lecture/Day11_Hour4_Advanced.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/assignments/Advanced_Day11_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/quizzes/Advanced_Day11_Quiz.html",
+              "href": null
+            }
+          }
+        },
+        {
+          "id": "day-12",
+          "dayNumber": 12,
+          "title": "Day 12",
+          "order": 12,
+          "primaryHref": "slides/advanced/day-12/day-12-session-12.html",
+          "sourcePrimaryHref": "Advanced/lessons/slides/day-12/day-12-session-12.html",
+          "breadcrumbs": [
+            {
+              "label": "Course",
+              "href": "index.html"
+            },
+            {
+              "label": "Python Programming: Advanced",
+              "href": "slides/advanced/index.html"
+            },
+            {
+              "label": "Day 12",
+              "href": "slides/advanced/day-12/day-12-session-12.html"
+            }
+          ],
+          "prev": {
+            "label": "Day 11",
+            "href": "slides/advanced/day-11/day-11-session-11.html"
+          },
+          "next": null,
+          "artifacts": {
+            "slides": {
+              "present": true,
+              "delivery": "pages",
+              "href": "slides/advanced/day-12/day-12-session-12.html",
+              "sourcePath": "Advanced/lessons/slides/day-12/day-12-session-12.html",
+              "downloads": {
+                "html": "slides/advanced/day-12/day-12-session-12.html",
+                "pdf": null,
+                "pptx": null,
+                "png": null
+              }
+            },
+            "lecture": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/lessons/lecture/Day12_Hour1_Advanced.md",
+              "href": null,
+              "repoPaths": [
+                "Advanced/lessons/lecture/Day12_Hour1_Advanced.md",
+                "Advanced/lessons/lecture/Day12_Hour2_Advanced.md",
+                "Advanced/lessons/lecture/Day12_Hour3_Advanced.md",
+                "Advanced/lessons/lecture/Day12_Hour4_Advanced.md"
+              ],
+              "count": 4
+            },
+            "assignment": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/assignments/Advanced_Day12_homework.ipynb",
+              "href": null
+            },
+            "quiz": {
+              "present": true,
+              "delivery": "repo",
+              "repoPath": "Advanced/quizzes/Advanced_Day12_Quiz.html",
+              "href": null
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/slides/shared/portal/portal.css
+++ b/slides/shared/portal/portal.css
@@ -1,0 +1,461 @@
+/* Shared portal tokens and components for the course landing surfaces.
+   Marp slide themes keep their own @theme files; keep the shared semantic values
+   aligned manually until the module portals fully converge on this system. */
+:root {
+  color-scheme: light;
+  --bg: #f7f7f7;
+  --fg: #111111;
+  --muted: #4f5b66;
+  --accent: #0066ff;
+  --accent-contrast: #ffffff;
+  --code-bg: #1e1e1e;
+  --code-fg: #f8f8f2;
+  --code-border: #cccccc;
+  --table-border: #d0d7de;
+  --blockquote-bg: #eef4ff;
+  --blockquote-border: #b6cbff;
+  --border: #d4dbe5;
+  --surface-1: rgba(255, 255, 255, 0.9);
+  --surface-2: rgba(230, 240, 255, 0.88);
+  --focus-ring: rgba(0, 102, 255, 0.35);
+  --shadow: 0 24px 60px rgba(17, 17, 17, 0.12);
+  --radius-md: 16px;
+  --radius-lg: 28px;
+  --space-base: 24px;
+  --max-width: 1180px;
+  --font-body: system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-heading: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --transition-speed: 0.3s;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #0d1117;
+  --fg: #e6edf3;
+  --muted: #9da7b1;
+  --accent: #2f81f7;
+  --accent-contrast: #0d1117;
+  --code-bg: #161b22;
+  --code-fg: #c9d1d9;
+  --code-border: #30363d;
+  --table-border: #30363d;
+  --blockquote-bg: #111827;
+  --blockquote-border: #2f81f7;
+  --border: #30363d;
+  --surface-1: rgba(22, 27, 34, 0.9);
+  --surface-2: rgba(15, 23, 42, 0.92);
+  --focus-ring: rgba(47, 129, 247, 0.42);
+  --shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body.portal-page {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-body);
+  background:
+    radial-gradient(circle at top left, rgba(0, 102, 255, 0.14), transparent 32%),
+    linear-gradient(180deg, var(--bg) 0%, color-mix(in srgb, var(--bg) 94%, var(--accent) 6%) 100%);
+  color: var(--fg);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--accent);
+}
+
+a:hover {
+  text-decoration-thickness: 2px;
+}
+
+a:focus-visible,
+button:focus-visible,
+select:focus-visible,
+summary:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.portal-shell {
+  width: min(var(--max-width), calc(100% - (var(--space-base) * 2)));
+  margin: 0 auto;
+  padding: calc(var(--space-base) * 1.5) 0 calc(var(--space-base) * 2.5);
+}
+
+.portal-skip-link {
+  position: absolute;
+  left: 16px;
+  top: -64px;
+  z-index: 1000;
+  padding: 12px 16px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  text-decoration: none;
+}
+
+.portal-skip-link:focus {
+  top: 16px;
+}
+
+.portal-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-base);
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: calc(var(--space-base) * 1.75);
+}
+
+.portal-hero {
+  flex: 1 1 560px;
+  padding: calc(var(--space-base) * 1.4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, var(--surface-1), var(--surface-2));
+  box-shadow: var(--shadow);
+}
+
+.portal-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  font-size: 0.88rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.portal-hero h1,
+.portal-section h2,
+.portal-card h2,
+.portal-card h3 {
+  margin: 0;
+  font-family: var(--font-heading);
+  line-height: 1.15;
+}
+
+.portal-hero h1 {
+  margin-top: 18px;
+  font-size: clamp(2.2rem, 4vw, 4rem);
+}
+
+.portal-hero p {
+  max-width: 62ch;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.portal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.portal-button,
+.portal-link-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 0 16px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition:
+    transform var(--transition-speed) ease,
+    background var(--transition-speed) ease,
+    border-color var(--transition-speed) ease;
+}
+
+.portal-button:hover,
+.portal-link-chip:hover {
+  transform: translateY(-1px);
+}
+
+.portal-button[data-variant="primary"] {
+  background: var(--accent);
+  color: var(--accent-contrast);
+}
+
+.portal-button[data-variant="secondary"] {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--fg);
+}
+
+.portal-toolbar {
+  flex: 0 1 320px;
+  display: grid;
+  gap: 16px;
+  align-self: stretch;
+}
+
+.portal-panel,
+.portal-card,
+.portal-section {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+  box-shadow: var(--shadow);
+}
+
+.portal-panel {
+  padding: 18px;
+}
+
+.portal-breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  padding: 14px 18px;
+  margin-bottom: 18px;
+}
+
+.portal-breadcrumbs a {
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.portal-breadcrumb-separator {
+  color: var(--muted);
+}
+
+.portal-panel h2 {
+  margin: 0 0 14px;
+  font-size: 1rem;
+}
+
+.portal-theme-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.portal-theme-row select {
+  flex: 1;
+  min-height: 44px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.portal-stats-grid,
+.portal-module-grid,
+.portal-day-grid {
+  display: grid;
+  gap: var(--space-base);
+}
+
+.portal-stats-grid {
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  margin-top: 28px;
+}
+
+.portal-stat {
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border));
+}
+
+:root[data-theme="dark"] .portal-stat {
+  background: rgba(13, 17, 23, 0.42);
+}
+
+.portal-stat strong {
+  display: block;
+  font-size: 1.5rem;
+  line-height: 1.1;
+}
+
+.portal-stat span {
+  display: block;
+  margin-top: 6px;
+  color: var(--muted);
+}
+
+.portal-module-grid {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.portal-day-grid {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  margin-top: 24px;
+}
+
+.portal-card {
+  padding: calc(var(--space-base) * 1.1);
+}
+
+.portal-card p {
+  color: var(--muted);
+}
+
+.portal-card h3 {
+  font-size: 1.2rem;
+}
+
+.portal-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.portal-card-header h2 {
+  font-size: 1.5rem;
+}
+
+.portal-badge-row,
+.portal-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.portal-badge,
+.portal-link-chip {
+  border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--fg);
+}
+
+.portal-chip-list {
+  margin: 18px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.portal-chip-list a {
+  text-decoration: none;
+}
+
+.portal-day-links {
+  min-height: 44px;
+}
+
+.portal-day-links .portal-note {
+  margin: 0;
+}
+
+.portal-summary {
+  margin-top: 12px;
+}
+
+.portal-summary em {
+  display: block;
+  margin-top: 10px;
+  color: var(--muted);
+}
+
+.portal-card-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 20px 0;
+}
+
+.portal-meta-item {
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--bg) 80%, var(--surface-2));
+  border: 1px solid var(--border);
+}
+
+.portal-meta-item strong {
+  display: block;
+  font-size: 1.1rem;
+}
+
+.portal-meta-item span {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.portal-section {
+  margin-top: calc(var(--space-base) * 1.4);
+  padding: calc(var(--space-base) * 1.15);
+}
+
+.portal-section h2 {
+  font-size: 1.55rem;
+}
+
+.portal-section p {
+  color: var(--muted);
+}
+
+.portal-note {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.portal-status-badge[data-state="available"] {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 20%, var(--border));
+}
+
+.portal-status-badge[data-state="missing"] {
+  background: color-mix(in srgb, #b42318 12%, transparent);
+  border-color: color-mix(in srgb, #b42318 18%, var(--border));
+}
+
+.portal-footer {
+  margin-top: calc(var(--space-base) * 1.8);
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.portal-hidden {
+  display: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+@media (max-width: 720px) {
+  .portal-shell {
+    width: min(100% - 28px, var(--max-width));
+    padding-top: 20px;
+  }
+
+  .portal-card-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .portal-stats-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/slides/shared/portal/portal.css
+++ b/slides/shared/portal/portal.css
@@ -48,6 +48,28 @@
   --shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
 }
 
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    color-scheme: dark;
+    --bg: #0d1117;
+    --fg: #e6edf3;
+    --muted: #9da7b1;
+    --accent: #2f81f7;
+    --accent-contrast: #0d1117;
+    --code-bg: #161b22;
+    --code-fg: #c9d1d9;
+    --code-border: #30363d;
+    --table-border: #30363d;
+    --blockquote-bg: #111827;
+    --blockquote-border: #2f81f7;
+    --border: #30363d;
+    --surface-1: rgba(22, 27, 34, 0.9);
+    --surface-2: rgba(15, 23, 42, 0.92);
+    --focus-ring: rgba(47, 129, 247, 0.42);
+    --shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  }
+}
+
 * {
   box-sizing: border-box;
 }

--- a/slides/shared/portal/portal.js
+++ b/slides/shared/portal/portal.js
@@ -1,22 +1,27 @@
 (function () {
   const THEME_STORAGE_KEY = "pyc-theme";
   const THEME_ATTRIBUTE = "data-theme";
+  let repositoryMeta = {
+    owner: "dhar174",
+    name: "python_programming_courses",
+    defaultBranch: "main",
+  };
 
   function resolveBasePath() {
     if (typeof window.__PYC_BASE_PATH === "string") {
       return window.__PYC_BASE_PATH;
     }
 
-    const repoMarker = "/python_programming_courses/";
     const pathname = window.location.pathname;
-    if (pathname.includes(repoMarker)) {
-      return pathname.slice(0, pathname.indexOf(repoMarker) + repoMarker.length);
+    const slidesMarker = "/slides/";
+    if (pathname.includes(slidesMarker)) {
+      return pathname.slice(0, pathname.indexOf(slidesMarker) + 1);
     }
-    if (pathname.startsWith("/slides/")) {
-      return "/";
+    const htmlMatch = pathname.match(/^(.*\/)(?:index|404)\.html$/);
+    if (htmlMatch) {
+      return htmlMatch[1] || "/";
     }
-    const lastSlash = pathname.lastIndexOf("/");
-    return lastSlash >= 0 ? pathname.slice(0, lastSlash + 1) : "/";
+    return "/";
   }
 
   function isSourcePreview() {
@@ -38,27 +43,45 @@
     root.removeAttribute(THEME_ATTRIBUTE);
   }
 
+  function safeGetThemePreference() {
+    try {
+      return localStorage.getItem(THEME_STORAGE_KEY) || "auto";
+    } catch {
+      return "auto";
+    }
+  }
+
+  function safeSetThemePreference(value) {
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, value);
+    } catch {
+      // Ignore persistence failures and still apply the theme for the current session.
+    }
+  }
+
   function bindThemeControl() {
     const select = document.querySelector("[data-theme-toggle]");
     if (!select) {
       return;
     }
 
-    const initial = localStorage.getItem(THEME_STORAGE_KEY) || "auto";
+    const initial = safeGetThemePreference();
     select.value = initial;
     applyTheme(initial);
 
     select.addEventListener("change", function (event) {
       const value = event.target.value;
-      localStorage.setItem(THEME_STORAGE_KEY, value);
+      safeSetThemePreference(value);
       applyTheme(value);
     });
   }
 
   function repoBlobUrl(repoPath) {
-    const owner = document.body.getAttribute("data-repo-owner") || "dhar174";
-    const name = document.body.getAttribute("data-repo-name") || "python_programming_courses";
-    return `https://github.com/${owner}/${name}/blob/main/${repoPath}`;
+    return `https://github.com/${repositoryMeta.owner}/${repositoryMeta.name}/blob/${repositoryMeta.defaultBranch}/${repoPath}`;
+  }
+
+  function repoTreeUrl(repoPath) {
+    return `https://github.com/${repositoryMeta.owner}/${repositoryMeta.name}/tree/${repositoryMeta.defaultBranch}/${repoPath}`;
   }
 
   function setText(selector, value) {
@@ -104,9 +127,12 @@
     const lecture = module.days.find((day) => day.artifacts.lecture.present);
     const assignment = module.days.find((day) => day.artifacts.assignment.present);
     const quiz = module.days.find((day) => day.artifacts.quiz.present);
+    const lectureDirectory = lecture && lecture.artifacts.lecture.repoPath
+      ? lecture.artifacts.lecture.repoPath.replace(/\/[^/]+$/, "")
+      : null;
     const items = [
-      lecture && lecture.artifacts.lecture.repoPath
-        ? { label: "Lecture scripts", href: repoBlobUrl(lecture.artifacts.lecture.repoPath) }
+      lectureDirectory
+        ? { label: "Lecture scripts", href: repoTreeUrl(lectureDirectory) }
         : null,
       assignment && assignment.artifacts.assignment.repoPath
         ? { label: "Assignments", href: repoBlobUrl(assignment.artifacts.assignment.repoPath) }
@@ -228,8 +254,11 @@
       return;
     }
 
-    document.body.setAttribute("data-repo-owner", manifest.repository.owner);
-    document.body.setAttribute("data-repo-name", manifest.repository.name);
+    repositoryMeta = {
+      owner: manifest.repository.owner || repositoryMeta.owner,
+      name: manifest.repository.name || repositoryMeta.name,
+      defaultBranch: manifest.repository.defaultBranch || repositoryMeta.defaultBranch,
+    };
 
     setText("[data-course-modules]", manifest.stats.modules);
     setText("[data-course-days]", manifest.stats.days);
@@ -261,7 +290,7 @@
     });
   }
 
-  const storedTheme = localStorage.getItem(THEME_STORAGE_KEY) || "auto";
+  const storedTheme = safeGetThemePreference();
   applyTheme(storedTheme);
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", init, { once: true });

--- a/slides/shared/portal/portal.js
+++ b/slides/shared/portal/portal.js
@@ -1,0 +1,271 @@
+(function () {
+  const THEME_STORAGE_KEY = "pyc-theme";
+  const THEME_ATTRIBUTE = "data-theme";
+
+  function resolveBasePath() {
+    if (typeof window.__PYC_BASE_PATH === "string") {
+      return window.__PYC_BASE_PATH;
+    }
+
+    const repoMarker = "/python_programming_courses/";
+    const pathname = window.location.pathname;
+    if (pathname.includes(repoMarker)) {
+      return pathname.slice(0, pathname.indexOf(repoMarker) + repoMarker.length);
+    }
+    if (pathname.startsWith("/slides/")) {
+      return "/";
+    }
+    const lastSlash = pathname.lastIndexOf("/");
+    return lastSlash >= 0 ? pathname.slice(0, lastSlash + 1) : "/";
+  }
+
+  function isSourcePreview() {
+    return Boolean(window.__PYC_SOURCE_PREVIEW);
+  }
+
+  function withBasePath(relativePath) {
+    const normalizedBase = resolveBasePath().replace(/\/+$/, "/");
+    const trimmedRelative = String(relativePath || "").replace(/^\/+/, "");
+    return `${normalizedBase}${trimmedRelative}`;
+  }
+
+  function applyTheme(preference) {
+    const root = document.documentElement;
+    if (preference === "dark" || preference === "light") {
+      root.setAttribute(THEME_ATTRIBUTE, preference);
+      return;
+    }
+    root.removeAttribute(THEME_ATTRIBUTE);
+  }
+
+  function bindThemeControl() {
+    const select = document.querySelector("[data-theme-toggle]");
+    if (!select) {
+      return;
+    }
+
+    const initial = localStorage.getItem(THEME_STORAGE_KEY) || "auto";
+    select.value = initial;
+    applyTheme(initial);
+
+    select.addEventListener("change", function (event) {
+      const value = event.target.value;
+      localStorage.setItem(THEME_STORAGE_KEY, value);
+      applyTheme(value);
+    });
+  }
+
+  function repoBlobUrl(repoPath) {
+    const owner = document.body.getAttribute("data-repo-owner") || "dhar174";
+    const name = document.body.getAttribute("data-repo-name") || "python_programming_courses";
+    return `https://github.com/${owner}/${name}/blob/main/${repoPath}`;
+  }
+
+  function setText(selector, value) {
+    const node = document.querySelector(selector);
+    if (node && value !== undefined && value !== null) {
+      node.textContent = String(value);
+    }
+  }
+
+  function setLink(selector, href) {
+    const node = document.querySelector(selector);
+    if (!node) {
+      return;
+    }
+
+    const sourceHref = node.getAttribute("data-source-href");
+    const targetHref = isSourcePreview() && sourceHref ? sourceHref : href;
+    if (targetHref) {
+      node.setAttribute("href", targetHref.startsWith("http") ? targetHref : withBasePath(targetHref));
+    }
+  }
+
+  function renderModuleSummary(module) {
+    const moduleId = module.id;
+    setText(`[data-module-days="${moduleId}"]`, module.stats.days);
+    setText(`[data-module-slides="${moduleId}"]`, module.stats.slides);
+    setText(`[data-module-lectures="${moduleId}"]`, module.stats.lectures);
+    setText(`[data-module-assignments="${moduleId}"]`, module.stats.assignments);
+    setText(`[data-module-quizzes="${moduleId}"]`, module.stats.quizzes);
+
+    const primaryLink = isSourcePreview()
+      ? module.sourcePrimaryHref || module.sourceLandingPage || module.primaryHref || module.landingPage
+      : module.primaryHref || module.landingPage;
+    if (primaryLink) {
+      setLink(`[data-module-link="${moduleId}"]`, primaryLink);
+    }
+
+    const repoLinks = document.querySelector(`[data-module-repo-links="${moduleId}"]`);
+    if (!repoLinks) {
+      return;
+    }
+
+    const lecture = module.days.find((day) => day.artifacts.lecture.present);
+    const assignment = module.days.find((day) => day.artifacts.assignment.present);
+    const quiz = module.days.find((day) => day.artifacts.quiz.present);
+    const items = [
+      lecture && lecture.artifacts.lecture.repoPath
+        ? { label: "Lecture scripts", href: repoBlobUrl(lecture.artifacts.lecture.repoPath) }
+        : null,
+      assignment && assignment.artifacts.assignment.repoPath
+        ? { label: "Assignments", href: repoBlobUrl(assignment.artifacts.assignment.repoPath) }
+        : null,
+      quiz && quiz.artifacts.quiz.repoPath
+        ? { label: "Quizzes", href: repoBlobUrl(quiz.artifacts.quiz.repoPath) }
+        : null,
+    ].filter(Boolean);
+
+    repoLinks.innerHTML = "";
+    items.forEach(function (item) {
+      const link = document.createElement("a");
+      link.className = "portal-link-chip";
+      link.href = item.href;
+      link.textContent = item.label;
+      repoLinks.appendChild(link);
+    });
+  }
+
+  function renderFeaturedDays(modules) {
+    const container = document.querySelector("[data-featured-days]");
+    if (!container) {
+      return;
+    }
+
+    container.innerHTML = "";
+    modules.forEach(function (module) {
+      const days = module.days.slice(0, 3);
+      days.forEach(function (day) {
+        const item = document.createElement("li");
+        const link = document.createElement("a");
+        link.className = "portal-link-chip";
+        const dayTarget = isSourcePreview()
+          ? day.sourcePrimaryHref || day.artifacts.slides.sourcePath || day.primaryHref
+          : day.primaryHref;
+        link.href = dayTarget ? withBasePath(dayTarget) : "#";
+        link.textContent = `${module.title} · Day ${day.dayNumber}`;
+        item.appendChild(link);
+        container.appendChild(item);
+      });
+    });
+  }
+
+  function labelFromLecturePath(repoPath, index) {
+    const match = /Hour(\d+)/.exec(repoPath || "");
+    if (match) {
+      return `Lecture H${match[1]}`;
+    }
+    return `Lecture ${index + 1}`;
+  }
+
+  function appendChip(container, label, href, state) {
+    const node = href ? document.createElement("a") : document.createElement("span");
+    node.className = "portal-link-chip portal-status-badge";
+    node.textContent = label;
+    node.dataset.state = state || "available";
+    if (href) {
+      node.href = href;
+    }
+    container.appendChild(node);
+  }
+
+  function enhanceModulePage(manifest) {
+    const moduleId = document.body.dataset.moduleId;
+    if (!moduleId) {
+      return;
+    }
+
+    const module = manifest.modules.find((item) => item.id === moduleId);
+    if (!module) {
+      return;
+    }
+
+    setText("[data-module-total-days]", module.stats.days);
+    setText("[data-module-total-lectures]", module.stats.lectures);
+    setText("[data-module-total-assignments]", module.stats.assignments);
+    setText("[data-module-total-quizzes]", module.stats.quizzes);
+
+    module.days.forEach(function (day) {
+      const artifacts = day.artifacts || {};
+      const badgeContainer = document.querySelector(`[data-day-badges="${day.id}"]`);
+      if (badgeContainer) {
+        badgeContainer.innerHTML = "";
+        [
+          { key: "slides", label: "Slides" },
+          { key: "lecture", label: "Lecture" },
+          { key: "assignment", label: "Assignment" },
+          { key: "quiz", label: "Quiz" },
+        ].forEach(function (artifact) {
+          const artifactData = artifacts[artifact.key];
+          const isPresent = Boolean(artifactData && artifactData.present);
+          appendChip(badgeContainer, `${artifact.label} ${isPresent ? "✓" : "—"}`, null, isPresent ? "available" : "missing");
+        });
+      }
+
+      const linkContainer = document.querySelector(`[data-day-links="${day.id}"]`);
+      if (linkContainer) {
+        linkContainer.innerHTML = "";
+
+        const lecturePaths = artifacts.lecture && Array.isArray(artifacts.lecture.repoPaths)
+          ? artifacts.lecture.repoPaths
+          : [];
+        lecturePaths.forEach(function (repoPath, index) {
+          appendChip(linkContainer, labelFromLecturePath(repoPath, index), repoBlobUrl(repoPath), "available");
+        });
+
+        if (artifacts.assignment && artifacts.assignment.repoPath) {
+          appendChip(linkContainer, "Assignment", repoBlobUrl(artifacts.assignment.repoPath), "available");
+        }
+        if (artifacts.quiz && artifacts.quiz.repoPath) {
+          appendChip(linkContainer, "Quiz", repoBlobUrl(artifacts.quiz.repoPath), "available");
+        }
+      }
+    });
+  }
+
+  function enhanceFromManifest(manifest) {
+    if (!manifest || !Array.isArray(manifest.modules)) {
+      return;
+    }
+
+    document.body.setAttribute("data-repo-owner", manifest.repository.owner);
+    document.body.setAttribute("data-repo-name", manifest.repository.name);
+
+    setText("[data-course-modules]", manifest.stats.modules);
+    setText("[data-course-days]", manifest.stats.days);
+    setText("[data-course-slides]", manifest.stats.slides);
+    setText("[data-course-artifacts]", manifest.stats.lectures + manifest.stats.assignments + manifest.stats.quizzes);
+
+    manifest.modules.forEach(renderModuleSummary);
+    renderFeaturedDays(manifest.modules);
+    enhanceModulePage(manifest);
+  }
+
+  function fetchManifest() {
+    return fetch(withBasePath("slides/shared/portal/course-manifest.json"), { cache: "no-store" })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error(`Manifest request failed: ${response.status}`);
+        }
+        return response.json();
+      });
+  }
+
+  function init() {
+    bindThemeControl();
+    fetchManifest().then(enhanceFromManifest).catch(function () {
+      const note = document.querySelector("[data-manifest-status]");
+      if (note) {
+        note.textContent = "Static overview loaded. Manifest-driven summaries are unavailable in this preview.";
+      }
+    });
+  }
+
+  const storedTheme = localStorage.getItem(THEME_STORAGE_KEY) || "auto";
+  applyTheme(storedTheme);
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/spec/spec-process-cicd-marp-action.md
+++ b/spec/spec-process-cicd-marp-action.md
@@ -203,7 +203,7 @@ deployment:
 | Advanced generated output is missing HTML | Publish uses the checked-in Advanced standalone slide tree | Inspect `_site/slides/advanced/` in the artifact |
 | Printable index or custom 404 exists in source | Workflow copies each page into its contract path | Inspect `_site/slides/printable-index.html` and `_site/404.html` in the artifact |
 | No generated root landing page exists | Workflow creates or copies a valid `_site/index.html` entrypoint | Open the published site root and confirm it resolves to course or slide content |
-| A lecture-script-only change lands under `lessons/lecture/` | No slide publish run is triggered by path filters alone | Review trigger configuration and workflow history |
+| A lecture-script-only change lands under `lessons/lecture/` | Publish runs so the manifest-backed portal summaries stay current | Review trigger configuration and workflow history |
 | Advanced config changes outside watched paths | Publish may not run automatically | Confirm trigger coverage whenever config files change |
 
 ## Validation Criteria

--- a/spec/spec-process-cicd-marp-action.md
+++ b/spec/spec-process-cicd-marp-action.md
@@ -46,7 +46,7 @@ graph TD
 |----|-------------|----------|-------------------|
 | REQ-001 | The workflow shall support both manual runs and automatic publish runs from repository changes. | High | A maintainer can trigger a publish manually, and matching pushes to `main` start the workflow automatically. |
 | REQ-002 | The build job shall publish Basics and Advanced slide outputs as separate module trees. | High | The Pages artifact contains both `slides/basics/` and `slides/advanced/` when content is available. |
-| REQ-003 | The workflow shall preserve a usable published landing experience even when generated module output lacks a usable HTML entrypoint. | High | The final Pages artifact includes a working root entrypoint that resolves to published slide content. |
+| REQ-003 | The workflow shall preserve a usable published landing experience even when generated module output lacks a usable HTML entrypoint. | High | The final Pages artifact includes a working root entrypoint that resolves to published course or slide content. |
 | REQ-004 | The workflow shall permit checked-in standalone slide trees to serve as fallback publish content. | High | When generated HTML is unavailable for a module, the final artifact still contains that module's checked-in standalone slide site. |
 | REQ-005 | The workflow shall package a single Pages artifact and deploy it through a separate deployment step. | High | Publish output is staged before deployment and released through the Pages environment. |
 | REQ-006 | The workflow shall avoid exposing top-level README artifacts as published slide entrypoints. | Medium | The published module roots do not surface README files as the main landing content. |
@@ -76,6 +76,14 @@ repository_triggers:
   paths:
     - Basics/lessons/slides/**
     - Advanced/lessons/slides/**
+    - Basics/lessons/lecture/**
+    - Advanced/lessons/lecture/**
+    - Basics/assignments/**
+    - Advanced/assignments/**
+    - Basics/quizzes/**
+    - Advanced/quizzes/**
+    - slides/**
+    - scripts/generate_portal_manifest.py
     - .marprc.yml
     - .github/workflows/marp-action.yml
     - _site/slides/**
@@ -93,6 +101,7 @@ pages_artifact:
   root_entrypoint: _site/index.html
   basics_module_tree: _site/slides/basics/**
   advanced_module_tree: _site/slides/advanced/**
+  shared_portal_assets: _site/slides/shared/portal/**
 deployment:
   environment: github-pages
 ```
@@ -123,8 +132,9 @@ deployment:
 | Error Type | Response | Recovery Action |
 |------------|----------|-----------------|
 | Missing generated module HTML | Fall back to checked-in standalone slide trees | Copy the module's checked-in slide site into the Pages artifact and continue |
+| Missing approved supporting page | Fail portal validation | Restore `slides/printable-index.html` or `slides/404.html`, or update the manifest contract intentionally |
 | Missing fallback slide content | Fail the build | Restore the missing checked-in slide tree or fix build generation so the module produces HTML |
-| Missing root entrypoint | Generate or copy a safe root entrypoint | Publish a validated redirect or static landing page into `_site/index.html` |
+| Missing root entrypoint | Generate or copy a safe root entrypoint | Publish `slides/index.html` into `_site/index.html` when available, otherwise generate a validated redirect into `_site/index.html` |
 | Deployment failure | Stop publish completion | Re-run the workflow after resolving Pages or permission issues |
 
 ## Quality Gates
@@ -135,6 +145,7 @@ deployment:
 |------|----------|-------------------|
 | Module output availability | Each module must contribute usable HTML or an approved fallback tree | None |
 | Safe root entrypoint | The final artifact must include a valid root landing page | None |
+| Supporting page presence | Approved supporting pages must be staged at their contract paths when the manifest advertises them | None |
 | Artifact upload | `_site/` must be packaged successfully before deploy begins | None |
 
 ## Monitoring & Observability
@@ -190,7 +201,8 @@ deployment:
 |----------|-------------------|-------------------|
 | Basics generated output is missing HTML | Publish uses the checked-in Basics standalone slide tree | Inspect `_site/slides/basics/` in the artifact |
 | Advanced generated output is missing HTML | Publish uses the checked-in Advanced standalone slide tree | Inspect `_site/slides/advanced/` in the artifact |
-| No generated root landing page exists | Workflow creates or copies a valid `_site/index.html` entrypoint | Open the published site root and confirm it resolves to slide content |
+| Printable index or custom 404 exists in source | Workflow copies each page into its contract path | Inspect `_site/slides/printable-index.html` and `_site/404.html` in the artifact |
+| No generated root landing page exists | Workflow creates or copies a valid `_site/index.html` entrypoint | Open the published site root and confirm it resolves to course or slide content |
 | A lecture-script-only change lands under `lessons/lecture/` | No slide publish run is triggered by path filters alone | Review trigger configuration and workflow history |
 | Advanced config changes outside watched paths | Publish may not run automatically | Confirm trigger coverage whenever config files change |
 
@@ -199,6 +211,7 @@ deployment:
 ### Workflow Validation
 
 - **VLD-001**: A successful run publishes a root Pages landing page plus both module slide trees
+- **VLD-005**: Approved supporting pages (`_site/slides/printable-index.html`, `_site/404.html`) are present whenever the manifest advertises them
 - **VLD-002**: Manual dispatch can republish the site without requiring a content change
 - **VLD-003**: If generated module HTML is unavailable, fallback content preserves a usable published site
 - **VLD-004**: Changes to the workflow or watched slide paths trigger publication automatically on `main`
@@ -212,7 +225,7 @@ deployment:
 
 ### Update Process
 
-1. **Specification Update**: Update this document and the README workflow notes first
+1. **Specification Update**: Update this document, `docs/portal-architecture.md`, and the README workflow notes first when entrypoint or fallback behavior changes
 2. **Review & Approval**: Review trigger coverage, fallback behavior, and root entrypoint handling together
 3. **Implementation**: Apply workflow changes in `.github/workflows/marp-action.yml`
 4. **Testing**: Validate with a manual workflow dispatch and inspect the resulting Pages artifact
@@ -227,5 +240,6 @@ deployment:
 ## Related Specifications
 
 - [`../README.md`](../README.md)
+- [`../docs/portal-architecture.md`](../docs/portal-architecture.md)
 - [`spec-process-project-completion.md`](spec-process-project-completion.md)
 - [`../.github/workflows/marp-action.yml`](../.github/workflows/marp-action.yml)


### PR DESCRIPTION
## Summary
- add the portal architecture contract, shared portal asset kit, manifest generator, and publish-contract validator
- rebuild the Basics and Advanced module landing pages as static-first portals on the shared system
- upgrade the root dashboard and add the printable index and custom 404 supporting pages
- stage and validate the full portal publish contract in the Pages workflow and docs

## Testing
- python -m py_compile scripts\generate_portal_manifest.py scripts\check_portal_publish.py
- python scripts\generate_portal_manifest.py --repo-root . --output slides\shared\portal\course-manifest.json
- python scripts\generate_portal_manifest.py --repo-root . --site-root scratch\portal-check\_site --output scratch\portal-check\_site\slides\shared\portal\course-manifest.json
- python scripts\check_portal_publish.py --repo-root . --site-root scratch\portal-check\_site
- browser smoke checks against source-preview and published-shape local previews for root, Basics, Advanced, printable index, and 404 pages

Closes #420
Closes #421
Closes #422
Closes #423
Closes #424
Closes #425
Refs #419